### PR TITLE
feat: Add examples for Authentication for multiple providers

### DIFF
--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -89,6 +89,12 @@ data:
     integrations:
       github:
       - host: github.com
+      # gitlab:
+      # - host: gitlab.com
+      # - host: gitlab.internal.io # Self-hosted GitLab
+      #   apiBaseUrl: https://gitlab.internal.io/api/v4
+      # bitbucketCloud:
+      # - host: bitbucket.org
 
     auth:
       # see https://backstage.io/docs/auth/ to learn about auth providers

--- a/deploy/app.yaml
+++ b/deploy/app.yaml
@@ -95,7 +95,7 @@ data:
       environment: development
       providers:
         # See https://backstage.io/docs/auth/guest/provider
-        guest: {}
+        # guest: {}
 
         github:
           development:
@@ -105,7 +105,29 @@ data:
               resolvers:
                 - resolver: usernameMatchingUserEntityName
                   dangerouslyAllowSignInWithoutUserInCatalog: true
+        # Bitbucket example for authentication
+        # bitbucket:
+        #   development:
+        #     clientId: ${AUTH_BITBUCKET_CLIENT_ID:-}
+        #     clientSecret: ${AUTH_BITBUCKET_CLIENT_SECRET:-}
+        #     signIn:
+        #       resolvers:
+        #         - resolver: usernameMatchingUserEntityAnnotation
+        #           dangerouslyAllowSignInWithoutUserInCatalog: true
 
+        # Gitlab example for authentication
+        # gitlab:
+        #   development:
+        #     clientId: ${AUTH_GITLAB_CLIENT_ID}
+        #     clientSecret: ${AUTH_GITLAB_CLIENT_SECRET}
+        #     signIn:
+        #       resolvers:
+        #         - resolver: emailMatchingUserEntityProfileEmail
+        #           dangerouslyAllowSignInWithoutUserInCatalog: true
+    signInPage:
+      - github
+      # - gitlab
+      # - bitbucket
     dynamicPlugins:
       frontend:
         red-hat-developer-hub.backstage-plugin-x2a:
@@ -151,6 +173,7 @@ data:
           url: ${AAP_URL:-https://aap.example.com}
           orgName: ${AAP_ORG_NAME:-MyOrganization}
           oauthToken: ${AAP_OAUTH_TOKEN:-your-oauth-token}
+          skipSSLVerification: ${AAP_SKIP_SSL_VERIFICATION:-false}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/deploy/secrets.yaml.template
+++ b/deploy/secrets.yaml.template
@@ -56,3 +56,22 @@ stringData:
   AAP_URL: "https://your-aap-instance.com"
   AAP_ORG_NAME: "your-org-name"
   AAP_OAUTH_TOKEN: "REPLACE-WITH-YOUR-AAP-TOKEN"
+
+
+  # GitHub auth:
+  # Docs: https://x2ansible.github.io/x2a-convertor/ui/authentication.html#github
+  # Example Config:
+  # AUTH_GITHUB_CLIENT_ID: ""
+  # AUTH_GITHUB_CLIENT_SECRET: ""
+
+  # Bitbucket auth:
+  # Docs: https://x2ansible.github.io/x2a-convertor/ui/authentication.html#bitbucket
+  # Example Config:
+  # AUTH_BITBUCKET_CLIENT_ID: ""
+  # AUTH_BITBUCKET_CLIENT_SECRET: ""
+  
+  # Gitlab auth:
+  # Docs: https://x2ansible.github.io/x2a-convertor/ui/authentication.html#gitlab
+  # Example config:
+  # AUTH_GITLAB_CLIENT_ID: ""
+  # AUTH_GITLAB_CLIENT_SECRET: ""


### PR DESCRIPTION
Add an example for Gitlab and Bitbucket and improve the secrets.yaml template for getting in there more easily.


I didn't add this, because if we're not using local instance, it's not really needed, want to keep it minimal as possible

https://github.com/redhat-developer/rhdh-plugins/blob/d1ae4767b0a0f00114b658f900b6de379a22735f/workspaces/x2a/app-config.yaml#L58-L72