### PR TITLE
feat: Ansible doc lookup changes:

### DIFF
--- a/tests/tools/test_ansible_doc_lookup.py
+++ b/tests/tools/test_ansible_doc_lookup.py
@@ -101,6 +101,54 @@ class TestBuildParamMeta:
         assert _build_param_meta(opt) == ["str"]
 
 
+class TestDocCLIBridgeFormatModuleDocs:
+    """Tests for DocCLIBridge.format_module_docs error handling."""
+
+    def setup_method(self) -> None:
+        with patch.object(DocCLIBridge, "__init__", lambda self: None):
+            self.bridge = DocCLIBridge()
+
+    def test_returns_formatted_docs_on_success(self) -> None:
+        docs = {
+            "doc": {
+                "plugin_name": "test.module",
+                "short_description": "Test",
+                "options": {},
+            }
+        }
+        with patch.object(self.bridge, "get_module_docs", return_value=docs):
+            result = self.bridge.format_module_docs("test.module")
+
+        assert result is not None
+        assert "test.module -- Test" in result
+
+    def test_returns_none_when_not_found(self) -> None:
+        with patch.object(self.bridge, "get_module_docs", return_value=None):
+            result = self.bridge.format_module_docs("fake.module")
+
+        assert result is None
+
+    def test_returns_error_string_on_exception(self) -> None:
+        exc = Exception("module removed: Use replacement.module instead")
+        with patch.object(self.bridge, "get_module_docs", side_effect=exc):
+            result = self.bridge.format_module_docs("removed.module")
+
+        assert result is not None
+        assert "ERROR" in result
+        assert "Use replacement.module instead" in result
+
+    def test_surfaces_replacement_guidance_from_exception(self) -> None:
+        exc = Exception("Missing documentation: Use microsoft.ad.membership instead.")
+        with patch.object(self.bridge, "get_module_docs", side_effect=exc):
+            result = self.bridge.format_module_docs(
+                "ansible.windows.win_domain_membership"
+            )
+
+        assert result is not None
+        assert "ERROR" in result
+        assert "microsoft.ad.membership" in result
+
+
 class TestFormatDoc:
     """Tests for DocCLIBridge._format_doc -- renders compact plaintext."""
 
@@ -243,6 +291,18 @@ class TestAnsibleDocLookupTool:
         assert "ERROR" in result
         assert "fake.nonexistent" in result
 
+    def test_removed_module_returns_error_with_guidance(self) -> None:
+        self.mock_format.return_value = (
+            "ERROR: Module 'ansible.windows.win_domain_membership' "
+            "documentation unavailable: module ansible.windows.win_domain_membership "
+            "Missing documentation: Use microsoft.ad.membership instead."
+        )
+
+        result = self.tool._run(module_name="ansible.windows.win_domain_membership")
+
+        assert "ERROR" in result
+        assert "microsoft.ad.membership" in result
+
     def test_list_no_filter_returns_all(self) -> None:
         result = self.tool._run()
 
@@ -302,12 +362,12 @@ class TestDocCLIBridgeIntegration:
 
     def test_builtin_module_docs(self) -> None:
         docs = self.bridge.get_module_docs("ansible.builtin.copy")
-
         assert docs is not None
-        assert "doc" in docs
-        assert docs["doc"]["plugin_name"] == "ansible.builtin.copy"
-        assert "options" in docs["doc"]
-        assert "dest" in docs["doc"]["options"]
+
+        doc = docs["doc"]
+        assert doc["plugin_name"] == "ansible.builtin.copy"
+        assert "options" in doc
+        assert "dest" in doc["options"]
 
     def test_builtin_format(self) -> None:
         result = self.bridge.format_module_docs("ansible.builtin.copy")
@@ -335,6 +395,14 @@ class TestDocCLIBridgeIntegration:
         result = self.bridge.format_module_docs("fake.collection.nonexistent")
 
         assert result is None
+
+    def test_removed_module_returns_error_string(self) -> None:
+        """Modules removed from collections should return an error, not raise."""
+        result = self.bridge.format_module_docs("ansible.windows.win_domain_membership")
+
+        # Should not raise; returns either None or an error string
+        if result is not None:
+            assert "ERROR" in result
 
     def test_list_all_modules_returns_dict(self) -> None:
         modules = self.bridge.list_all_modules()

--- a/tools/ansible_doc_lookup.py
+++ b/tools/ansible_doc_lookup.py
@@ -49,9 +49,19 @@ class DocCLIBridge:
         Output is one line per parameter with inline metadata (type,
         required, default, choices). Only the first description sentence
         is kept. Ansible markup like C(), V(), O() is stripped.
+
+        When a module has been removed from its collection, Ansible
+        raises an exception whose message typically contains replacement
+        guidance.  That message is returned as an error string instead
+        of propagating the exception.
         """
-        plugin_docs = self.get_module_docs(fqcn)
-        if not plugin_docs:
+        try:
+            plugin_docs = self.get_module_docs(fqcn)
+        except Exception as exc:
+            logger.warning("ansible doc lookup failed for %s: %s", fqcn, exc)
+            return f"ERROR: Module '{fqcn}' documentation unavailable: {exc}"
+
+        if plugin_docs is None:
             return None
 
         doc = plugin_docs["doc"]


### PR DESCRIPTION
before:
```
In [2]:   bridge = DocCLIBridge()
   ...:   bridge.get_module_docs("ansible.windows.win_domain_membership")
---------------------------------------------------------------------------
AnsiblePluginRemovedError                 Traceback (most recent call last)
File ~/dev/upstream/x2ansible/x2a-convertor/.venv/lib64/python3.13/site-packages/ansible/cli/doc.py:829, in DocCLI._get_plugins_docs(self, plugin_type, names, fail_ok, fail_on_errors)
    828 try:
--> 829     doc, plainexamples, returndocs, metadata = self._get_plugin_docs_with_jinja2_builtins(
    830         plugin,
    831         plugin_type,
    832         loader,
    833         fragment_loader,
    834         jinja2_builtins,
    835     )
    836 except AnsiblePluginNotFound as e:

File ~/dev/upstream/x2ansible/x2a-convertor/.venv/lib64/python3.13/site-packages/ansible/cli/doc.py:881, in DocCLI._get_plugin_docs_with_jinja2_builtins(self, plugin_name, plugin_type, loader, fragment_loader, jinja_builtins)
    880 try:
--> 881     return get_plugin_docs(plugin_name, plugin_type, loader, fragment_loader, (context.CLIARGS['verbosity'] > 0))
    882 except Exception:
```

Now:

```
In [2]:   bridge = DocCLIBridge()
   ...:   bridge.get_module_docs("ansible.windows.win_domain_membership")
2026-04-17 11:32:32 [warning  ] ansible doc lookup failed for ansible.windows.win_domain_membership: module ansible.windows.win_domain_membership Missing documentation (or could not parse documentation): The 'ansible.windows.win_domain_membership' module has been removed. Use microsoft.ad.membership instead. This feature was removed from collection 'ansible.windows' version 3.0.0.
Out[2]: "module ansible.windows.win_domain_membership Missing documentation (or could not parse documentation): The 'ansible.windows.win_domain_membership' module has been removed. Use microsoft.ad.membership instead. This feature was removed from collection 'ansible.windows' version 3.0.0."
```