### PR TITLE
fix: add namespace to programmatic meta/main.yml generation

### DIFF
--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -154,6 +154,7 @@ class WriteAgent(BaseAgent[ExportState]):
 
         galaxy_info = source_meta.get("galaxy_info", {})
         galaxy_info["role_name"] = role_name
+        galaxy_info.setdefault("namespace", "x2a")
         galaxy_info.setdefault("author", "Migration Tool")
         galaxy_info.setdefault("description", "Migrated to modern Ansible")
         galaxy_info.setdefault("license", "Apache-2.0")
@@ -184,6 +185,7 @@ class WriteAgent(BaseAgent[ExportState]):
         meta_data = {
             "galaxy_info": {
                 "role_name": role_name,
+                "namespace": "x2a",
                 "author": "Migration Tool",
                 "description": "Migrated to modern Ansible",
                 "license": "Apache-2.0",


### PR DESCRIPTION
This PR makes sure that a namespace field gets appended to he meta/main.yml file that is generated by the write agent. 
This is crucial for the galaxy role to be able to run molecule tests
before, the prompt told the write agent to add the namespace but it was not added in the end
