### PR TITLE
fix: fix variable tags, add cross-platform to write agent prompts

### DIFF
--- a/prompts/export_ansible_review_system.md
+++ b/prompts/export_ansible_review_system.md
@@ -54,7 +54,16 @@ Common patterns:
 
 Fix: Reorder tasks within the file so that: packages are installed first, then configuration is deployed, then services are enabled/started.
 
-### 5. Molecule Test Correctness
+### 5. Invalid Module Parameters
+
+Tasks that use parameters not supported by the Ansible module.
+
+Common patterns:
+- `ansible.builtin.template` with `variables:` — this parameter does not exist. Template variables must be passed via task-level `vars:`, not as a module parameter. This often happens when converting Chef's `variables()` block.
+
+Fix: Move `variables:` content to task-level `vars:`.
+
+### 6. Molecule Test Correctness
 
 Molecule test files (converge.yml, verify.yml) that violate the execution environment constraints or will fail at runtime.
 
@@ -75,8 +84,8 @@ Fix: Remove `become: true`, replace `include_role` with direct task simulation, 
 2. Read EVERY task file (tasks/*.yml), including files referenced by `include_tasks` or `import_tasks`
 3. Read defaults/main.yml and vars/main.yml if they exist
 4. Read handlers/main.yml if it exists
-5. For each task file, trace the execution order and check for all four categories above (1-4)
-6. Read molecule/default/converge.yml and molecule/default/verify.yml if they exist and check for category 5 issues
+5. For each task file, trace the execution order and check for categories 1-5 above
+6. Read molecule/default/converge.yml and molecule/default/verify.yml if they exist and check for category 6 issues
 7. When you find an issue, fix it immediately by rewriting the affected file
 8. After all fixes, produce a summary report
 

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -63,6 +63,54 @@ WRONG output (do NOT do this):
 
 If a template has NO ERB variables (static content), copy it as-is.
 
+TEMPLATE VARIABLE PASSING:
+When a task uses ansible.builtin.template and needs to pass variables into the template, use
+task-level `vars:` — NOT a `variables:` parameter on the module (which does not exist).
+
+CORRECT — task-level vars:
+```yaml{% raw %}
+- name: Create site configuration
+  ansible.builtin.template:
+    src: site.conf.j2
+    dest: "/etc/nginx/conf.d/{{ item.key }}.conf"
+    mode: "0644"
+  vars:
+    server_name: "{{ item.key }}"
+    document_root: "{{ item.value.document_root }}"
+  loop: "{{ sites | dict2items }}"{% endraw %}
+```
+
+WRONG — `variables` is not a valid module parameter:
+```yaml{% raw %}
+- name: Create site configuration
+  ansible.builtin.template:
+    src: site.conf.j2
+    dest: "/etc/nginx/conf.d/{{ item.key }}.conf"
+    variables:
+      server_name: "{{ item.key }}"{% endraw %}
+```
+
+Chef's `template` resource uses `variables(...)` — in Ansible, the equivalent is `vars:` at the task level.
+
+CROSS-PLATFORM / OS-FAMILY AWARENESS:
+Migrated roles must work on both Debian/Ubuntu AND RHEL/Rocky/CentOS unless the source
+explicitly targets only one family. Apply these rules:
+
+1. **Service users differ by OS family:**
+   - nginx runs as `www-data` on Debian but `nginx` on RHEL
+   - Apache runs as `www-data` on Debian but `apache` on RHEL
+   - Use a variable with a conditional default:
+   ```yaml{% raw %}
+   nginx_user: "{{ 'www-data' if ansible_os_family == 'Debian' else 'nginx' }}"{% endraw %}
+   ```
+
+2. **Package manager modules:**
+   - Use `ansible.builtin.package` (generic) instead of `ansible.builtin.apt` or `ansible.builtin.dnf`
+     unless you need distro-specific parameters
+
+3. **Templates with OS-specific values:**
+   Put OS-dependent values in defaults/main.yml as variables, not hardcoded in templates.
+
 RECIPES (.rb → .yml tasks):
 - Convert Chef resources to Ansible modules using FQCN (Fully Qualified Collection Names)
 - Example: ansible.builtin.package, NOT package
@@ -306,8 +354,12 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - bionic  # 18.04
         - focal   # 20.04
+        - jammy   # 22.04
+    - name: EL
+      versions:
+        - "8"
+        - "9"
   galaxy_tags: []
 ```
 IMPORTANT: Always include `namespace: x2a` — Molecule's galaxy prerun check requires a valid namespace.

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -69,47 +69,35 @@ task-level `vars:` — NOT a `variables:` parameter on the module (which does no
 
 CORRECT — task-level vars:
 ```yaml{% raw %}
-- name: Create site configuration
+- name: Deploy configuration
   ansible.builtin.template:
-    src: site.conf.j2
-    dest: "/etc/nginx/conf.d/{{ item.key }}.conf"
+    src: app.conf.j2
+    dest: "/etc/app/{{ item.key }}.conf"
     mode: "0644"
   vars:
-    server_name: "{{ item.key }}"
-    document_root: "{{ item.value.document_root }}"
-  loop: "{{ sites | dict2items }}"{% endraw %}
+    app_name: "{{ item.key }}"
+    app_port: "{{ item.value.port }}"
+  loop: "{{ apps | dict2items }}"{% endraw %}
 ```
 
 WRONG — `variables` is not a valid module parameter:
 ```yaml{% raw %}
-- name: Create site configuration
+- name: Deploy configuration
   ansible.builtin.template:
-    src: site.conf.j2
-    dest: "/etc/nginx/conf.d/{{ item.key }}.conf"
+    src: app.conf.j2
+    dest: "/etc/app/{{ item.key }}.conf"
     variables:
-      server_name: "{{ item.key }}"{% endraw %}
+      app_name: "{{ item.key }}"{% endraw %}
 ```
 
 Chef's `template` resource uses `variables(...)` — in Ansible, the equivalent is `vars:` at the task level.
 
-CROSS-PLATFORM / OS-FAMILY AWARENESS:
-Migrated roles must work on both Debian/Ubuntu AND RHEL/Rocky/CentOS unless the source
-explicitly targets only one family. Apply these rules:
-
-1. **Service users differ by OS family:**
-   - nginx runs as `www-data` on Debian but `nginx` on RHEL
-   - Apache runs as `www-data` on Debian but `apache` on RHEL
-   - Use a variable with a conditional default:
-   ```yaml{% raw %}
-   nginx_user: "{{ 'www-data' if ansible_os_family == 'Debian' else 'nginx' }}"{% endraw %}
-   ```
-
-2. **Package manager modules:**
-   - Use `ansible.builtin.package` (generic) instead of `ansible.builtin.apt` or `ansible.builtin.dnf`
-     unless you need distro-specific parameters
-
-3. **Templates with OS-specific values:**
-   Put OS-dependent values in defaults/main.yml as variables, not hardcoded in templates.
+CROSS-PLATFORM COMPATIBILITY:
+Migrated roles should be portable across OS families unless the source explicitly targets one.
+- Use `ansible.builtin.package` instead of distro-specific modules (`apt`, `dnf`) when possible
+- When service users, paths, or package names differ across OS families, use variables with
+  `ansible_os_family` conditionals in defaults/main.yml rather than hardcoding values
+- Put OS-dependent values in defaults/main.yml as variables, not hardcoded in templates or tasks
 
 RECIPES (.rb → .yml tasks):
 - Convert Chef resources to Ansible modules using FQCN (Fully Qualified Collection Names)


### PR DESCRIPTION
                                                                                                                              
  Summary: 
After e2e testing of running migrated roles on AAP, some bugs appeared in the migration files. 
                                            
1. "variable -> vars": Illegal tags were appearing on migrated ansible. this PR adds TEMPLATE VARIABLE PASSING section: shows correct vars: syntax vs invalid variables: parameter -- that Chef's variables() block was being mistranslated 
_2. Add CROSS-PLATFORM / OS-FAMILY AWARENESS section: service users (www-data vs nginx), generic ansible.builtin.package preference, and OS-dependent values in defaults_  -- removed                                                                                                                  
3. Update meta/main.yml example to include EL 8/9 platforms alongside Ubuntu 

1 is critical, 2-3 are nice to have but can be removed if reviewer believes too much context is added. 