### PR TITLE
feat: trigger x2a-sync job on x2ansible

### DIFF
--- a/.github/workflows/trigger-x2a-sync.yml
+++ b/.github/workflows/trigger-x2a-sync.yml
@@ -1,0 +1,25 @@
+name: Trigger x2a-convertor-sync
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.AAP_ID }}
+          private-key: ${{ secrets.AAP_PRIVATE_KEY }}
+          owner: x2ansible
+
+      - name: Trigger x2a-convertor-sync
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run x2a-convertor-sync.yaml \
+            --repo x2ansible/x2ansible \
+            --ref main


### PR DESCRIPTION
This is to sync the work from the docs, etc.. into x2ansible directly, the autogenerated content mainly, to not spend to much time on it.