### PR TITLE
fix: fix problems with branch and tag pushes

### DIFF
--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -42,7 +42,8 @@ jobs:
         tags: |
           type=ref,event=tag
           type=raw,value=latest,enable={{is_default_branch}}
-          type=sha,prefix={{branch}}-
+          type=ref,event=branch,prefix={{branch}}-,suffix=-{{sha}}
+          type=sha,event=tag
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v5


### PR DESCRIPTION
https://github.com/x2ansible/x2a-convertor/actions/runs/24727287806

```
Builder info
/usr/bin/docker buildx build --cache-from type=gha --cache-to type=gha,mode=max --file Dockerfile --iidfile /home/runner/work/_temp/docker-actions-toolkit-5BqKrr/build-iidfile-ec08d051e1.txt --label org.opencontainers.image.created=2026-04-21T14:13:05.940Z --label org.opencontainers.image.description= --label org.opencontainers.image.licenses= --label org.opencontainers.image.revision=eb78f513b4248dec2084332a8d883224b7406915 --label org.opencontainers.image.source=https://github.com/***/x2a-convertor --label org.opencontainers.image.title=x2a-convertor --label org.opencontainers.image.url=https://github.com/***/x2a-convertor --label org.opencontainers.image.version=v1.0.0 --platform linux/amd64,linux/arm64 --attest type=provenance,mode=max,builder-id=https://github.com/***/x2a-convertor/actions/runs/24727287806 --tag quay.io/***/x2a-convertor:v1.0.0 --tag quay.io/***/x2a-convertor:-eb78f51 --tag quay.io/***/x2a-convertor:latest --metadata-file /home/runner/work/_temp/docker-actions-toolkit-5BqKrr/build-metadata-feb768765a.json --push .
ERROR: failed to build: invalid tag "quay.io/***/x2a-convertor:-eb78f51": invalid reference format
Error: buildx failed with: ERROR: failed to build: invalid tag "quay.io/***/x2a-convertor:-eb78f51": invalid reference format
```

Now is working:
TAGS:
```
Docker tags
  quay.io/***/ee-x2a:v0.002
  quay.io/***/ee-x2a:sha-fd23ab8
  quay.io/***/ee-x2a:latest
```

Bracnh:

```
Docker tags
  quay.io/***/ee-x2a:test-test-fd23ab8
  quay.io/***/ee-x2a:sha-fd23ab8
```