### PR TITLE
feat: telemetry with real names

### DIFF
--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -35,6 +35,7 @@ class BaseAgent[S: BaseState](ABC):
     """
 
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = []
+    _NAME: ClassVar[str | None] = None
 
     def __init__(self, model: BaseChatModel | None = None):
         self.model = model or get_model()
@@ -42,6 +43,8 @@ class BaseAgent[S: BaseState](ABC):
 
     @property
     def agent_name(self) -> str:
+        if self._NAME:
+            return self._NAME
         return self.__class__.__name__
 
     def extra_tools_from_state(self, state: S) -> list[BaseTool]:

--- a/src/exporters/aap_discovery_agent.py
+++ b/src/exporters/aap_discovery_agent.py
@@ -88,6 +88,8 @@ class AAPDiscoveryAgent(BaseAgent[ExportState]):
     5. Returns collections that can be reused in the migration
     """
 
+    _NAME = "AAP Collection Discovery"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: AAPListCollectionsTool(),
         lambda: AAPSearchCollectionsTool(),

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -34,6 +34,8 @@ class CredentialAgent(BaseAgent[ExportState]):
     then writes the credential files and updates the checklist.
     """
 
+    _NAME = "Credential Extractor"
+
     EXTRACTION_PROMPT_NAME = "export_credential_extraction_system"
 
     def execute(self, state: ExportState, metrics: AgentMetrics | None) -> ExportState:

--- a/src/exporters/molecule_agent.py
+++ b/src/exporters/molecule_agent.py
@@ -47,6 +47,8 @@ class MoleculeAgent(BaseAgent[ExportState]):
     block the migration pipeline.
     """
 
+    _NAME = "Molecule Test Generator"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: ReadFileTool(),
         lambda: WriteFileTool(),

--- a/src/exporters/planning_agent.py
+++ b/src/exporters/planning_agent.py
@@ -27,6 +27,8 @@ class PlanningAgent(BaseAgent[ExportState]):
     - Categorizes items (templates, recipes, attributes, files, structure)
     """
 
+    _NAME = "Export Planner"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: ListDirectoryTool(),
         lambda: ReadFileTool(),

--- a/src/exporters/validation_agent.py
+++ b/src/exporters/validation_agent.py
@@ -94,6 +94,8 @@ class ValidationAgent(BaseAgent[ExportState]):
     The agent returns only when validation passes or max attempts exhausted.
     """
 
+    _NAME = "Ansible Lint Validator"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: ReadFileTool(),
         lambda: DiffFileTool(),

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -48,6 +48,8 @@ class WriteAgent(BaseAgent[ExportState]):
     The agent returns only when complete or max attempts exhausted.
     """
 
+    _NAME = "Ansible Role Writer"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: FileSearchTool(),
         lambda: ListDirectoryTool(),

--- a/src/init/initialize_subagent.py
+++ b/src/init/initialize_subagent.py
@@ -28,6 +28,8 @@ class InitializeSubAgent(BaseAgent[InitState]):
     and generate a high-level migration plan document.
     """
 
+    _NAME = "Migration Plan Writer"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: FileSearchTool(),
         lambda: ListDirectoryTool(),

--- a/src/init/metadata_extraction_agent.py
+++ b/src/init/metadata_extraction_agent.py
@@ -22,6 +22,8 @@ class MetadataExtractionAgent(BaseAgent[InitState]):
     and generate generated-project-metadata.json.
     """
 
+    _NAME = "Metadata Extractor"
+
     SYSTEM_PROMPT_NAME = "init_metadata_extraction_system"
     USER_PROMPT_NAME = "init_metadata_extraction_task"
 

--- a/src/inputs/ansible/analysis_validation_agent.py
+++ b/src/inputs/ansible/analysis_validation_agent.py
@@ -17,6 +17,8 @@ class AnalysisValidationAgent(BaseAgent[AnsibleAnalysisState]):
     between the migration specification and the structured analysis.
     """
 
+    _NAME = "Ansible Analysis Validator"
+
     SYSTEM_PROMPT_NAME = "ansible_analysis_validation_system"
     USER_PROMPT_NAME = "ansible_analysis_validation_task"
 

--- a/src/inputs/ansible/cleanup_agent.py
+++ b/src/inputs/ansible/cleanup_agent.py
@@ -17,6 +17,8 @@ class CleanupAgent(BaseAgent[AnsibleAnalysisState]):
     the specification after validation notes have been appended.
     """
 
+    _NAME = "Ansible Analysis Cleanup"
+
     SYSTEM_PROMPT_NAME = "ansible_analysis_cleanup_system"
     USER_PROMPT_NAME = "ansible_analysis_cleanup_task"
 

--- a/src/inputs/ansible/report_writer_agent.py
+++ b/src/inputs/ansible/report_writer_agent.py
@@ -25,6 +25,8 @@ class ReportWriterAgent(BaseAgent[AnsibleAnalysisState]):
     a detailed migration specification based on the structured analysis.
     """
 
+    _NAME = "Ansible Report Writer"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: FileSearchTool(),
         lambda: ListDirectoryTool(),

--- a/src/inputs/chef/analysis_validation_agent.py
+++ b/src/inputs/chef/analysis_validation_agent.py
@@ -17,6 +17,8 @@ class AnalysisValidationAgent(BaseAgent[ChefState]):
     between the migration specification and the structured analysis.
     """
 
+    _NAME = "Chef Analysis Validator"
+
     SYSTEM_PROMPT_NAME = "chef_analysis_validation_system"
     USER_PROMPT_NAME = "chef_analysis_validation_task"
 

--- a/src/inputs/chef/cleanup_agent.py
+++ b/src/inputs/chef/cleanup_agent.py
@@ -17,6 +17,8 @@ class CleanupAgent(BaseAgent[ChefState]):
     the specification after validation notes have been appended.
     """
 
+    _NAME = "Chef Analysis Cleanup"
+
     SYSTEM_PROMPT_NAME = "chef_analysis_cleanup_system"
     USER_PROMPT_NAME = "chef_analysis_cleanup_task"
 

--- a/src/inputs/chef/report_writer_agent.py
+++ b/src/inputs/chef/report_writer_agent.py
@@ -26,6 +26,8 @@ class ReportWriterAgent(BaseAgent[ChefState]):
     a detailed migration specification based on the structured analysis.
     """
 
+    _NAME = "Chef Report Writer"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: FileSearchTool(),
         lambda: ListDirectoryTool(),

--- a/src/inputs/module_selection_agent.py
+++ b/src/inputs/module_selection_agent.py
@@ -18,6 +18,8 @@ class ModuleSelectionAgent(BaseAgent[MigrationState]):
     and identify the target module path, technology, and name.
     """
 
+    _NAME = "Module Selector"
+
     SYSTEM_PROMPT_NAME = "analyze_select_module_system"
     USER_PROMPT_NAME = "analyze_select_module_task"
 

--- a/src/inputs/powershell/analysis_validation_agent.py
+++ b/src/inputs/powershell/analysis_validation_agent.py
@@ -17,6 +17,8 @@ class AnalysisValidationAgent(BaseAgent[PowerShellAnalysisState]):
     between the migration specification and the structured analysis.
     """
 
+    _NAME = "PowerShell Analysis Validator"
+
     SYSTEM_PROMPT_NAME = "powershell_analysis_validation_system"
     USER_PROMPT_NAME = "powershell_analysis_validation_task"
 

--- a/src/inputs/powershell/cleanup_agent.py
+++ b/src/inputs/powershell/cleanup_agent.py
@@ -17,6 +17,8 @@ class CleanupAgent(BaseAgent[PowerShellAnalysisState]):
     the specification after validation notes have been appended.
     """
 
+    _NAME = "PowerShell Analysis Cleanup"
+
     SYSTEM_PROMPT_NAME = "powershell_analysis_cleanup_system"
     USER_PROMPT_NAME = "powershell_analysis_cleanup_task"
 

--- a/src/inputs/powershell/report_writer_agent.py
+++ b/src/inputs/powershell/report_writer_agent.py
@@ -25,6 +25,8 @@ class ReportWriterAgent(BaseAgent[PowerShellAnalysisState]):
     a detailed migration specification based on the structured analysis.
     """
 
+    _NAME = "PowerShell Report Writer"
+
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
         lambda: FileSearchTool(),
         lambda: ListDirectoryTool(),

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -18,6 +18,28 @@ class ConcreteAgent(BaseAgent[BaseState]):
         return state
 
 
+class NamedAgent(BaseAgent[BaseState]):
+    """Agent with a custom _NAME for testing."""
+
+    _NAME = "My Custom Agent"
+
+    def execute(self, state: BaseState, metrics):
+        """Minimal execute implementation."""
+        return state
+
+
+class TestBaseAgentName:
+    """Tests for BaseAgent.agent_name property."""
+
+    def test_agent_name_defaults_to_class_name(self):
+        agent = ConcreteAgent()
+        assert agent.agent_name == "ConcreteAgent"
+
+    def test_agent_name_uses_custom_name_when_defined(self):
+        agent = NamedAgent()
+        assert agent.agent_name == "My Custom Agent"
+
+
 class TestBaseAgentTokenExtraction:
     """Tests for BaseAgent._extract_token_usage method."""
 


### PR DESCRIPTION
Telemetry was a great addition, but in the Backstage plugin the agent names are not meaningful for users. This adds a way to define human-friendly agent names that describe what each agent does, making them useful for end users.

List of changes:

- InitializeSubAgent -> Migration Plan Writer
- MetadataExtractionAgent -> Metadata Extractor
- ModuleSelectionAgent -> Module Selector
- ReportWriterAgent (Chef) -> Chef Report Writer
- CleanupAgent (Chef) -> Chef Analysis Cleanup
- AnalysisValidationAgent (Chef) -> Chef Analysis Validator
- ReportWriterAgent (Ansible) -> Ansible Report Writer
- CleanupAgent (Ansible) -> Ansible Analysis Cleanup
- AnalysisValidationAgent (Ansible) -> Ansible Analysis Validator
- ReportWriterAgent (PowerShell) -> PowerShell Report Writer
- CleanupAgent (PowerShell) -> PowerShell Analysis Cleanup
- AnalysisValidationAgent (PowerShell) -> PowerShell Analysis Validator
- PlanningAgent -> Export Planner
- WriteAgent -> Ansible Role Writer
- MoleculeAgent -> Molecule Test Generator
- ValidationAgent -> Ansible Lint Validator
- CredentialAgent -> Credential Extractor
- AAPDiscoveryAgent -> AAP Collection Discovery