### PR TITLE
Credentials Support

### DIFF
--- a/prompts/chef_analysis_cleanup_system.md
+++ b/prompts/chef_analysis_cleanup_system.md
@@ -71,6 +71,24 @@ The cookbook performs operations in this order:
 **System package dependencies**: [list]
 **Service dependencies**: [list]
 
+## Credentials
+
+**Detection Summary**: [N credentials detected across M files]
+
+**Source**:
+  - **Provider**: [provider name or "None detected"]
+  - **URL**: [if applicable]
+  - **Path**: [if applicable]
+
+### [Credential Purpose - e.g., "Database Password"]
+- **Variable(s)**: [names]
+- **Source file(s)**: [paths]
+- **Current storage**: [method]
+- **Usage context**: [description]
+
+**If no credentials detected:**
+No credentials or secrets were detected in this cookbook. All configuration values appear to be non-sensitive.
+
 ## Checks for the Migration
 
 **Files to verify**: [list ALL files]
@@ -106,4 +124,6 @@ Respond with ONLY the cleaned, final migration plan. No explanations, no preambl
 - All recipes mentioned in correct order
 - All .each loops expanded with actual item names
 - Pre-flight checks for every instance individually
+- Credentials section preserved with all detected secrets documented
+- Source provider information retained
 - Proper template formatting throughout

--- a/prompts/chef_analysis_system.md
+++ b/prompts/chef_analysis_system.md
@@ -38,6 +38,18 @@ Your task is to write detailed specification guide of the Chef cookbook with ste
    - Note variables and how many times each template renders
    - Check for static files being deployed
 
+6. **Detect credentials and secrets:**
+   - Look for `data_bag_item` and `encrypted_data_bag_item` calls in recipes
+   - Check for Chef Vault usage: `chef_vault_item`, `ChefVault::Item`
+   - Check for CyberArk integration: `conjur_variable`, `cyberark` data bags, Conjur cookbook usage
+   - Identify vault attribute patterns: `node['vault']`, `node['secrets']`
+   - Find environment variables in .erb templates referencing secrets: `ENV['PASSWORD']`, `ENV['API_KEY']`
+   - Look for hardcoded passwords, tokens, or API keys in attribute files
+   - Check for SSL/TLS certificate references: paths to .pem, .key, .crt files
+   - Identify database connection strings with embedded credentials
+   - Note `secrets` or `credentials` related attribute namespaces
+   - For EACH detected credential, record: variable name, source file, and how it is used (data bag, vault, hardcoded, environment variable)
+
 **USING STRUCTURED ANALYSIS DATA:**
 
 You will receive detailed structured analysis showing:
@@ -308,6 +320,30 @@ The cookbook performs operations in this order:
 **System package dependencies**: [packages installed: postgresql, redis-server, nginx, etc]
 **Service dependencies**: [systemd services managed]
 
+## Credentials
+
+[Document ALL credentials, secrets, and sensitive data detected in the cookbook.
+This section guides the Solutions Architect on configuring credentials in AAP.]
+
+**Detection Summary**: [N credentials detected across M files]
+
+**Source**:
+  - **Provider**: [HashiCorp Vault / CyberArk / AWS Secrets Manager / Internal / Hardcoded / None detected]
+  - **URL**: [vault address or secret manager endpoint, if detected]
+  - **Path**: [secret path or data bag name, if detected]
+
+### [Credential Purpose - e.g., "Database Password"]
+
+- **Variable(s)**: [variable names as used in source, e.g., `node['postgresql']['password']`]
+- **Source file(s)**: [paths where credential is referenced]
+- **Current storage**: [encrypted_data_bag / data_bag / chef_vault / environment_variable / hardcoded / attribute]
+- **Usage context**: [what this credential is used for: DB connection, API auth, SSH key, TLS cert, etc.]
+
+[Repeat for each detected credential]
+
+**If no credentials detected:**
+No credentials or secrets were detected in this cookbook. All configuration values appear to be non-sensitive.
+
 ## Checks for the Migration
 
 **Files to verify**:
@@ -518,6 +554,9 @@ tail -f /var/log/*.log  # WRONG - which specific log file?
 - Pre-flight checks for EVERY site/instance individually
 - Actual package names that exist (nginx, fail2ban, openssl - NOT "sysctl")
 - Port numbers for each service instance
+- Credentials section present with all detected secrets listed explicitly
+- Each credential includes: variable name, source file, current storage method, and usage context
+- Source provider documented (HashiCorp Vault / CyberArk / AWS Secrets Manager / Internal / Hardcoded / None detected)
 
 If you write "for each site" or "for each instance", you FAILED.
 If you skip any recipe file, you FAILED.

--- a/prompts/chef_analysis_validation_system.md
+++ b/prompts/chef_analysis_validation_system.md
@@ -17,6 +17,7 @@ You will receive:
 3. **Provider Coverage**: Custom resources reference analyzed providers
 4. **Attribute Accuracy**: Attributes mentioned in plan exist in attributes analysis
 5. **No Hallucinations**: Nothing in the plan contradicts the structured analysis
+6. **Credential Coverage**: If recipes contain `data_bag_item`, `encrypted_data_bag_item`, `chef_vault_item`, environment variable secrets in templates, or hardcoded passwords in attributes, verify these are documented in the Credentials section. Each credential must include: variable name, source file, current storage method, and usage context. The Source provider block must be present
 
 ## Response Format
 

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -121,6 +121,22 @@ CRITICAL: For technologies where NO collection was discovered in the AAP Private
   - ansible.builtin.template for configuration files
   - ansible.builtin.service for service management
 
+CREDENTIAL HANDLING:
+When the task prompt includes an "AAP Credential Variables" section:
+- Replace ALL third-party secret lookups (conjur_variable, chef_vault_item, hashicorp vault lookups,
+  encrypted data bag lookups) with the provided AAP credential variables
+- AAP credential types inject variables via `extra_vars` — they are available as regular Ansible
+  variables (e.g. {% raw %}`{{ variable_name }}`{% endraw %}). They are NOT environment variables — never use
+  `lookup('ansible.builtin.env', ...)` or `lookup('env', ...)` for credential variables
+- Include `tasks/validate_credentials.yml` as the FIRST include_tasks in `tasks/main.yml`:
+  ```yaml
+  - name: Validate credential variables
+    ansible.builtin.include_tasks: validate_credentials.yml
+  ```
+- NEVER write or overwrite `tasks/validate_credentials.yml` or any file under `aap-configuration/` —
+  these are pre-generated and already marked "complete" in the checklist. If you write to these paths
+  you will destroy correct content with incorrect content
+
 USING ansible_doc_lookup FOR NON-BUILTIN MODULES:
 CRITICAL: When using Ansible modules that are NOT from ansible.builtin.*, you MUST use ansible_doc_lookup to retrieve the correct module parameters and usage.
 

--- a/prompts/export_ansible_write_task.j2
+++ b/prompts/export_ansible_write_task.j2
@@ -38,6 +38,24 @@ Write this content to `{{ ansible_path }}/requirements.yml` using ansible_write.
 {% endif %}
 {% endif %}
 
+{% if credential_config and credential_config.has_credentials %}
+## AAP Credential Variables (USE THESE!)
+
+The following credential variables are injected by AAP credential types at runtime.
+Use these variables directly in your tasks instead of any third-party secret lookups.
+
+**Available variables:**
+{% for var in credential_config.variable_names %}
+- `{{ '{{' }} {{ var }} {{ '}}' }}`
+{% endfor %}
+
+**CRITICAL RULES:**
+1. Replace ALL third-party secret lookups (CyberArk Conjur, HashiCorp Vault, Chef Vault, encrypted data bags) with the AAP credential variables listed above
+2. Reference these variables directly using standard Jinja2 syntax: `{{ '{{' }} variable_name {{ '}}' }}`
+3. Include `tasks/validate_credentials.yml` as the FIRST include in `tasks/main.yml`
+4. Do NOT recreate `aap-configuration/` files or `tasks/validate_credentials.yml` - they are pre-generated
+{% endif %}
+
 ## Current Checklist
 
 <checklist>

--- a/prompts/export_credential_extraction_system.md
+++ b/prompts/export_credential_extraction_system.md
@@ -1,0 +1,51 @@
+You are a credential extraction specialist for infrastructure-to-Ansible migrations.
+
+Your task is to analyze a migration plan and extract all third-party credential references
+that need to be converted to AAP (Ansible Automation Platform) credential types.
+
+Look for credentials from these providers:
+- **CyberArk Conjur**: `conjur_variable`, Conjur lookups, Conjur API tokens
+- **HashiCorp Vault**: `vault` lookups, Vault tokens, AppRole credentials
+- **Chef Vault**: `chef_vault_item`, encrypted data bags with secrets
+- **Encrypted Data Bags**: Chef encrypted data bag items containing secrets
+- **AWS Secrets Manager**: AWS secret references
+- **Azure Key Vault**: Azure key vault references
+- **Custom secret stores**: Any other third-party secret management
+
+For each credential found, extract:
+
+1. **name**: A clean, descriptive AAP credential type name
+   - Use title case: "CyberArk Conjur Database" not "cyberark_conjur_database"
+   - Include the provider and purpose: "HashiCorp Vault API" not just "Vault"
+
+2. **source_provider**: Snake_case provider identifier
+   - cyberark_conjur, hashicorp_vault, chef_vault, encrypted_data_bag, aws_secrets_manager, azure_key_vault
+
+3. **fields**: Each secret or configuration value as a CredentialField
+   - **id**: Clean snake_case identifier (e.g., `db_password`, `api_token`, `conjur_account`)
+   - **type**: Always "string" for credential fields
+   - **label**: Human-readable label (e.g., "Database Password")
+   - **secret**: Set to `true` for passwords, keys, tokens, and any sensitive values
+   - **help_text**: Brief description of what this field is used for
+
+4. **required_fields**: List of field IDs that are mandatory for the credential to work
+
+5. **usage_context**: How the credential is used (e.g., "Database connection for PostgreSQL", "API authentication for service X")
+
+Rules:
+- If the migration plan says "No credentials detected" or has no Credentials section, return an empty list
+- Group related secrets into a single credential (e.g., username + password for the same service = one credential)
+- Mark passwords, keys, tokens, and API secrets as `secret: true`
+- Mark connection URLs, hostnames, and non-sensitive config as `secret: false`
+- Generate clean snake_case IDs from the original variable names
+- Do NOT invent credentials that are not mentioned in the plan
+
+---
+
+## High-Level Migration Plan
+
+{high_level_migration_plan}
+
+## Module Migration Plan
+
+{migration_plan}

--- a/prompts/init_migration_instructions.md
+++ b/prompts/init_migration_instructions.md
@@ -109,7 +109,12 @@ Analyze the source repository to determine target environment specifications:
 [Identify security configurations that need special attention]
 - Security practice 1: Migration approach
 - Security practice 2: Migration approach
-- Vault/secrets management: Migration strategy
+- Vault/secrets management: For each module, identify credential patterns:
+  - Chef encrypted data bags, Chef Vault usage, vault attributes
+  - Hardcoded credentials in attributes or templates
+  - SSL/TLS certificate references
+  - Environment variable secrets
+  - Document the count and type of credentials detected per module
 
 ### Technical Challenges
 [Identify potential roadblocks and complex migrations]

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -1,0 +1,154 @@
+"""Credential extraction agent for AAP credential configuration.
+
+This agent extracts third-party credentials from migration plans and generates
+AAP-style credential configuration files (controller_credential_types.yml,
+controller_credentials.yml, validate_credentials.yml).
+
+Runs as a workflow node before the planning agent so that both the planning
+and write agents have access to credential_config in the state.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from prompts.get_prompt import get_prompt
+from src.base_agent import BaseAgent
+from src.exporters.state import ExportState
+from src.types import ChecklistStatus
+from src.types.credential import (
+    CredentialConfig,
+    CredentialExtractionOutput,
+)
+from src.types.telemetry import AgentMetrics
+
+
+class CredentialAgent(BaseAgent[ExportState]):
+    """Agent that extracts credentials from migration plan and writes AAP config files.
+
+    Runs as its own workflow node before the planning agent.
+    Extracts the ## Credentials section, uses LLM structured output to parse it,
+    then writes the credential files and updates the checklist.
+    """
+
+    EXTRACTION_PROMPT_NAME = "export_credential_extraction_system"
+
+    def execute(self, state: ExportState, metrics: AgentMetrics | None) -> ExportState:
+        """Extract credentials and write AAP configuration files."""
+        self._log.info("Starting credential extraction")
+
+        extraction_prompt = self._build_extraction_prompt(state)
+        credentials = self._extract_credentials(extraction_prompt, metrics)
+
+        if not credentials:
+            self._log.info("No credentials detected in migration plan")
+            return state.update(credential_config=CredentialConfig.empty())
+
+        self._log.info(f"Extracted {len(credentials)} credentials")
+
+        credential_config = CredentialConfig.from_extracted(
+            credentials, str(state.module)
+        )
+
+        state = self._write_credential_files(state, credential_config)
+
+        if metrics:
+            metrics.record_metric("credentials_found", len(credentials))
+
+        return state.update(credential_config=credential_config)
+
+    # -------------------------------------------------------------------------
+    # Extraction
+    # -------------------------------------------------------------------------
+
+    def _build_extraction_prompt(self, state: ExportState) -> str:
+        """Build the prompt for credential extraction from migration plan."""
+        return get_prompt(self.EXTRACTION_PROMPT_NAME).format(
+            high_level_migration_plan=state.high_level_migration_plan.to_document(),
+            migration_plan=state.module_migration_plan.to_document(),
+        )
+
+    def _extract_credentials(self, prompt: str, metrics: AgentMetrics | None) -> list:
+        """Extract credentials using LLM structured output."""
+        try:
+            result = self.invoke_structured(CredentialExtractionOutput, prompt, metrics)
+            if isinstance(result, CredentialExtractionOutput):
+                return result.credentials
+            return []
+
+        except Exception as e:
+            self._log.warning(f"Credential extraction failed: {e}")
+            return []
+
+    # -------------------------------------------------------------------------
+    # File Writing
+    # -------------------------------------------------------------------------
+
+    def _write_credential_files(
+        self, state: ExportState, config: CredentialConfig
+    ) -> ExportState:
+        """Write all credential configuration files and update checklist."""
+        ansible_path = state.get_ansible_path()
+
+        self._write_credential_file(
+            state,
+            config.credential_types_yaml,
+            Path(ansible_path)
+            / "aap-configuration"
+            / "controller_credential_types.yml",
+            "AAP credential types configuration",
+        )
+
+        self._write_credential_file(
+            state,
+            config.credentials_yaml,
+            Path(ansible_path) / "aap-configuration" / "controller_credentials.yml",
+            "AAP credentials configuration",
+        )
+
+        self._write_credential_file(
+            state,
+            config.validate_tasks_yaml,
+            Path(ansible_path) / "tasks" / "validate_credentials.yml",
+            "Credential validation tasks",
+        )
+
+        return state
+
+    def _write_credential_file(
+        self,
+        state: ExportState,
+        content: str,
+        file_path: Path,
+        description: str,
+    ) -> None:
+        """Write a single credential file and update the checklist."""
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text(content, encoding="utf-8")
+        self._log.info(f"Created: {file_path}")
+
+        target_path_str = str(file_path)
+        source_path = "N/A"
+
+        assert state.checklist is not None, (
+            "Checklist must exist before writing credential files"
+        )
+
+        updated = state.checklist.update_task(
+            source_path=source_path,
+            target_path=target_path_str,
+            status=ChecklistStatus.COMPLETE,
+            notes=description,
+        )
+
+        if not updated:
+            state.checklist.add_task(
+                category="credentials",
+                source_path=source_path,
+                target_path=target_path_str,
+                status=ChecklistStatus.COMPLETE,
+                description=description,
+            )
+            self._log.info(f"Added task to checklist: {target_path_str}")
+
+        state.checklist.save(state.get_checklist_path())

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -12,6 +12,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from langchain_core.exceptions import LangChainException
+from pydantic import ValidationError
+
 from prompts.get_prompt import get_prompt
 from src.base_agent import BaseAgent
 from src.exporters.state import ExportState
@@ -75,9 +78,11 @@ class CredentialAgent(BaseAgent[ExportState]):
             if isinstance(result, CredentialExtractionOutput):
                 return result.credentials
             return []
-
+        except (LangChainException, ValidationError) as e:
+            self._log.warning(f"Credential extraction parsing failed: {e}")
+            return []
         except Exception as e:
-            self._log.warning(f"Credential extraction failed: {e}")
+            self._log.warning(f"Credential extraction failed unexpectedly: {e}")
             return []
 
     # -------------------------------------------------------------------------

--- a/src/exporters/state.py
+++ b/src/exporters/state.py
@@ -12,6 +12,7 @@ from src.types import (
     AnsibleModule,
     BaseState,
     Checklist,
+    CredentialConfig,
     DocumentFile,
     MigrationStateInterface,
 )
@@ -53,6 +54,7 @@ class ExportState(BaseState, MigrationStateInterface):
         last_output: Last output from the workflow
         checklist: Migration checklist tracking file transformations
         aap_discovery: Result of AAP collection discovery for deduplication
+        credential_config: Extracted credential configuration for AAP
     """
 
     # Fields inherited from BaseState:
@@ -74,6 +76,7 @@ class ExportState(BaseState, MigrationStateInterface):
     last_output: str = field(kw_only=True)
     checklist: Checklist | None = field(default=None, kw_only=True)
     aap_discovery: AAPDiscoveryResult | None = field(default=None, kw_only=True)
+    credential_config: CredentialConfig | None = field(default=None, kw_only=True)
     source_technology: Technology = field(default=Technology.CHEF, kw_only=True)
 
     def get_ansible_path(self) -> str:

--- a/src/exporters/to_ansible.py
+++ b/src/exporters/to_ansible.py
@@ -11,6 +11,7 @@ from typing import Literal
 from langgraph.graph import END, START, StateGraph
 
 from src.exporters.aap_discovery_agent import AAPDiscoveryAgent
+from src.exporters.credential_agent import CredentialAgent
 from src.exporters.molecule_agent import MoleculeAgent
 from src.exporters.planning_agent import PlanningAgent
 from src.exporters.state import ExportState
@@ -62,6 +63,7 @@ class ToAnsibleSubagent:
         self.module = module
 
         self.discovery_agent = AAPDiscoveryAgent(model=self.model)
+        self.credential_agent = CredentialAgent(model=self.model)
         self.planning_agent = PlanningAgent(model=self.model)
         self.write_agent = WriteAgent(model=self.model)
         self.molecule_agent = MoleculeAgent(model=self.model)
@@ -88,6 +90,7 @@ class ToAnsibleSubagent:
         workflow = StateGraph(ExportState)
         workflow.add_node("initialize", self._initialize)
         workflow.add_node("discover_collections", self.discovery_agent)
+        workflow.add_node("extract_credentials", self.credential_agent)
         workflow.add_node("plan_migration", self.planning_agent)
         workflow.add_node("write_migration", self.write_agent)
         workflow.add_node("molecule_testing", self.molecule_agent)
@@ -96,7 +99,8 @@ class ToAnsibleSubagent:
 
         workflow.add_edge(START, "initialize")
         workflow.add_edge("initialize", "discover_collections")
-        workflow.add_edge("discover_collections", "plan_migration")
+        workflow.add_edge("discover_collections", "extract_credentials")
+        workflow.add_edge("extract_credentials", "plan_migration")
 
         workflow.add_conditional_edges(
             "plan_migration", self._check_failure_after_agent
@@ -270,6 +274,7 @@ class ToAnsibleSubagent:
             last_output="",
             checklist=None,
             aap_discovery=None,
+            credential_config=None,
             source_technology=source_technology or Technology.CHEF,
             failed=False,
             failure_reason="",

--- a/src/exporters/types.py
+++ b/src/exporters/types.py
@@ -13,6 +13,7 @@ class MigrationCategory(str, Enum):
     STRUCTURE = "structure"
     DEPENDENCIES = "dependencies"
     MOLECULE = "molecule"
+    CREDENTIALS = "credentials"
 
     def to_title(self) -> str:
         """Return markdown title for this category"""
@@ -24,5 +25,6 @@ class MigrationCategory(str, Enum):
             self.STRUCTURE: "### Structure Files",
             self.DEPENDENCIES: "### Dependencies (requirements.yml)",
             self.MOLECULE: "### Molecule Testing",
+            self.CREDENTIALS: "### Credentials → AAP Configuration",
         }
         return titles.get(self, f"### {self.value.title()}")

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -227,6 +227,7 @@ class WriteAgent(BaseAgent[ExportState]):
             if export_state.checklist
             else "",
             aap_discovery=export_state.aap_discovery,
+            credential_config=export_state.credential_config,
         )
 
         result = self.invoke_react(

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -20,6 +20,7 @@ from .checklist import (
     ChecklistItem,
     ChecklistStatus,
 )
+from .credential import CredentialConfig
 from .document import DocumentFile
 from .metadata import MetadataCollection, ModuleMetadata
 from .migration_state import MigrationStateInterface
@@ -35,6 +36,7 @@ __all__ = [
     "Checklist",
     "ChecklistItem",
     "ChecklistStatus",
+    "CredentialConfig",
     "DocumentFile",
     "MetadataCollection",
     "MigrationStateInterface",

--- a/src/types/checklist.py
+++ b/src/types/checklist.py
@@ -104,6 +104,13 @@ class Checklist:
         Raises:
             ValueError: If category is not valid for the injected enum
         """
+        # Reject glob patterns -- each entry must reference a concrete file
+        glob_chars = ("*", "?", "[")
+        if any(c in target_path for c in glob_chars):
+            raise ValueError(
+                f"target_path must be a concrete file path, not a glob pattern: '{target_path}'"
+            )
+
         # Check if task already exists
         existing_item = self.find_task(source_path, target_path)
         if existing_item:
@@ -456,10 +463,14 @@ class Checklist:
         ) -> str:
             """Add a new task to the migration checklist.
 
+            Each entry must reference ONE specific file. Never use glob patterns
+            (*, ?, []) in paths. If a directory contains multiple files, add a
+            separate task for each file.
+
             Args:
                 category: Category of the task (e.g., 'templates', 'recipes', 'attributes')
                 source_path: Source file path in Chef
-                target_path: Target file path in Ansible
+                target_path: Target file path in Ansible (must be a concrete path, no globs)
                 description: Optional description of the task
                 status: Task status (pending, complete, missing, error)
                 notes: Optional notes about the task

--- a/src/types/checklist.py
+++ b/src/types/checklist.py
@@ -46,12 +46,12 @@ class ChecklistItem(BaseModel):
     )
 
     def target_exists(self) -> bool:
-        """Check if the target file exists on the filesystem
+        """Check if the target path exists on the filesystem.
 
         Returns:
-            True if target_path exists as a file, False otherwise
+            True if target_path exists as a file or directory, False otherwise
         """
-        return Path(self.target_path).is_file()
+        return Path(self.target_path).exists()
 
 
 class Checklist:

--- a/src/types/credential.py
+++ b/src/types/credential.py
@@ -1,0 +1,278 @@
+"""Credential management types for AAP credential configuration.
+
+This module contains data types for extracting third-party credentials
+from migration plans and generating AAP-style credential configuration files
+(controller_credential_types.yml, controller_credentials.yml, validate_credentials.yml).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class CredentialField(BaseModel):
+    """A single input field for an AAP credential type."""
+
+    id: str = Field(
+        description="Snake_case identifier for this field (e.g., 'api_token')"
+    )
+    type: str = Field(
+        default="string",
+        description="Field type: string or boolean",
+    )
+    label: str = Field(description="Human-readable label (e.g., 'API Token')")
+    secret: bool = Field(
+        default=False,
+        description="Whether this field contains a secret value (passwords, keys, tokens)",
+    )
+    help_text: str = Field(
+        default="",
+        description="Help text describing this field",
+    )
+
+
+class ExtractedCredential(BaseModel):
+    """A credential extracted from a migration plan's Credentials section."""
+
+    name: str = Field(
+        description="Human-readable credential name (e.g., 'CyberArk Conjur API')"
+    )
+    description: str = Field(
+        default="",
+        description="Description of what this credential is used for",
+    )
+    source_provider: str = Field(
+        description="Original provider (e.g., 'cyberark_conjur', 'hashicorp_vault', 'chef_vault')",
+    )
+    fields: list[CredentialField] = Field(
+        default_factory=list,
+        description="List of credential input fields",
+    )
+    required_fields: list[str] = Field(
+        default_factory=list,
+        description="List of field IDs that are required",
+    )
+    usage_context: str = Field(
+        default="",
+        description="How this credential is used in the source code (e.g., 'database connection', 'API authentication')",
+    )
+
+
+class CredentialExtractionOutput(BaseModel):
+    """LLM structured output for extracting credentials from migration plan."""
+
+    credentials: list[ExtractedCredential] = Field(
+        default_factory=list,
+        description="List of credentials found in the migration plan's Credentials section",
+    )
+
+
+@dataclass(frozen=True)
+class CredentialConfig:
+    """Domain state carrying rendered AAP credential YAML and variable names.
+
+    Generated deterministically from extracted credentials -- no LLM involved
+    in the YAML rendering step.
+    """
+
+    credential_types_yaml: str
+    credentials_yaml: str
+    validate_tasks_yaml: str
+    variable_names: tuple[str, ...]
+    credentials: tuple[ExtractedCredential, ...]
+
+    @classmethod
+    def empty(cls) -> CredentialConfig:
+        """Create an empty config indicating no credentials were found."""
+        return cls(
+            credential_types_yaml="",
+            credentials_yaml="",
+            validate_tasks_yaml="",
+            variable_names=(),
+            credentials=(),
+        )
+
+    @property
+    def has_credentials(self) -> bool:
+        """Check if any credentials were extracted."""
+        return len(self.credentials) > 0
+
+    @classmethod
+    def from_extracted(
+        cls,
+        credentials: list[ExtractedCredential],
+        module_name: str,
+    ) -> CredentialConfig:
+        """Build a CredentialConfig from extracted credentials.
+
+        Renders the three YAML files deterministically using the AAP format.
+
+        Args:
+            credentials: List of extracted credentials from LLM
+            module_name: Name of the module being migrated
+
+        Returns:
+            CredentialConfig with rendered YAML strings
+        """
+        if not credentials:
+            return cls.empty()
+
+        variable_names = _collect_variable_names(credentials)
+        credential_types_yaml = _render_credential_types(credentials)
+        credentials_yaml = _render_credentials(credentials, module_name)
+        validate_tasks_yaml = _render_validate_tasks(variable_names)
+
+        return cls(
+            credential_types_yaml=credential_types_yaml,
+            credentials_yaml=credentials_yaml,
+            validate_tasks_yaml=validate_tasks_yaml,
+            variable_names=tuple(variable_names),
+            credentials=tuple(credentials),
+        )
+
+
+# ---------------------------------------------------------------------------
+# YAML Rendering (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _collect_variable_names(credentials: list[ExtractedCredential]) -> list[str]:
+    """Collect all variable names from credential fields."""
+    return [field.id for cred in credentials for field in cred.fields]
+
+
+def _render_credential_types(credentials: list[ExtractedCredential]) -> str:
+    """Render controller_credential_types.yml content."""
+    types = [_build_credential_type_entry(cred) for cred in credentials]
+
+    content = str(
+        yaml.dump(
+            {"controller_credential_types": types},
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    )
+
+    # Inject !unsafe tags on injector values (yaml.dump cannot emit custom tags cleanly)
+    content = _inject_unsafe_tags(content)
+
+    return "---\n" + content
+
+
+def _build_credential_type_entry(cred: ExtractedCredential) -> dict:
+    """Build a single credential type entry for controller_credential_types.yml."""
+    fields = [_build_field_entry(f) for f in cred.fields]
+
+    injectors = {
+        "extra_vars": {f.id: f"UNSAFE_PLACEHOLDER {{{{{f.id}}}}}" for f in cred.fields}
+    }
+
+    entry: dict = {
+        "name": cred.name,
+        "description": cred.description or f"Credential type for {cred.name}",
+        "kind": "cloud",
+        "inputs": {
+            "fields": fields,
+            "required": cred.required_fields or [f.id for f in cred.fields if f.secret],
+        },
+        "injectors": injectors,
+    }
+
+    return entry
+
+
+def _build_field_entry(field: CredentialField) -> dict:
+    """Build a single field entry for the inputs.fields list."""
+    entry: dict = {
+        "id": field.id,
+        "type": field.type,
+        "label": field.label,
+    }
+
+    if field.secret:
+        entry["secret"] = True
+
+    if field.help_text:
+        entry["help_text"] = field.help_text
+
+    return entry
+
+
+def _inject_unsafe_tags(content: str) -> str:
+    """Replace UNSAFE_PLACEHOLDER markers with !unsafe YAML tags.
+
+    yaml.dump cannot emit custom tags on specific values, so we use a
+    placeholder string and post-process. yaml.dump outputs the values
+    unquoted, so we match without surrounding quotes.
+    """
+    import re
+
+    return re.sub(
+        r"UNSAFE_PLACEHOLDER \{\{(\w+)\}\}",
+        r"!unsafe '{{ \1 }}'",
+        content,
+    )
+
+
+def _render_credentials(
+    credentials: list[ExtractedCredential], module_name: str
+) -> str:
+    """Render controller_credentials.yml content."""
+    creds = [_build_credential_entry(cred, module_name) for cred in credentials]
+
+    content = str(
+        yaml.dump(
+            {"controller_credentials": creds},
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    )
+
+    return "---\n" + content
+
+
+def _build_credential_entry(cred: ExtractedCredential, module_name: str) -> dict:
+    """Build a single credential entry for controller_credentials.yml."""
+    inputs = {}
+    for field in cred.fields:
+        if field.secret:
+            inputs[field.id] = "{{ " + f"vault_{field.id}" + " }}"
+        else:
+            inputs[field.id] = "{{ " + field.id + " }}"
+
+    return {
+        "name": f"{cred.name} - {module_name}",
+        "description": cred.description or f"Credential for {module_name}",
+        "organization": "Default",
+        "credential_type": cred.name,
+        "update_secrets": True,
+        "inputs": inputs,
+    }
+
+
+def _render_validate_tasks(variable_names: list[str]) -> str:
+    """Render tasks/validate_credentials.yml content."""
+    tasks = [
+        {
+            "name": "Validate required credential variables are defined",
+            "ansible.builtin.assert": {
+                "that": [f"{var} is defined" for var in variable_names],
+                "fail_msg": "One or more required credential variables are not defined. "
+                "Ensure the AAP credential type is attached to the job template.",
+                "quiet": True,
+            },
+        }
+    ]
+
+    content = str(
+        yaml.dump(
+            tasks,
+            default_flow_style=False,
+            sort_keys=False,
+        )
+    )
+
+    return "---\n" + content

--- a/src/types/credential.py
+++ b/src/types/credential.py
@@ -7,6 +7,7 @@ from migration plans and generating AAP-style credential configuration files
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 
 import yaml
@@ -208,8 +209,6 @@ def _inject_unsafe_tags(content: str) -> str:
     placeholder string and post-process. yaml.dump outputs the values
     unquoted, so we match without surrounding quotes.
     """
-    import re
-
     return re.sub(
         r"UNSAFE_PLACEHOLDER \{\{(\w+)\}\}",
         r"!unsafe '{{ \1 }}'",


### PR DESCRIPTION
This is the first PR for the credentials support:
- On the migration-plan-module add a credentials section.
- On the migration to ansible, to handle credentials

# On the follow-up PR:

- [ ] Docs, to be working with PR #170 and PR #161. So updating all
- [ ] Publish command, to add the credentials on the README 

The main reason to do like this, because maybe the PR feedback comes in very different way, so prefer to merge one, and getting into the next phase with clear path.

# Pending:
- [ ] To create a jira issues on how to threat credentials on Ansible and Powershell Input agent. (This code does not break it)
  

Each commit has his own description, but I copy here the content:

~~~
commit a069fda096180cd60341190a670a26a314f89dc6
Author: Eloy Coto <eloy.coto@acalustra.com>
Date:   Wed Apr 15 12:50:26 2026 +0200

    feat:to_ansible to write Ansible Automation platform credentials
    
    Ansible Automation credentials are written inside the credentials and
    not inside the project, but we need to signal the users that some
    credentials are in use.
    
    This commit add a way to:
    
    - Checking that credentials are in place before Ansible.
    - The reason to write before, is that because for Ansible, the credentials are just extravars, so we need to define it before so the WriterAgent is getting all requirements in terms of vars.
    
    The secrets cannot be loaded from the project, but we created a check on
    the first task, to signal the user that the secrets is needed:
    
    ```
    $ -> head  ../chef-examples/ansible/roles/nginx_multisite/tasks/main.yml
    
    ---
    - name: Validate required credentials
      ansible.builtin.include_tasks: validate_credentials.yml
    - name: Install and configure Nginx
      ansible.builtin.include_tasks: install.yml
    - name: Configure SSL certificates
      ansible.builtin.include_tasks: ssl.yml
    - name: Configure virtual hosts
      ansible.builtin.include_tasks: vhosts.yml
    - name: Configure security
    $ -> cat ansible/roles/nginx_multisite/tasks/validate_credentials.yml
    ---
    - name: Verify SSL passphrase is available
      ansible.builtin.assert:
        that:
          - ssl_passphrase_path is defined
        fail_msg: SSL passphrase variable (ssl_passphrase_path) is not defined. This should be provided by AAP credential.
        success_msg: SSL passphrase variable is available.
    ```
    
    Because the ansible Automation platform is handling the credentials in a specific way:
    
    https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.5/html/configuring_automation_execution/assembly-controller-secret-management
    
    There is a Galaxy collection used widely across multuple teams to handle
    AAP credentials:
    
    https://galaxy.ansible.com/ui/repo/published/infra/aap_configuration/content/role/controller_credentials/
    
    So we also wrote the files needed for that:
    
    ```
    $ -> find  ../chef-examples/ansible/roles/nginx_multisite/aap-configuration
    ../chef-examples/ansible/roles/nginx_multisite/aap-configuration
    ../chef-examples/ansible/roles/nginx_multisite/aap-configuration/controller_credential_types.yml
    ../chef-examples/ansible/roles/nginx_multisite/aap-configuration/controller_credentials.yml
    ```
    
    Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>

commit 66cb66f73fbcabcc55736598dcd635a6614e2fa3
Author: Eloy Coto <eloy.coto@acalustra.com>
Date:   Wed Apr 15 12:33:27 2026 +0200

    feat: checklist: If is a folder, target_exists should return true
    
    Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>

commit 83d2116ced26f22a37a4403e1b78758ca92fe1fb
Author: Eloy Coto <eloy.coto@acalustra.com>
Date:   Wed Apr 15 11:05:12 2026 +0200

    Input agent: adding credentials
    
    Credentials are hard, but it's should be referenced on the migration-module-plan. This PR adds a way to add credentials on the migration file, so for each credentials, it'll be referenced here correctly as text.
    
    Example output:
    
    ~~~
    
    **TLDR**: This cookbook installs and configures Nginx as a web server with multiple virtual hosts (3 sites), each with SSL enabled. It also implements security hardening through fail2ban, UFW firewall, and system-level security configurations.
    
    **Service Type**: Web Server
    
    **Configured Instances**:
    
    - **test.cluster.local**:
      - Location/Path: /opt/server/test
      - Port/Socket: 80 (redirect to 443), 443 (HTTPS)
      - Key Config: SSL enabled, serves static content
    
    - **ci.cluster.local**:
      - Location/Path: /opt/server/ci
      - Port/Socket: 80 (redirect to 443), 443 (HTTPS)
      - Key Config: SSL enabled, serves static content
    
    - **status.cluster.local**:
      - Location/Path: /opt/server/status
      - Port/Socket: 80 (redirect to 443), 443 (HTTPS)
      - Key Config: SSL enabled, serves static content
    
    ```
    cookbooks/nginx-multisite/recipes/default.rb
    cookbooks/nginx-multisite/recipes/nginx.rb
    cookbooks/nginx-multisite/recipes/security.rb
    cookbooks/nginx-multisite/recipes/sites.rb
    cookbooks/nginx-multisite/recipes/ssl.rb
    cookbooks/nginx-multisite/templates/default/fail2ban.jail.local.erb
    cookbooks/nginx-multisite/templates/default/nginx.conf.erb
    cookbooks/nginx-multisite/templates/default/security.conf.erb
    cookbooks/nginx-multisite/templates/default/site.conf.erb
    cookbooks/nginx-multisite/templates/default/sysctl-security.conf.erb
    cookbooks/nginx-multisite/attributes/default.rb
    ```
    
    The cookbook performs operations in this order:
    
    1. **default** (`cookbooks/nginx-multisite/recipes/default.rb`):
       - Includes other recipes in sequence: security, nginx, ssl, sites
       - Resources: include_recipe (4)
    
    2. **security** (`cookbooks/nginx-multisite/recipes/security.rb`):
       - Installs security packages: fail2ban, ufw
       - Configures fail2ban with custom jail settings
       - Sets up UFW firewall with default deny policy and allows SSH, HTTP, HTTPS
       - Configures system security via sysctl
       - Hardens SSH configuration if enabled in attributes
       - Resources: package (1), service (1), template (1), execute (5), template (1), execute (1), execute (2), service (1)
    
    3. **nginx** (`cookbooks/nginx-multisite/recipes/nginx.rb`):
       - Installs nginx package
       - Configures main nginx.conf and security.conf
       - Enables and starts nginx service
       - Creates document root directories for each site: test.cluster.local, ci.cluster.local, status.cluster.local
       - Deploys index.html files for each site: test.cluster.local, ci.cluster.local, status.cluster.local
       - Resources: package (1), template (2), service (1), directory (3), cookbook_file (3)
    
    4. **ssl** (`cookbooks/nginx-multisite/recipes/ssl.rb`):
       - Installs SSL-related packages: openssl, ca-certificates
       - Creates SSL certificate group and directories
       - Generates self-signed SSL certificates for each site: test.cluster.local, ci.cluster.local, status.cluster.local
       - Resources: package (1), group (1), directory (2), execute (3)
    
    5. **sites** (`cookbooks/nginx-multisite/recipes/sites.rb`):
       - Creates Nginx site configuration files for each site: test.cluster.local, ci.cluster.local, status.cluster.local
       - Creates symlinks to enable the sites: test.cluster.local, ci.cluster.local, status.cluster.local
       - Removes default site configuration
       - Resources: template (3), link (3), file (1)
    
    **External cookbook dependencies**: None explicitly defined
    **System package dependencies**: nginx, fail2ban, ufw, openssl, ca-certificates
    **Service dependencies**: nginx, fail2ban, ssh
    
    **Detection Summary**: 1 credential detected across 1 file
    
    **Source**:
      - **Provider**: CyberArk Conjur
      - **URL**: https://conjur.example.com
      - **Path**: production/nginx/ssl_passphrase
    
    - **Variable(s)**: `node['cyberark']['conjur']['variable']`
    - **Source file(s)**: cookbooks/nginx-multisite/attributes/default.rb
    - **Current storage**: CyberArk Conjur
    - **Usage context**: Used for generating self-signed SSL certificates for the Nginx virtual hosts
    
    **Files to verify**:
    - /etc/nginx/nginx.conf
    - /etc/nginx/conf.d/security.conf
    - /etc/nginx/sites-available/test.cluster.local
    - /etc/nginx/sites-available/ci.cluster.local
    - /etc/nginx/sites-available/status.cluster.local
    - /etc/nginx/sites-enabled/test.cluster.local
    - /etc/nginx/sites-enabled/ci.cluster.local
    - /etc/nginx/sites-enabled/status.cluster.local
    - /etc/ssl/certs/test.cluster.local.crt
    - /etc/ssl/certs/ci.cluster.local.crt
    - /etc/ssl/certs/status.cluster.local.crt
    - /etc/ssl/private/test.cluster.local.key
    - /etc/ssl/private/ci.cluster.local.key
    - /etc/ssl/private/status.cluster.local.key
    - /etc/fail2ban/jail.local
    - /etc/sysctl.d/99-security.conf
    - /opt/server/test/index.html
    - /opt/server/ci/index.html
    - /opt/server/status/index.html
    
    **Service endpoints to check**:
    - Ports listening: 80, 443
    - Network interfaces: All interfaces (default)
    
    **Templates rendered**:
    - nginx.conf.erb → /etc/nginx/nginx.conf (1 time)
    - security.conf.erb → /etc/nginx/conf.d/security.conf (1 time)
    - site.conf.erb → /etc/nginx/sites-available/test.cluster.local (1 time)
    - site.conf.erb → /etc/nginx/sites-available/ci.cluster.local (1 time)
    - site.conf.erb → /etc/nginx/sites-available/status.cluster.local (1 time)
    - fail2ban.jail.local.erb → /etc/fail2ban/jail.local (1 time)
    - sysctl-security.conf.erb → /etc/sysctl.d/99-security.conf (1 time)
    
    ```bash
    systemctl status nginx
    systemctl status fail2ban
    ps aux | grep nginx
    
    nginx -t
    nginx -T | grep -E 'server_name|listen'
    
    curl -I http://test.cluster.local
    curl -I -k https://test.cluster.local
    curl -s -k https://test.cluster.local | grep -i "html"
    ls -la /opt/server/test/
    cat /etc/nginx/sites-available/test.cluster.local
    openssl x509 -in /etc/ssl/certs/test.cluster.local.crt -text -noout | grep "Subject:"
    
    curl -I http://ci.cluster.local
    curl -I -k https://ci.cluster.local
    curl -s -k https://ci.cluster.local | grep -i "html"
    ls -la /opt/server/ci/
    cat /etc/nginx/sites-available/ci.cluster.local
    openssl x509 -in /etc/ssl/certs/ci.cluster.local.crt -text -noout | grep "Subject:"
    
    curl -I http://status.cluster.local
    curl -I -k https://status.cluster.local
    curl -s -k https://status.cluster.local | grep -i "html"
    ls -la /opt/server/status/
    cat /etc/nginx/sites-available/status.cluster.local
    openssl x509 -in /etc/ssl/certs/status.cluster.local.crt -text -noout | grep "Subject:"
    
    cat /etc/fail2ban/jail.local
    fail2ban-client status
    ufw status verbose
    sysctl -a | grep -E 'rp_filter|accept_redirects|send_redirects|accept_source_route|log_martians|echo_ignore|disable_ipv6|syncookies'
    grep -E "PermitRootLogin|PasswordAuthentication" /etc/ssh/sshd_config
    
    openssl s_client -connect test.cluster.local:443 -tls1_2 < /dev/null | grep "Protocol"
    openssl s_client -connect ci.cluster.local:443 -tls1_2 < /dev/null | grep "Protocol"
    openssl s_client -connect status.cluster.local:443 -tls1_2 < /dev/null | grep "Protocol"
    
    ls -la /etc/ssl/private/
    ls -la /etc/ssl/certs/
    getfacl /etc/ssl/private/test.cluster.local.key
    getfacl /etc/ssl/private/ci.cluster.local.key
    getfacl /etc/ssl/private/status.cluster.local.key
    
    tail -f /var/log/nginx/access.log
    tail -f /var/log/nginx/error.log
    tail -f /var/log/nginx/test.cluster.local_access.log
    tail -f /var/log/nginx/test.cluster.local_error.log
    tail -f /var/log/nginx/ci.cluster.local_access.log
    tail -f /var/log/nginx/ci.cluster.local_error.log
    tail -f /var/log/nginx/status.cluster.local_access.log
    tail -f /var/log/nginx/status.cluster.local_error.log
    
    netstat -tulpn | grep nginx
    ss -tlnp | grep nginx
    lsof -i :80
    lsof -i :443
    ```
    ~~~
    
    Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>
~~~