### PR TITLE
feat: connect timeout changes

### DIFF
--- a/docs/configuration_options.md
+++ b/docs/configuration_options.md
@@ -28,6 +28,8 @@ Auto-generated from `src/config/settings.py`.
 | `REASONING_EFFORT` | string | - | Claude reasoning effort level |
 | `RATE_LIMIT_REQUESTS` | integer | - | Rate limit requests per second |
 | `LLM_MAX_RETRIES` | integer | `6` | Maximum retry attempts on throttling (429) and server errors |
+| `LLM_READ_TIMEOUT` | integer | `900` | Read timeout in seconds for LLM API responses (applies to both Bedrock and OpenAI) |
+| `LLM_CONNECT_TIMEOUT` | integer | `60` | Connection timeout in seconds for LLM API connections (applies to both Bedrock and OpenAI) |
 
 ## OpenAI Configuration
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -46,6 +46,16 @@ class LLMSettings(BaseSettings):
         validation_alias="LLM_MAX_RETRIES",
         description="Maximum retry attempts on throttling (429) and server errors",
     )
+    read_timeout: int = Field(
+        default=900,
+        validation_alias="LLM_READ_TIMEOUT",
+        description="Read timeout in seconds for LLM API responses (applies to both Bedrock and OpenAI)",
+    )
+    connect_timeout: int = Field(
+        default=60,
+        validation_alias="LLM_CONNECT_TIMEOUT",
+        description="Connection timeout in seconds for LLM API connections (applies to both Bedrock and OpenAI)",
+    )
 
 
 class OpenAISettings(BaseSettings):

--- a/src/model.py
+++ b/src/model.py
@@ -103,6 +103,7 @@ def get_model() -> BaseChatModel:
     kwargs: dict[str, Any] = {
         "max_tokens": settings.llm.max_tokens,
         "temperature": settings.llm.temperature,
+        "timeout": settings.llm.read_timeout,
     }
 
     if settings.llm.reasoning_effort:
@@ -131,13 +132,18 @@ def get_model() -> BaseChatModel:
         kwargs["region_name"] = region_name
         logger.debug(f"AWS_REGION: {region_name}")
 
-        # Configure botocore-level retry for throttling (429) and server errors
+        # Configure botocore-level retry and timeout for throttling (429) and server errors
         max_retries = settings.llm.max_retries
+        read_timeout = settings.llm.read_timeout
+        connect_timeout = settings.llm.connect_timeout
         kwargs["config"] = BotoConfig(
             retries={"max_attempts": max_retries, "mode": "adaptive"},
+            read_timeout=read_timeout,
+            connect_timeout=connect_timeout,
         )
         logger.info(
-            f"Bedrock retry enabled: {max_retries} max attempts with adaptive backoff"
+            f"Bedrock config: {max_retries} max attempts with adaptive backoff, "
+            f"read_timeout={read_timeout}s, connect_timeout={connect_timeout}s"
         )
 
         # If we have access keys, pass them as SecretStr
@@ -171,6 +177,7 @@ def get_model() -> BaseChatModel:
         if not kwargs["base_url"]:
             logger.warning("OPENAI_API_BASE is not set")
         logger.debug(f"OPENAI_API_BASE: {kwargs['base_url']}")
+        logger.info(f"OpenAI timeout: {settings.llm.read_timeout}s")
 
     kwargs["model_provider"] = provider
     logger.info(


### PR DESCRIPTION
We're not getting now the 429 issues anymore, but we're still getting the connect timeout:

```
Error: System error: Read timeout on endpoint URL: "https://bedrock-runtime.eu-west-2.amazonaws.com/model/anthropic.claude-3-7-sonnet-20250219-v1%3A0/converse"
```

The problem is that the model can take more than default 60seconds to reply, and a time to connect higger than expected based on the loads.

With this the problem should be alliviated a bit more.