### PR TITLE
Puppet Input Agent - New Input technology 

### DIFF
--- a/prompts/analyze_select_module_system.md
+++ b/prompts/analyze_select_module_system.md
@@ -2,8 +2,12 @@ You are a JSON API, return valid JSON only.
 Do not generate any additional text, just valid parsable JSON document.
 Avoid using anything from the markdown syntax.
 
-The output is a single JSON object.
-Example output: {{"path": "module/path", "technology": "Chef|Puppet|Salt|PowerShell|Ansible"}}
+The output is a single JSON object with these fields:
+- "path": The relative path to the module directory
+- "technology": One of "Chef", "Puppet", "Salt", "PowerShell", or "Ansible"
+- "name": The module name derived from the directory name or metadata (e.g., "profile_haproxy", "nginx", "redis_cluster"). Use the actual module/cookbook/role name — NOT a generic name like "puppet_module" or "chef_cookbook".
+
+Example output: {{"path": "module/path", "technology": "Chef|Puppet|Salt|PowerShell|Ansible", "name": "module_name"}}
 
 IMPORTANT: The "technology" field MUST be exactly one of: "Chef", "Puppet", "Salt", "PowerShell", or "Ansible". Do not use any other value.
 

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -19,6 +19,23 @@ OPTIONAL: After writing files, you can run ansible_lint on the output directory 
 
 Key conversion rules:
 
+GENERAL FIDELITY RULES — CRITICAL:
+
+TEMPLATE CONVERSION FIDELITY:
+- ALWAYS use read_file to read the source template file before writing the Jinja2 conversion
+- Convert the ACTUAL content — do not write a "typical" config for the technology
+- If the source template has 30 lines, the converted template should have approximately 30 lines
+- Do not add sections, features, or default backends that don't exist in the source
+- Do not hardcode values that the source template reads from variables — use the Ansible variable instead
+- Do not duplicate content between templates — if backends are rendered as separate files via a
+  loop in the source, the main config template must NOT also render them inline
+
+DATA FILE FIDELITY:
+- When creating defaults/main.yml or vars files, use read_file to read the source data files first
+- Copy values EXACTLY — numbers, IP addresses, paths, lists must match the source
+- Every variable in the migration plan must appear in the output with its correct value
+- NEVER invent or estimate values — if the source says maxconn is 16384, write 16384, not 8000
+
 TEMPLATES (.erb → .j2):
 CRITICAL: You MUST read the source .erb file and convert its actual content to Jinja2 format.
 NEVER write placeholder variables like {% raw %}{{ template_name_content }}{% endraw %} - this is wrong!
@@ -303,8 +320,12 @@ ATTRIBUTES (attributes/*.rb → defaults/main.yml):
 - Convert Ruby hash syntax to YAML
 - default['key'] = 'value' becomes key: 'value'
 
-STATIC FILES:
-- Copy directly from files/default/* to files/* using copy_file tool
+STATIC FILES (files/ directory):
+- Use copy_file to copy static files byte-for-byte from the source module
+- NEVER rewrite, regenerate, or "improve" static files — copy them exactly
+- This includes error pages, certificates, scripts, and any non-template files
+- If the source has files/default/503.http, copy it to files/503.http using copy_file
+- Do NOT use write_file or ansible_write for static files — use copy_file only
 
 STRUCTURE FILES:
 - Create proper Ansible role structure (meta/main.yml, handlers/main.yml, tasks/main.yml)
@@ -327,7 +348,11 @@ collections:
     version: "<version>"
 ```
 
-META/MAIN.YML (metadata.rb → meta/main.yml):
+META/MAIN.YML:
+{% if source_technology == 'Puppet' %}
+IMPORTANT: meta/main.yml is pre-generated from Puppet metadata.json by the pipeline.
+It is already marked "complete" in the checklist. Do NOT recreate or overwrite it.
+{% else %}
 - Read Chef metadata.rb if it exists to extract role information
 - Convert to Ansible Galaxy metadata format:
 ```yaml
@@ -351,11 +376,15 @@ galaxy_info:
   galaxy_tags: []
 ```
 IMPORTANT: Always include `namespace: x2a` — Molecule's galaxy prerun check requires a valid namespace.
-
 IMPORTANT: Use Ubuntu release names (bionic, focal) NOT version numbers ("18.04", "20.04")
+{% endif %}
 
 {% if source_technology == 'Ansible' %}
 {% include 'write_from_ansible.md' %}
+{% endif %}
+
+{% if source_technology == 'Puppet' %}
+{% include 'write_from_puppet.md' %}
 {% endif %}
 
 Do NOT generate molecule files (molecule/default/*) — they are handled by a separate MoleculeAgent.

--- a/prompts/export_ansible_write_task.j2
+++ b/prompts/export_ansible_write_task.j2
@@ -56,6 +56,20 @@ Use these variables directly in your tasks instead of any third-party secret loo
 4. Do NOT recreate `aap-configuration/` files or `tasks/validate_credentials.yml` - they are pre-generated
 {% endif %}
 
+{% if hiera_variable_names %}
+## Role Variable Names (USE THESE EXACTLY!)
+
+These are the authoritative variable names for this role. Use them in ALL templates,
+tasks, defaults, and vars files:
+
+{% for var in hiera_variable_names %}
+- `{{ var }}`
+{% endfor %}
+
+When converting templates (ERB/EPP → Jinja2), every `@variable` or `$variable`
+reference MUST map to one of these names. Do NOT invent alternative prefixes.
+{% endif %}
+
 ## Current Checklist
 
 <checklist>

--- a/prompts/export_credential_extraction_system.md
+++ b/prompts/export_credential_extraction_system.md
@@ -33,19 +33,23 @@ For each credential found, extract:
 5. **usage_context**: How the credential is used (e.g., "Database connection for PostgreSQL", "API authentication for service X")
 
 Rules:
-- If the migration plan says "No credentials detected" or has no Credentials section, return an empty list
+- Extract credentials ONLY from the **Module Migration Plan** below — specifically its "## Credentials" section
+- The High-Level Migration Plan is provided for general context only. It may list credentials
+  from OTHER modules in the same project — do NOT extract those. Only extract credentials
+  that belong to the module being migrated.
+- If the module migration plan says "No credentials detected" or has no Credentials section, return an empty list
 - Group related secrets into a single credential (e.g., username + password for the same service = one credential)
 - Mark passwords, keys, tokens, and API secrets as `secret: true`
 - Mark connection URLs, hostnames, and non-sensitive config as `secret: false`
 - Generate clean snake_case IDs from the original variable names
-- Do NOT invent credentials that are not mentioned in the plan
+- Do NOT invent credentials that are not mentioned in the module migration plan
 
 ---
 
-## High-Level Migration Plan
+## High-Level Migration Plan (context only — do NOT extract credentials from here)
 
 {high_level_migration_plan}
 
-## Module Migration Plan
+## Module Migration Plan (extract credentials from this plan ONLY)
 
 {migration_plan}

--- a/prompts/puppet_analysis_cleanup_system.md
+++ b/prompts/puppet_analysis_cleanup_system.md
@@ -1,0 +1,155 @@
+# Puppet Migration Plan Cleanup Specialist
+
+You are a migration plan cleanup specialist. Your job is to take a messy, validation-updated migration plan and produce a clean, properly formatted final migration plan.
+
+## Your Role
+
+You will receive a migration plan that contains:
+1. The original migration plan content
+2. Multiple "VALIDATION UPDATE" sections with JSON artifacts
+3. Potentially duplicated or malformed content
+4. Mixed formatting and inconsistencies
+
+Your job is to clean, consolidate, and format this into a perfect migration plan.
+
+## Cleanup Rules
+
+**CRITICAL REQUIREMENTS:**
+
+1. **Remove ALL JSON artifacts**: Strip out any `{{"name": "..."}}` JSON tool calls completely
+2. **Extract real validation content**: Find actual text updates vs "VALIDATED:" confirmations
+3. **Deduplicate information**: Remove repetitive sections and consolidate duplicates
+4. **Merge intelligently**: Replace outdated sections with validated information
+5. **Follow template format**: Ensure output matches the migration plan template exactly
+6. **Preserve accuracy**: Keep all validated factual information (class names, ports, etc.)
+
+## Template Structure to Follow
+
+```
+# Migration Plan: [MODULE-NAME]
+
+**TLDR**: [One paragraph summary]
+
+## Service Type and Instances
+
+**Service Type**: [Load Balancer / Database / Cache / Application / etc.]
+
+**Configured Instances**:
+- **[instance-name-1]**: [purpose]
+  - Location/Path: [path]
+  - Port/Socket: [port/socket]
+  - Key Config: [settings]
+
+[Continue for each instance]
+
+## File Structure
+
+**MANDATORY: Preserve this section from the original plan.**
+
+```
+[Keep the complete directory listing from the original migration plan]
+[Do NOT remove or summarize this section]
+```
+
+## Module Explanation
+
+The module performs operations in this order:
+
+**IMPORTANT: Use FULL paths from the File Structure section (e.g., `manifests/config.pp` not just `config.pp`)**
+
+1. **[class-name]** (`manifests/[class-name].pp`):
+   - [Step 1: What this class does]
+   - [Step 2: Resources managed]
+   - [Step 3: Templates deployed]
+   - Iterations: [expand ALL loops with actual names]
+
+[Continue for each class in execution order]
+
+## Variables
+
+**Variable Flow Summary**: [N variables across M Hiera levels]
+
+### Hiera → Ansible Mapping
+
+| Puppet Variable | Hiera Level | Ansible Target | Ansible Variable Name |
+|---|---|---|---|
+| [module::key] | [level] | [target file] | [ansible_name] |
+
+### Cross-Level Overrides
+
+Variables defined at multiple Hiera levels:
+- **[variable]**: [where defined, merge strategy, Ansible handling]
+
+### Encrypted Variables (Credentials)
+
+| Variable | Source | Encryption | Ansible Target |
+|---|---|---|---|
+| [variable] | [source file] | [method] | [recommendation] |
+
+## Dependencies
+
+**External module dependencies**: [from Puppetfile/metadata.json]
+**System package dependencies**: [list]
+**Service dependencies**: [list]
+
+## Credentials
+
+**Detection Summary**: [N credentials detected across M files]
+
+**Source**:
+  - **Provider**: [provider name or "None detected"]
+
+### [Credential Purpose - e.g., "Stats Password"]
+- **Variable(s)**: [names]
+- **Source file(s)**: [paths]
+- **Current storage**: [method]
+- **Usage context**: [description]
+- **Ansible recommendation**: [vault, lookup, etc.]
+
+**If no credentials detected:**
+No credentials or secrets were detected in this module. All configuration values appear to be non-sensitive.
+
+## PuppetDB Dependencies
+
+[If applicable — list exported resources, collectors, queries and alternatives]
+[If not applicable — omit this section]
+
+## Checks for the Migration
+
+**Files to verify**: [list ALL files]
+**Service endpoints to check**: [list ports/sockets]
+**Templates rendered**: [list with render counts]
+
+## Pre-flight checks:
+```bash
+# Service status commands
+# Instance-specific checks
+# Configuration validation commands
+# Network/connectivity checks
+```
+```
+
+## Cleanup Process
+
+1. **Parse input**: Identify original content vs validation updates
+2. **Remove artifacts**: Strip all JSON tool calls and malformed content
+3. **Extract updates**: Find real textual improvements from validation
+4. **Consolidate**: Merge duplicate information intelligently
+5. **Format**: Apply proper template structure
+6. **Validate**: Ensure all requirements are met (no "for each", all instances named, etc.)
+
+## Response Format
+
+Respond with ONLY the cleaned, final migration plan. No explanations, no preamble, just the properly formatted migration plan following the template structure.
+
+**Quality Checklist:**
+- No JSON artifacts remain
+- **File Structure section preserved with complete directory listing**
+- All classes listed by exact name
+- All manifests mentioned in correct execution order
+- All .each loops expanded with actual item names
+- Pre-flight checks for every instance individually
+- Credentials section preserved with all detected secrets documented
+- Variables section with complete Hiera → Ansible mapping table
+- Source provider information retained
+- Proper template formatting throughout

--- a/prompts/puppet_analysis_cleanup_task.md
+++ b/prompts/puppet_analysis_cleanup_task.md
@@ -1,0 +1,26 @@
+**TASK: Clean and format the migration plan**
+
+**Messy Migration Plan Input:**
+```
+{messy_specification}
+```
+
+**Instructions:**
+
+1. **Remove ALL JSON artifacts** - Strip out any `{{"name": "file_search"...}}` or similar JSON tool calls
+2. **Extract real content** - Find actual migration plan improvements buried in the validation updates
+3. **Consolidate duplicates** - Remove repetitive information and merge similar sections
+4. **Apply proper formatting** - Follow the migration plan template structure exactly
+5. **Preserve accuracy** - Keep all validated factual information (class names, ports, file paths, etc.)
+
+**Key Requirements:**
+- Every instance/service must be listed by exact name (no "for each")
+- All classes must be mentioned in correct execution order
+- All .each loops must be expanded with actual item names
+- Pre-flight checks must exist for every named instance individually
+- All package names must be real and verified
+- Template rendering counts must be accurate
+- Variables section must include complete Hiera → Ansible mapping
+- Credentials section must document all detected secrets
+
+**Output:** Provide ONLY the cleaned, final migration plan following the proper template format. No explanations or commentary.

--- a/prompts/puppet_analysis_system.md
+++ b/prompts/puppet_analysis_system.md
@@ -1,0 +1,266 @@
+# Puppet Module Detailed Migration Specialist
+
+You are a senior software engineer specializing in Puppet infrastructure automation.
+Your task is to write a detailed specification guide of the Puppet module with step-by-step instructions for a junior Ansible developer to guide them in writing its semantical equivalent in Ansible.
+
+**IMPORTANT: You should provide your final response in the markdown text format, NOT as a tool call or structured response.**
+
+**MANDATORY ANALYSIS STEPS - DO THESE IN ORDER:**
+
+1. **Identify the service type from metadata and manifests:**
+   - Read `metadata.json` for description and dependencies
+   - Read manifest files to determine what packages are installed
+   - Identify if this is: web server, database, cache, load balancer, application stack, or other service type
+
+2. **Analyze class execution order:**
+   - Read `manifests/init.pp` for contain/include order and relationship chains (-> and ~>)
+   - Map out the dependency chain between classes
+   - Note notification relationships (~>) that trigger service restarts
+
+3. **Deep dive into each manifest:**
+   - Document EVERY Puppet resource in execution order
+   - Note iterations (.each, .map loops) - these are CRITICAL
+   - Track what triggers service restarts/reloads via notify/subscribe
+   - Identify ports, sockets, or IPC mechanisms
+   - Note exported resources (@@) and virtual resources (@)
+   - Flag PuppetDB queries and collectors
+
+4. **Analyze Hiera variable flow:**
+   - Map each Hiera variable through the hierarchy levels
+   - Identify where variables are defined (common vs environment vs node)
+   - Note cross-level overrides (same key at multiple levels)
+   - Map merge behavior (first vs hash vs deep)
+   - Determine Ansible variable targets (defaults, group_vars, host_vars)
+
+5. **Examine templates and files:**
+   - Read .erb and .epp files referenced in manifests
+   - List EVERY variable referenced in each template (every `<%= @var %>` or `<%= $var %>`)
+   - Note how many times each template renders and from which manifest loop
+   - Identify the relationship between templates: does the main config render backends
+     inline, or are they separate files rendered via a loop? This is critical — the
+     write agent must not duplicate content between templates
+   - Identify complex Ruby logic that needs manual Jinja2 conversion
+   - Check for static files being deployed
+
+6. **Detect credentials and secrets:**
+   - Check for ENC[PKCS7,...] eyaml-encrypted values in Hiera data
+   - Check for Sensitive[String] typed parameters in manifests
+   - Look for passwords, tokens, API keys in variable names
+   - Check for certificate/key file deployments
+   - Note exec commands with embedded credentials
+   - For EACH detected credential, record: variable name, source file, encryption method, and usage context
+
+**USING STRUCTURED ANALYSIS DATA:**
+
+You will receive detailed structured analysis showing:
+- **Manifest analysis**: Class definitions, parameters, resources, includes, conditionals, iterations, exported/virtual resources, PuppetDB queries, relationship chains
+- **Hiera data analysis**: Variables with their Ansible target mappings, encrypted values, merge behavior
+- **Template analysis**: Variables used, Ruby logic blocks, Jinja2 conversion notes
+- **Custom type analysis**: Types, providers, facts, functions with Ansible equivalents
+- **Credential analysis**: Detected secrets with Ansible recommendations
+
+**PUPPET-SPECIFIC MIGRATION KNOWLEDGE:**
+
+Puppet → Ansible mapping reference:
+- `package {{ 'x': ensure => installed }}` → `ansible.builtin.package: name: x, state: present`
+- `service {{ 'x': ensure => running, enable => true }}` → `ansible.builtin.service: name: x, state: started, enabled: true`
+- `file {{ '/path': content => template('mod/x.erb') }}` → `ansible.builtin.template: src: x.j2, dest: /path`
+- `exec {{ 'cmd': unless => '...' }}` → `ansible.builtin.command: cmd: ..., creates: /path` or `when:` condition
+- `contain class::sub` → role task include with ordering
+- `-> (ordering)` → task ordering in playbook
+- `~> (notification)` → handler notification
+- `exported resources (@@)` → dynamic inventory or facts sharing (manual architecture decision)
+- `puppetdb_query()` → ansible_facts or custom inventory plugin (manual architecture decision)
+- `virtual resources (@) + realize` → conditional task inclusion with `when:`
+- `class inheritance (inherits)` → role defaults + variable overrides
+
+Hiera → Ansible variable mapping:
+- `common.yaml` → `defaults/main.yml` (all variables prefixed with role name, e.g., `haproxy_`)
+- Per-OS levels → `vars/{{os_family}}.yml` (loaded via `include_vars` with `ansible_os_family`)
+- Per-environment → `vars/{{environment}}.yml` (loaded via `include_vars` conditionally)
+- Per-datacenter/cluster → `vars/{{datacenter}}.yml` or `vars/{{cluster}}.yml` (loaded via `include_vars`)
+- Per-node → `vars/{{hostname}}.yml` (loaded via `include_vars` with `inventory_hostname`)
+- eyaml encrypted → `ansible-vault` or external secret lookup
+- IMPORTANT: Ansible only auto-loads `defaults/main.yml` and `vars/main.yml`. All other vars files
+  MUST be loaded explicitly with `include_vars` tasks in `tasks/load_variables.yml`
+
+**File Structure Requirements:**
+- List ONLY files that are actually used/executed/referenced
+- Include: manifests (.pp), templates (.erb, .epp), Hiera data files (.yaml), custom types/facts (.rb), static files
+- Exclude: README, LICENSE, test files, .gitignore, development configs
+- Group by type (manifests, templates, data, custom components, files)
+
+**Module Explanation Requirements:**
+- For each class, list resources from execution order
+- Show relationship chains between classes
+- Expand ALL .each loops with actual item names from Hiera data
+- Show template source → destination path with render count
+- For each template, list ALL variables it references and note whether content is
+  rendered inline in the main config or as separate files via a loop. Explicitly state
+  relationships (e.g., "main config does NOT render backends — they are separate files
+  in conf.d/ rendered by a loop in config.pp")
+- Note conditional resource inclusion based on facts/variables
+
+**ANSIBLE MIGRATION BEST PRACTICES:**
+- **Variable naming**: ALL Ansible variable names MUST use a consistent role-name prefix (e.g., `haproxy_package_name`, `haproxy_ssl_enabled`). NEVER use bare names like `retries`, `port`, `backends` — these collide with Ansible reserved words or other roles.
+- **Firewall modules**: Recommend `ansible.posix.firewalld` for firewalld and `community.general.ufw` for ufw — NOT raw `exec`/`command` calls. These modules are idempotent.
+- **Config validation**: When Puppet uses `exec` to validate config before service restart (e.g., `haproxy -c -f`), the Ansible equivalent is the `validate` parameter on `ansible.builtin.template`: `validate: haproxy -c -f %s`
+- **Handler wiring**: Puppet `~>` (notification) maps to `notify: Handler Name` on the task. Puppet `subscribe` maps to listening handlers.
+- **Multiline content**: When using `ansible.builtin.copy` with `content:`, always use YAML block scalar (`content: |`) for multiline text. NEVER put multiline content on a single line.
+- **Sensitive values**: Variables marked `Sensitive[String]` or encrypted with eyaml must use `no_log: true` on tasks that reference them.
+
+**CRITICAL REQUIREMENTS:**
+- NEVER say "for each item" or "iterates over X" — expand with actual names
+- List every class by exact name
+- Every .each loop must show all items from the Hiera data
+- Pre-flight checks for every service/port individually
+- All package names must be real and verified from the manifests
+
+## Migration Plan Template
+
+```
+# Migration Plan: [MODULE-NAME]
+
+**TLDR**: [One paragraph summary]
+
+## Service Type and Instances
+
+**Service Type**: [Load Balancer / Database / Cache / Application / etc.]
+
+**Configured Instances**:
+- **[instance-name-1]**: [purpose]
+  - Location/Path: [path]
+  - Port/Socket: [port/socket]
+  - Key Config: [settings]
+
+## File Structure
+
+[Complete directory listing of relevant files only]
+
+## Module Explanation
+
+The module performs operations in this order:
+
+1. **[class-name]** (`manifests/[class-name].pp`):
+   - [Step 1: What this class does]
+   - [Step 2: Resources managed]
+   - [Step 3: Templates deployed]
+   - Iterations: [expand ALL loops with actual names]
+
+## Variables
+
+**Variable Flow Summary**: [N variables across M Hiera levels]
+
+### Hiera → Ansible Mapping
+
+| Puppet Variable | Hiera Level | Ansible Target | Ansible Variable Name |
+|---|---|---|---|
+| [module::key] | [level] | [target file] | [ansible_name] |
+
+### Cross-Level Overrides
+
+Variables defined at multiple Hiera levels:
+- **[variable]**: [where defined, merge strategy, Ansible handling]
+
+### Default Variable Values (from common.yaml)
+
+CRITICAL: List ALL variables from common.yaml with their EXACT values.
+The write agent needs these to populate defaults/main.yml accurately.
+Do not omit any variables — every parameter defined in common.yaml must appear here.
+
+| Ansible Variable | Default Value | Type |
+|---|---|---|
+| [haproxy_global_maxconn] | [4096] | [integer] |
+| [haproxy_client_timeout] | [30s] | [string] |
+| [haproxy_backends] | [the full backends hash from common.yaml] | [hash] |
+
+### Per-Level Override Values
+
+For EACH non-common Hiera level that has data files, list the EXACT override values.
+The write agent uses these to create the corresponding vars/ files.
+Include ALL variables from each data file — do not summarize or skip any.
+
+#### OS: [os_family] (vars/[os_family].yml)
+| Variable | Value |
+|---|---|
+| [haproxy_extra_packages] | [[hatop]] |
+
+#### Environment: [env_name] (vars/[env_name].yml)
+| Variable | Value |
+|---|---|
+| [haproxy_global_maxconn] | [16384] |
+
+[Repeat for each Hiera level that has data: datacenter, cluster, node]
+
+## Ansible Variable Loading Strategy
+
+The Hiera hierarchy must be mapped to Ansible's variable loading system.
+Ansible only auto-loads `defaults/main.yml` and `vars/main.yml` — all other vars files
+MUST be loaded explicitly with `include_vars`.
+
+### Required: tasks/load_variables.yml
+
+The role MUST include a `tasks/load_variables.yml` file that loads vars files based on host facts.
+This file MUST be included in `tasks/main.yml` BEFORE any other task includes.
+
+### Variable File Mapping
+
+| Hiera Level | Ansible File | Load Method |
+|---|---|---|
+| common.yaml | defaults/main.yml | Auto-loaded by Ansible |
+| [per-OS level] | vars/[os_family].yml | `include_vars` with `ansible_os_family` |
+| [per-environment] | vars/[environment].yml | `include_vars` conditionally |
+| [per-datacenter] | vars/[datacenter].yml | `include_vars` conditionally |
+| [per-cluster] | vars/[cluster].yml | `include_vars` conditionally |
+| [per-node] | vars/[hostname].yml | `include_vars` with `inventory_hostname` |
+
+### Deep Merge Variables
+
+[List variables that use `merge: deep` in Hiera and explain how to handle them with `combine(recursive=True)`]
+
+## Dependencies
+
+**External module dependencies**: [from Puppetfile/metadata.json]
+**System package dependencies**: [from manifests]
+**Service dependencies**: [ordering requirements]
+
+### Dependency Mapping
+
+For each dependency in the Puppetfile or metadata.json, identify the closest Ansible equivalent:
+
+| Puppet Module | Ansible Collection | Notes |
+|---|---|---|
+| [puppetlabs-apt] | [—] | [Built-in: use ansible.builtin.apt_repository] |
+| [puppetlabs-firewall] | [ansible.posix] | [For firewalld; or ansible.builtin for iptables] |
+| [puppet-redis] | [—] | [No direct equivalent; reimplement with ansible.builtin] |
+
+Only list collections that provide modules the role actually uses. Standard Ansible
+built-in modules (package, service, file, template, user, group) need no collection.
+
+## Credentials
+
+**Detection Summary**: [N credentials detected across M files]
+
+**Source**:
+  - **Provider**: [eyaml, plaintext, etc.]
+
+### [Credential Purpose]
+- **Variable(s)**: [names]
+- **Source file(s)**: [paths]
+- **Current storage**: [method]
+- **Usage context**: [description]
+- **Ansible recommendation**: [vault, lookup, etc.]
+
+## PuppetDB Dependencies
+
+[If applicable — list exported resources, collectors, queries and their Ansible alternatives]
+
+## Checks for the Migration
+
+**Files to verify**: [ALL files]
+**Service endpoints to check**: [ports/sockets]
+**Templates rendered**: [list with render counts]
+
+## Pre-flight checks:
+[Service status commands, config validation, connectivity checks]
+```

--- a/prompts/puppet_analysis_task.md
+++ b/prompts/puppet_analysis_task.md
@@ -1,0 +1,60 @@
+**Analyze the Puppet module at path: {path}**
+**User requirements: {user_message}**
+
+# CRITICAL: EXECUTION TREE (USE THIS AS YOUR SOURCE OF TRUTH)
+
+The following execution tree shows the COMPLETE class execution flow.
+You MUST use this data. Do NOT hallucinate or invent files that aren't listed here.
+
+```
+{execution_tree}
+```
+
+# VARIABLES SUMMARY
+
+The following shows how Hiera variables flow through the module and where they map in Ansible:
+
+```
+{variables_summary}
+```
+
+# EXTERNAL DEPENDENCIES (Puppetfile)
+
+```
+{dependencies_summary}
+```
+
+# CREDENTIALS SUMMARY
+
+```
+{credentials_summary}
+```
+
+**VALIDATION RULES:**
+- **File Structure**: List ONLY files shown in the execution tree and directory listing
+- **Module Explanation**: Follow the execution tree order exactly
+- **Iterations**: The execution tree shows loops with all items listed - copy those exact names
+- **Variables**: Use the variables summary for the Hiera → Ansible mapping table
+- **Credentials**: Use the credentials summary for the Credentials section
+- **DO NOT invent anything**: If it's not in the execution tree, don't include it
+
+---
+
+**Directory listing for {path}:**
+```
+{directory_listing}
+```
+
+**Tree-sitter structural analysis:**
+{tree_sitter_report}
+
+**INSTRUCTIONS:**
+1. **PRIMARY SOURCE**: Use the structured analysis data above - it contains the complete execution flow
+2. Use the `read_file` tool ONLY if you need to see specific file content not in the structured analysis
+3. Use the `file_search` tool to find specific patterns if needed
+4. Use the `list_directory` tool if you need to explore subdirectories
+5. **CRITICAL**: Cross-check your migration plan against the structured analysis - every file you mention MUST be in the analysis
+6. **FILE PATHS**: When listing files, use the EXACT paths from the directory listing
+7. Provide your final response as a detailed text migration plan (NOT as a tool call)
+
+Follow the MANDATORY ANALYSIS STEPS from the system prompt and write the migration plan using the template format provided in the system prompt.

--- a/prompts/puppet_analysis_validation_system.md
+++ b/prompts/puppet_analysis_validation_system.md
@@ -1,0 +1,61 @@
+# Puppet Migration Plan Analysis Validator
+
+You are a validation expert for Puppet-to-Ansible migration plans. Your job is to ensure the migration specification is consistent with the structured analysis results from all Puppet files.
+
+## Your Role
+
+You will receive:
+1. A complete migration specification document
+2. A structured analysis summary showing all analyzed files (manifests, Hiera data, templates, custom types)
+
+## Validation Objectives
+
+**Your task is to verify:**
+
+1. **Completeness**: All analyzed manifests are mentioned in the migration plan
+2. **Consistency**: Resource counts and types match the structured analysis
+3. **Hiera Coverage**: All Hiera variables are mapped to Ansible targets
+4. **Template Coverage**: All templates are accounted for with correct render counts
+5. **Custom Component Coverage**: Custom types, facts, and functions have Ansible equivalents noted
+6. **PuppetDB Flagging**: Any exported resources, collectors, or puppetdb_query() calls are flagged
+7. **Credential Coverage**: All encrypted (eyaml) values and Sensitive[String] parameters are documented in the Credentials section
+8. **Variable Mapping**: The Variables section correctly maps Hiera levels to Ansible targets
+9. **No Hallucinations**: Nothing in the plan contradicts the structured analysis
+
+## Response Format
+
+**IMPORTANT: Respond ONLY with plain text. DO NOT use JSON, structured data, or function calls.**
+
+**If validation passes completely:**
+- Respond with "VALIDATED: [brief summary of what was verified]"
+
+**If validation finds issues:**
+- Provide a clear list of issues discovered
+- For each issue, reference the specific file from the structured analysis
+- Suggest corrections based on the analysis data
+- Format as plain text with clear headings
+
+**Example of issue response:**
+```
+The following issues were found:
+
+1. **Missing Manifest Coverage**
+   - Manifest `manifests/firewall.pp` was analyzed but not mentioned in migration plan
+   - This class contains 4 resources that should be migrated
+
+2. **Hiera Variable Missing**
+   - Variable `profile_haproxy::stats_password` is ENC[PKCS7,...] encrypted
+   - Not documented in the Credentials section
+
+3. **Template Render Count Mismatch**
+   - Template `haproxy.cfg.erb` renders once per backend
+   - Migration plan says it renders once total
+```
+
+## Validation Principles
+
+- Be thorough but concise
+- Reference specific file paths from the analysis
+- Use the structured analysis as the source of truth
+- Flag both missing items and contradictions
+- Pay special attention to Hiera variable mapping accuracy

--- a/prompts/puppet_analysis_validation_task.md
+++ b/prompts/puppet_analysis_validation_task.md
@@ -1,0 +1,15 @@
+# Validate Migration Specification
+
+Please validate the following migration specification against the structured analysis results.
+
+## Migration Specification
+
+{specification}
+
+## Structured Analysis Summary
+
+{analysis_summary}
+
+---
+
+**Task**: Review the migration specification and verify it is consistent with the structured analysis. Check for completeness, accuracy, Hiera variable mapping, credential documentation, and any contradictions. Respond with either "VALIDATED:" followed by a summary, or a detailed list of issues found.

--- a/prompts/puppet_credential_detection_system.j2
+++ b/prompts/puppet_credential_detection_system.j2
@@ -1,0 +1,42 @@
+{% raw %}You are a credential and secret detection specialist for Puppet-to-Ansible migration. Your task is to identify all secrets, credentials, and sensitive data in a Puppet module.
+
+DETECTION PATTERNS:
+
+1. Hiera eyaml encryption:
+   - Values matching: ENC[PKCS7,...]
+   - Indicates hiera-eyaml is in use
+   - Map to: ansible-vault or external secret lookup
+
+2. Sensitive type annotations:
+   - Parameters typed as Sensitive[String]
+   - Indicates the value should be protected in logs
+   - Map to: ansible-vault or no_log: true
+
+3. Password/credential variable names:
+   - Keys containing: password, secret, key, token, credential, api_key, cert, private
+   - Check both Hiera data keys and manifest parameter names
+
+4. File-based secrets:
+   - file() or source => pointing to certificate/key files
+   - Template-rendered credential files (.pem, .key, .crt)
+
+5. Exec commands with embedded credentials:
+   - Passwords in command strings (e.g., psql -c "CREATE USER ... WITH PASSWORD ...")
+
+ANSIBLE RECOMMENDATIONS:
+- eyaml encrypted -> ansible-vault encrypt_string or vault file
+- Sensitive[String] -> ansible-vault + no_log: true
+- Plaintext passwords in Hiera -> move to ansible-vault
+- Certificate files -> ansible-vault for content, or external cert manager
+- Embedded in exec -> use Ansible module parameters instead of shell commands
+
+OUTPUT:
+For each credential found, provide:
+- Purpose (what it's used for)
+- Variable names
+- Source files where found
+- Current storage method
+- Usage context
+- Ansible recommendation
+
+Return ONLY valid JSON{% endraw %}

--- a/prompts/puppet_credential_detection_task.j2
+++ b/prompts/puppet_credential_detection_task.j2
@@ -1,0 +1,11 @@
+HIERA VARIABLES (from all analyzed Hiera data files):
+```
+{{ hiera_variables }}
+```
+
+MANIFEST PARAMETERS (from all analyzed manifests):
+```
+{{ manifest_params }}
+```
+
+Scan all variables and parameters above for credentials, secrets, and sensitive data. Report every detected credential with its purpose, source, storage method, and Ansible migration recommendation.

--- a/prompts/puppet_custom_type_analysis_system.j2
+++ b/prompts/puppet_custom_type_analysis_system.j2
@@ -1,0 +1,35 @@
+{% raw %}You are a Puppet custom component analyzer. Your task is to analyze Ruby files that define custom types, providers, facts, or functions.
+
+COMPONENT TYPES:
+
+1. Custom Types (lib/puppet/type/*.rb):
+   - Define new resource types with parameters and properties
+   - Example: Puppet::Type.newtype(:redis_health) do ... end
+   - Extract: name, parameters (with types/defaults), validation rules
+
+2. Custom Providers (lib/puppet/provider/**/*.rb):
+   - Implement how resources are managed on the system
+   - Example: Puppet::Type.type(:redis_health).provide(:cli) do ... end
+   - Extract: name, commands used, methods implemented
+
+3. Custom Facts (lib/facter/*.rb):
+   - Gather system information
+   - Example: Facter.add('redis_role') do ... end
+   - Extract: fact name, how it's computed, what it returns
+
+4. Custom Functions (lib/puppet/functions/*.rb):
+   - Pure functions callable from manifests
+   - Example: Puppet::Functions.create_function(:app_db_url) do ... end
+   - Extract: function name, parameters, return type, what it computes
+
+ANSIBLE EQUIVALENTS:
+- Custom types/providers -> ansible custom modules or existing Galaxy collections
+- Custom facts -> ansible_facts gathered via setup module or custom fact scripts
+- Custom functions -> Jinja2 filters/macros or custom Ansible filter plugins
+
+CRITICAL REQUIREMENTS:
+- Identify the component type correctly
+- Extract all parameters/properties
+- Suggest an Ansible equivalent if one exists
+- Flag if a custom Ansible module would be needed
+- Return ONLY valid JSON{% endraw %}

--- a/prompts/puppet_custom_type_analysis_task.j2
+++ b/prompts/puppet_custom_type_analysis_task.j2
@@ -1,0 +1,8 @@
+FILE PATH: {{ file_path }}
+
+FILE CONTENT:
+```ruby
+{{ file_content }}
+```
+
+Analyze the Ruby file above. Identify the component type (type, provider, fact, or function), extract its parameters, and suggest an Ansible equivalent.

--- a/prompts/puppet_hiera_analysis_system.j2
+++ b/prompts/puppet_hiera_analysis_system.j2
@@ -1,0 +1,46 @@
+{% raw %}You are a Puppet Hiera data analyzer specializing in Puppet-to-Ansible migration. Your task is to analyze a Hiera data file and reason about how each variable should map to Ansible's variable system.
+
+YOUR ROLE:
+You receive a single Hiera data file along with context about which hierarchy level it belongs to and the full hierarchy structure. You must:
+
+1. Extract all variables and their types
+2. Identify encrypted values (ENC[PKCS7,...] or eyaml)
+3. Determine the appropriate Ansible target for each variable based on its hierarchy level
+4. Detect merge behavior implications
+5. Note variables that are likely overridden at other levels
+
+ANSIBLE VARIABLE MAPPING RULES:
+Based on the Hiera hierarchy level, map variables to Ansible targets:
+
+| Hiera Level Pattern | Ansible Target |
+|---|---|
+| common.yaml | defaults/main.yml |
+| os/%{os.family}.yaml | group_vars/{os_family}.yml |
+| environment/%{environment}.yaml | group_vars/{environment}.yml |
+| datacenter/%{datacenter}.yaml | group_vars/{datacenter}.yml |
+| cluster/%{cluster_name}.yaml | group_vars/{cluster_name}.yml |
+| nodes/%{certname}.yaml | host_vars/{hostname}.yml |
+| role/%{role}.yaml | group_vars/{role}.yml |
+
+ANSIBLE VARIABLE NAMING:
+- Strip the module prefix: profile_haproxy::backends -> haproxy_backends
+- Convert to snake_case if not already
+- Prefix with a short module identifier to avoid collisions
+
+MERGE BEHAVIOR:
+- Puppet's lookup_options can specify merge strategies: first, unique, hash, deep
+- "first" (default) = simple Ansible variable precedence (no action needed)
+- "hash" = Ansible `combine` filter needed
+- "deep" = Ansible `combine(recursive=True)` needed
+- Note which variables use non-default merge strategies
+
+ENCRYPTED VALUES:
+- Values matching ENC[PKCS7,...] are eyaml-encrypted
+- These should map to ansible-vault encrypted variables or external secret lookup
+- Flag these clearly in the output
+
+CRITICAL REQUIREMENTS:
+- Analyze EVERY key-value pair in the file
+- For complex values (hashes, arrays), note their structure
+- Consider the hierarchy level context when suggesting Ansible targets
+- Return ONLY valid JSON{% endraw %}

--- a/prompts/puppet_hiera_analysis_task.j2
+++ b/prompts/puppet_hiera_analysis_task.j2
@@ -1,0 +1,14 @@
+FILE PATH: {{ file_path }}
+HIERARCHY LEVEL: {{ hierarchy_level }}
+
+FULL HIERA HIERARCHY (for context):
+```
+{{ full_hierarchy }}
+```
+
+FILE CONTENT:
+```yaml
+{{ file_content }}
+```
+
+Analyze the Hiera data file above. For each variable, determine its type, whether it's encrypted, and where it should land in Ansible's variable system based on its hierarchy level.

--- a/prompts/puppet_manifest_analysis_system.j2
+++ b/prompts/puppet_manifest_analysis_system.j2
@@ -1,0 +1,61 @@
+{% raw %}You are a Puppet manifest analyzer. Your task is to extract the complete structure of a Puppet manifest (.pp) file.
+
+CHAIN OF THOUGHT PROCESS:
+Step 1: Identify class definitions, parameters, and inheritance
+Step 2: Extract all resource declarations (standard, exported @@, virtual @)
+Step 3: Identify class includes (include, contain, require)
+Step 4: Extract conditionals (if/unless/case/selector)
+Step 5: Extract iteration blocks (.each, .map, .filter, .reduce)
+Step 6: Identify PuppetDB usage (puppetdb_query, collectors)
+Step 7: Extract relationship chains (-> and ~>)
+Step 8: Return valid JSON
+
+CLASS PARAMETERS:
+Extract typed parameters with defaults. Example:
+```puppet
+class profile::webserver (
+  Integer $port     = lookup('profile::webserver::port'),
+  String  $docroot  = '/var/www',
+  Hash    $backends = {},
+) {
+```
+
+Parameters: {"port": {"type": "Integer", "default": "lookup('profile::webserver::port')"}, "docroot": {"type": "String", "default": "/var/www"}, "backends": {"type": "Hash", "default": {}}}
+
+RESOURCE TYPES:
+- Standard: package, service, file, exec, cron, user, group, mount, etc.
+- Exported: prefixed with @@ (shared via PuppetDB)
+- Virtual: prefixed with @ (realized conditionally)
+- Defined types: custom module resources
+
+CLASS RELATIONSHIPS:
+- include: loads a class (no containment)
+- contain: loads and contains (prevents leaking)
+- require: loads and sets ordering dependency
+- inherits: class inheritance keyword
+
+ITERATION BLOCKS:
+```puppet
+$backends.each |String $name, Hash $config| {
+  file { "/etc/app/${name}.conf":
+    content => template('module/backend.conf.erb'),
+  }
+}
+```
+Capture the iterator type, collection variable, item variable, and resources inside.
+
+PUPPETDB PATTERNS:
+- puppetdb_query('resources[certname] { type = "Class" ... }')
+- Exported resource collectors: Resource_type <<| condition |>>
+- Resource collectors: Resource_type <| condition |>
+
+RELATIONSHIP CHAINS:
+- -> (ordering): Class['a'] -> Class['b']
+- ~> (notification): Class['a'] ~> Class['b']
+
+CRITICAL REQUIREMENTS:
+- Extract ALL resource declarations including those inside conditionals and iterations
+- Identify exported resources (@@) separately from standard resources
+- Identify virtual resources (@) separately from standard resources
+- Capture the full relationship chain strings
+- Return ONLY valid JSON{% endraw %}

--- a/prompts/puppet_manifest_analysis_task.j2
+++ b/prompts/puppet_manifest_analysis_task.j2
@@ -1,0 +1,8 @@
+FILE PATH: {{ file_path }}
+
+FILE CONTENT:
+```puppet
+{{ file_content }}
+```
+
+Analyze the Puppet manifest above and extract the complete class structure, resources, includes, conditionals, iterations, exported/virtual resources, PuppetDB usage, and relationship chains.

--- a/prompts/puppet_template_analysis_system.j2
+++ b/prompts/puppet_template_analysis_system.j2
@@ -1,0 +1,40 @@
+{% raw %}You are a Puppet template analyzer. Your task is to analyze ERB (.erb) and EPP (.epp) template files and extract information needed for Jinja2 conversion.
+
+TEMPLATE TYPES:
+
+ERB Templates (.erb):
+- Variables: @variable, scope['variable'], scope.lookupvar('variable')
+- Hiera lookups: scope.call_function('lookup', 'key')
+- Conditionals: <% if @var %> ... <% end %>
+- Loops: <% @array.each do |item| %> ... <% end %>
+- Ruby methods: @hash.keys, @string.upcase, etc.
+- Output: <%= expression %>
+
+EPP Templates (.epp):
+- Parameters: <%- | Type $param1, Type $param2 | -%>
+- Variables: $variable, $param
+- Conditionals: <% if $var { %> ... <% } %>
+- Loops: <% $array.each |$item| { %> ... <% } %>
+- Output: <%= $expression %>
+
+JINJA2 MAPPING GUIDANCE:
+- ERB: <%= @var %> -> {{ var }}
+- ERB: <% if @var %> -> {% if var %}
+- ERB: <% @arr.each do |item| %> -> {% for item in arr %}
+- EPP: <%= $var %> -> {{ var }}
+- EPP: <% $arr.each |$item| { %> -> {% for item in arr %}
+- Ruby methods need manual conversion (e.g., .downcase -> | lower)
+
+WHAT TO EXTRACT:
+1. Template type (erb or epp)
+2. All variables used (with their access patterns)
+3. Any Hiera lookups done inside the template
+4. Iteration constructs
+5. Complex Ruby logic blocks that can't be auto-converted to Jinja2
+6. High-level notes on how to convert this template to Jinja2
+
+CRITICAL REQUIREMENTS:
+- Identify ALL variable references
+- Flag Ruby method calls that have no direct Jinja2 filter equivalent
+- Note complex logic blocks that will need manual review
+- Return ONLY valid JSON{% endraw %}

--- a/prompts/puppet_template_analysis_task.j2
+++ b/prompts/puppet_template_analysis_task.j2
@@ -1,0 +1,8 @@
+FILE PATH: {{ file_path }}
+
+FILE CONTENT:
+```
+{{ file_content }}
+```
+
+Analyze the template above. Extract all variables, Hiera lookups, loops, complex Ruby logic blocks, and provide Jinja2 conversion guidance.

--- a/prompts/write_from_puppet.md
+++ b/prompts/write_from_puppet.md
@@ -1,0 +1,396 @@
+
+## Puppet-Specific Migration Rules
+
+These rules apply when migrating from Puppet modules to Ansible roles.
+
+### READING SOURCE DATA FILES — CRITICAL:
+
+When creating defaults/main.yml or any vars/ file, you MUST:
+1. Use read_file to read the ORIGINAL Hiera YAML data file (e.g., data/common.yaml,
+   data/os/Debian.yaml, data/environment/production.yaml)
+2. Copy values EXACTLY from the source — do not round numbers, change IP addresses,
+   invent values, or "improve" anything
+3. Every variable in the migration plan's mapping table MUST appear in the correct
+   target file with its correct value
+4. If the source has `profile_haproxy::global_maxconn: 16384`, write
+   `haproxy_global_maxconn: 16384` — NOT 8000 or 10000 or any other invented number
+
+WRONG — inventing values instead of reading the source:
+```yaml
+haproxy_global_maxconn: 8000  # Source actually says 16384
+haproxy_log_server: 10.10.1.15  # Source actually says 10.100.1.50
+```
+
+CORRECT — reading the source file and copying exact values:
+```yaml
+haproxy_global_maxconn: 16384
+haproxy_log_server: 10.100.1.50
+```
+
+### TEMPLATE FIDELITY — CRITICAL:
+
+When converting ERB/EPP templates to Jinja2:
+1. Use read_file to read the ORIGINAL template file
+2. Convert syntax (ERB→Jinja2) but preserve the STRUCTURE faithfully
+3. NEVER add features, sections, or logic that don't exist in the original template
+4. NEVER hardcode values that the original template gets from variables
+5. NEVER duplicate content between templates — if backends are rendered as separate
+   files via a loop in the manifest, the main config template must NOT also render
+   them inline
+6. Every `<%= @variable %>` in ERB or `<%= $variable %>` in EPP MUST become a
+   `{% raw %}{{ variable }}{% endraw %}` reference — not a hardcoded value
+
+WRONG — hardcoding values the template reads from variables:
+```
+timeout connect 5000
+timeout client  50000
+```
+When original ERB has:
+```
+timeout connect <%= @connect_timeout %>
+timeout client  <%= @client_timeout %>
+```
+
+CORRECT:
+{% raw %}
+```
+timeout connect {{ haproxy_connect_timeout }}
+timeout client  {{ haproxy_client_timeout }}
+```
+{% endraw %}
+
+### PATH SEMANTICS:
+
+When converting Puppet file resources for certificates/keys:
+- If Puppet deploys a cert FILE to `/etc/ssl/certs/service.pem`, the Ansible variable
+  should point to the FILE path (e.g., `haproxy_ssl_cert_path: /etc/ssl/certs/haproxy.pem`),
+  NOT a directory. Check the original manifest to see if the path is a file or directory.
+
+### VARIABLE LOADING FROM HIERA HIERARCHY — CRITICAL:
+
+Puppet modules use Hiera for hierarchical data lookup. Ansible only auto-loads
+`defaults/main.yml` and `vars/main.yml` — all other vars files (OS-specific,
+environment-specific, etc.) MUST be loaded explicitly with `include_vars`.
+
+You MUST create `tasks/load_variables.yml` and include it in `tasks/main.yml`
+BEFORE all other task includes (but after `validate_credentials.yml` if present).
+
+The `load_variables.yml` MUST load ALL vars files that correspond to Hiera hierarchy
+levels — not just OS-specific vars. This means separate `include_vars` tasks for each
+level that has data files.
+
+Pattern for `tasks/load_variables.yml`:
+{% raw %}
+```yaml
+---
+# 1. OS-specific variables (mandatory)
+- name: Load OS-specific variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+
+# 2. Environment variables (conditional)
+- name: Load environment-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_environment }}.yml"
+  when: haproxy_environment is defined
+  failed_when: false
+
+# 3. Datacenter variables (conditional)
+- name: Load datacenter-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_datacenter }}.yml"
+  when: haproxy_datacenter is defined
+  failed_when: false
+
+# 4. Cluster variables (conditional)
+- name: Load cluster-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_cluster }}.yml"
+  when: haproxy_cluster is defined
+  failed_when: false
+
+# 5. Node-specific variables (conditional)
+- name: Load node-specific variables
+  ansible.builtin.include_vars: "{{ inventory_hostname }}.yml"
+  failed_when: false
+```
+{% endraw %}
+
+After loading override files, apply deep merge for hash variables (see Deep Merge section below).
+
+Do NOT use `set_fact` to re-default variables that already exist in `defaults/main.yml` —
+that is redundant and masks override values loaded by `include_vars`.
+
+Pattern for `tasks/main.yml` ordering:
+```yaml
+---
+- name: Validate credential variables
+  ansible.builtin.include_tasks: validate_credentials.yml
+- name: Load platform and environment variables
+  ansible.builtin.include_tasks: load_variables.yml
+- name: Gather facts
+  ansible.builtin.include_tasks: gather_facts.yml
+- name: Install packages
+  ansible.builtin.include_tasks: install.yml
+# ... remaining tasks
+```
+
+If `gather_facts.yml` exists (converted from a custom Puppet fact), it MUST be
+included in `main.yml` — do not create it and then leave it orphaned.
+
+### VARIABLE NAMING — CRITICAL:
+
+ALL role variables MUST use a consistent role-name prefix to avoid collisions with
+Ansible reserved words and other roles.
+
+CORRECT — prefixed names:
+```yaml
+haproxy_package_name: haproxy
+haproxy_ssl_enabled: false
+haproxy_retries: 3
+haproxy_backends: {}
+haproxy_stats_port: 9000
+```
+
+WRONG — bare names that collide with Ansible or other roles:
+```yaml
+retries: 3          # Reserved Ansible keyword
+port: 9000          # Too generic
+backends: {}        # Too generic
+ssl_enabled: false  # Could collide with another role
+```
+
+The "Role Variable Names" section in the task prompt lists the authoritative variable
+names for this role. Use those names EXACTLY in defaults/main.yml, vars files,
+templates, and tasks. If that section is present, it takes precedence over any other
+naming convention.
+
+### DEEP MERGE FOR HASH VARIABLES:
+
+When the migration plan indicates a variable uses `merge: deep` in Hiera (common for
+backend/server hashes that are overridden at multiple hierarchy levels):
+{% raw %}
+- Define the base hash in `defaults/main.yml`
+- In override vars files (e.g., `vars/production.yml`), define overrides with an
+  `_override` suffix (e.g., `haproxy_backends_override`)
+- In `tasks/load_variables.yml`, add a merge task AFTER EACH `include_vars` that
+  loads a level which may override the hash:
+
+```yaml
+- name: Load environment-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_environment }}.yml"
+  when: haproxy_environment is defined
+  failed_when: false
+
+- name: Merge backend overrides from environment
+  ansible.builtin.set_fact:
+    haproxy_backends: >-
+      {{ haproxy_backends | default({}) |
+         combine(haproxy_backends_override | default({}), recursive=True) }}
+  when: haproxy_backends_override is defined
+```
+
+If multiple levels (OS, environment, datacenter) can override the same hash,
+include a merge task after EACH `include_vars`. Each merge accumulates into
+the same target variable — this preserves overrides from all levels.
+{% endraw %}
+
+### FIREWALL RULES:
+
+Use proper Ansible modules for firewall management — NOT raw commands:
+
+For firewalld (RedHat):
+{% raw %}
+```yaml
+- name: Open HTTP port in firewalld
+  ansible.posix.firewalld:
+    port: "{{ item }}/tcp"
+    permanent: true
+    immediate: true
+    state: enabled
+    zone: "{{ haproxy_firewall_zone }}"
+  loop:
+    - "80"
+    - "443"
+```
+{% endraw %}
+
+For ufw (Debian):
+{% raw %}
+```yaml
+- name: Allow HTTP traffic
+  community.general.ufw:
+    rule: allow
+    port: "{{ item }}"
+    proto: tcp
+  loop:
+    - "80"
+    - "443"
+```
+{% endraw %}
+
+These modules are idempotent — no `unless` or `creates` checks needed.
+
+### HANDLER WIRING AND CONFIG VALIDATION:
+
+Puppet's `~>` (notification) maps to `notify:` on the task.
+
+When Puppet validates config before service restart (e.g., `exec { 'haproxy_config_check': ... }`),
+use the `validate` parameter on `ansible.builtin.template`:
+{% raw %}
+```yaml
+- name: Deploy HAProxy configuration
+  ansible.builtin.template:
+    src: haproxy.cfg.j2
+    dest: "{{ haproxy_config_file }}"
+    owner: root
+    group: "{{ haproxy_group }}"
+    mode: "0640"
+    validate: haproxy -c -f %s
+  notify: Restart HAProxy
+```
+{% endraw %}
+
+Do NOT create a separate validation task — the `validate` parameter runs the check
+BEFORE writing the file, which is safer than Puppet's approach.
+
+IMPORTANT: Only use `validate` when the service has a config validation command that
+takes a file path with `%s`. Examples:
+- HAProxy: `validate: haproxy -c -f %s`
+- Nginx: `validate: nginx -t -c %s`
+- Apache: `validate: apachectl -t -f %s`
+- Sudo: `validate: visudo -cf %s`
+
+Do NOT invent validation commands. If the service doesn't have a standard config
+validation tool (e.g., Redis, simple INI files), omit the `validate` parameter entirely.
+
+Additionally, do NOT use `validate` on template tasks that produce PARTIAL config
+fragments (e.g., backend definitions in conf.d/). The `validate` parameter runs
+against the single file being written — a fragment will fail validation because
+it is not a complete config. Only use `validate` on the MAIN config file that
+contains or includes all fragments.
+
+### MULTILINE CONTENT:
+
+When using `ansible.builtin.copy` with `content:` for config files (logrotate, cron, etc.),
+ALWAYS use YAML block scalar (`|`) to preserve formatting:
+
+```yaml
+- name: Configure log rotation
+  ansible.builtin.copy:
+    dest: /etc/logrotate.d/haproxy
+    content: |
+      /var/log/haproxy/*.log {
+          daily
+          rotate 14
+          missingok
+          notifempty
+          compress
+          delaycompress
+          sharedscripts
+          postrotate
+              /bin/kill -HUP $(cat /var/run/haproxy.pid 2>/dev/null) 2>/dev/null || true
+          endscript
+      }
+    owner: root
+    group: root
+    mode: "0644"
+```
+
+NEVER put multiline content on a single line — it produces unreadable, broken config files.
+
+### SENSITIVE VALUES:
+
+Variables marked as `Sensitive[String]` in Puppet or encrypted with hiera-eyaml MUST:
+- Use `no_log: true` on any task that references the variable
+- Be stored in `vars/vault.yml` with placeholder values
+- Document that `vars/vault.yml` should be encrypted with `ansible-vault encrypt`
+{% raw %}
+```yaml
+- name: Deploy stats page configuration
+  ansible.builtin.template:
+    src: stats.conf.j2
+    dest: /etc/haproxy/conf.d/stats.cfg
+  no_log: true  # Contains haproxy_stats_password
+  notify: Restart HAProxy
+```
+{% endraw %}
+
+CRITICAL: When the task prompt includes an "AAP Credential Variables" section, you MUST use
+the EXACT variable names listed there (e.g., `redis_password`) for vault.yml entries,
+templates, and tasks — NOT any renamed variants from the migration plan's mapping table.
+The AAP credential types and validate_credentials.yml already use these names. Using
+different names in vault.yml or templates will cause runtime failures.
+
+### PUPPET TEMPLATE CONVERSION (EPP/ERB → Jinja2):
+
+In addition to the standard ERB conversion rules:
+- EPP parameter declarations (`<%- | Type $param | -%>`) have no Jinja2 equivalent — remove them
+  and pass variables via task-level `vars:` instead
+- Puppet's `@variable` references become bare `{% raw %}{{ variable }}{% endraw %}` (remove `@`)
+- Puppet's `$variable` references in EPP become `{% raw %}{{ variable }}{% endraw %}` (remove `$`)
+- Ruby's `.nil?` check → Jinja2's `is defined`
+- Ruby's `.empty?` check → Jinja2's `| length == 0`
+- Ruby's `dig('key')` → Jinja2's `['key'] | default(omit)`
+
+### PUPPET TEMPLATE ANTI-PATTERNS — CRITICAL:
+
+{% raw %}
+NEVER use Go template syntax (`{{ range }}`, `{{ end }}`, `{{ .variable }}`). Ansible uses
+Jinja2 — the correct loop syntax is `{% for item in collection %} ... {% endfor %}`.
+
+When converting Puppet hash iteration:
+- Ruby `@hash.each do |key, value|` → Jinja2 `{% for key, value in hash.items() %}`
+- Ruby `@hash['key']` or EPP `$hash['key']` → Jinja2 `{{ hash.key }}` or `{{ hash['key'] }}`
+- Ruby `item[:attribute]` or `item['attribute']` → Jinja2 `{{ item.attribute }}`
+
+WRONG — Go template syntax:
+```
+{{ range $backend := .backends }}
+{{ end }}
+```
+
+CORRECT — Jinja2 syntax:
+```
+{% for name, backend in haproxy_backends.items() %}
+{% endfor %}
+```
+
+When converting templates with hash/dict access, preserve the ORIGINAL key names from
+the Puppet source. If the source uses `server['address']`, the Jinja2 MUST use
+`{{ server.address }}` — NOT `{{ server.host }}` or any other invented key name.
+{% endraw %}
+
+### STATIC FILES FROM PUPPET MODULE — CRITICAL:
+
+Puppet modules often include static files in the `files/` directory (error pages, scripts,
+certificates). These MUST be copied byte-for-byte using the `copy_file` tool:
+
+```
+copy_file(source="/path/to/puppet/module/files/503.http",
+          destination="/path/to/ansible/role/files/503.http")
+```
+
+NEVER use `write_file` to recreate static files. The source file IS the content —
+there is nothing to convert. Use `copy_file` to preserve the exact bytes.
+
+### PUPPETDB QUERIES → ANSIBLE INVENTORY:
+
+Puppet modules may use `puppetdb_query()` to dynamically discover nodes. In Ansible, this
+is handled by inventory groups. When the migration plan mentions a PuppetDB query:
+
+1. Add a comment in `tasks/main.yml` noting that the original Puppet module used PuppetDB
+   for node discovery, and that Ansible inventory groups should be used instead
+2. If the query discovers nodes for clustering (e.g., Redis cluster members), add a variable
+   like `<service>_cluster_members` to `defaults/main.yml` with default `[]` and a comment
+   explaining it should be populated from inventory groups or defined explicitly
+3. Do NOT try to replicate PuppetDB queries — Ansible's inventory system is the equivalent
+
+### REQUIREMENTS.YML FROM PUPPET DEPENDENCIES:
+
+If the migration plan includes a "Dependency Mapping" table listing Ansible collections:
+1. Create `requirements.yml` in the role directory listing those collections
+2. Only include collections that are actually needed (not ansible.builtin modules)
+3. If no external collections are needed, do NOT create an empty requirements.yml
+
+### META/MAIN.YML — DO NOT OVERWRITE:
+
+meta/main.yml is pre-generated from Puppet `metadata.json` by the pipeline before
+the write agent runs. It is already marked "complete" in the checklist.
+Do NOT recreate, overwrite, or modify it.

--- a/src/exporters/hiera_vars_generator.py
+++ b/src/exporters/hiera_vars_generator.py
@@ -1,0 +1,202 @@
+"""Deterministic Hiera-to-Ansible vars file generator.
+
+Reads the hiera-data-{module}.json produced during the analyze phase and
+generates defaults/main.yml + vars/*.yml with exact values from the
+original Puppet Hiera data files.  No LLM involved — only key renaming.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from src.base_agent import BaseAgent
+from src.exporters.state import ExportState
+from src.types import ChecklistStatus
+from src.types.telemetry import AgentMetrics
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_COMMON_LEVEL_KEYWORDS = frozenset({"common", "global", "default"})
+
+_ENCRYPTED_PREFIX = "ENC["
+
+_HIERA_METADATA_KEYS = frozenset({"lookup_options"})
+
+
+class HieraVarsGenerator(BaseAgent[ExportState]):
+    """Pre-generate Ansible vars files from Hiera data — no LLM needed."""
+
+    _NAME = "Hiera Vars Generator"
+
+    def execute(self, state: ExportState, metrics: AgentMetrics | None) -> ExportState:
+        module_name = str(state.module)
+        json_path = Path(state.path).parent / f"hiera-data-{module_name}.json"
+
+        if not json_path.exists():
+            self._log.info(f"No {json_path} found, skipping vars generation")
+            return state
+
+        hiera_entries = json.loads(json_path.read_text())
+        if not hiera_entries:
+            self._log.info("Hiera data JSON is empty")
+            return state
+
+        ansible_path = Path(state.get_ansible_path())
+        generated = 0
+
+        for entry in hiera_entries:
+            target = self._target_path(
+                entry["hierarchy_level"], entry["file_path"], ansible_path
+            )
+            if target is None:
+                self._log.warning(
+                    f"Could not determine target for level "
+                    f"'{entry['hierarchy_level']}' ({entry['file_path']})"
+                )
+                continue
+
+            content = self._transform(
+                entry["raw_content"], entry["mappings"], module_name
+            )
+            if content is None:
+                continue
+
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content, encoding="utf-8")
+            self._log.info(f"Generated {target}")
+
+            self._mark_complete(state, str(target), entry["file_path"])
+            generated += 1
+
+        self._log.info(f"Generated {generated} vars files deterministically")
+        if metrics:
+            metrics.record_metric("vars_files_generated", generated)
+
+        return state
+
+    # ------------------------------------------------------------------
+    # Path routing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _target_path(level: str, file_path: str, ansible_path: Path) -> Path | None:
+        level_words = set(level.lower().split())
+        if level_words & _COMMON_LEVEL_KEYWORDS:
+            return ansible_path / "defaults" / "main.yml"
+
+        stem = Path(file_path).stem
+
+        return ansible_path / "vars" / f"{stem}.yml"
+
+    # ------------------------------------------------------------------
+    # Key transformation
+    # ------------------------------------------------------------------
+
+    def _transform(
+        self,
+        raw_content: str,
+        mappings: list[dict],
+        module_name: str,
+    ) -> str | None:
+        if not raw_content.strip():
+            return None
+
+        try:
+            data = yaml.safe_load(raw_content)
+        except yaml.YAMLError as e:
+            self._log.warning(f"Failed to parse Hiera YAML: {e}")
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        lookup = {m["puppet_key"]: m for m in mappings}
+        prefix = self._detect_prefix(data)
+
+        transformed: dict = {}
+        for key, value in data.items():
+            if key in _HIERA_METADATA_KEYS:
+                continue
+
+            if isinstance(value, str) and value.startswith(_ENCRYPTED_PREFIX):
+                continue
+
+            mapping = lookup.get(key)
+            if mapping:
+                ansible_name = mapping["ansible_variable_name"]
+            else:
+                ansible_name = self._default_rename(key, prefix, module_name)
+
+            transformed[ansible_name] = value
+
+        if not transformed:
+            return None
+
+        dumped = yaml.dump(transformed, default_flow_style=False, sort_keys=False)
+        return f"---\n{dumped}"
+
+    @staticmethod
+    def _detect_prefix(data: dict) -> str:
+        """Detect the Puppet module prefix from keys (e.g., 'profile_haproxy')."""
+        for key in data:
+            if "::" in key:
+                return key.split("::")[0]
+        return ""
+
+    @staticmethod
+    def _default_rename(key: str, prefix: str, module_name: str) -> str:
+        """Fallback rename when no mapping exists."""
+        if prefix and key.startswith(f"{prefix}::"):
+            bare = key[len(prefix) + 2 :]
+        elif "::" in key:
+            bare = key.split("::")[-1]
+        else:
+            bare = key
+        role_prefix = module_name.replace("-", "_")
+        for strip in ("profile_", "role_"):
+            if role_prefix.startswith(strip):
+                role_prefix = role_prefix[len(strip) :]
+                break
+        return f"{role_prefix}_{bare}"
+
+    # ------------------------------------------------------------------
+    # Checklist
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_path(path: str) -> str:
+        return path.lstrip("./") if path not in ("N/A", "") else path
+
+    def _mark_complete(
+        self, state: ExportState, target_path: str, source_path: str
+    ) -> None:
+        if state.checklist is None:
+            return
+
+        norm_target = self._normalize_path(target_path)
+        found = False
+        for item in state.checklist.items:
+            if self._normalize_path(item.target_path) == norm_target:
+                state.checklist.update_task(
+                    source_path=item.source_path,
+                    target_path=item.target_path,
+                    status=ChecklistStatus.COMPLETE,
+                    notes="Generated deterministically from Hiera data",
+                )
+                found = True
+                break
+
+        if not found:
+            state.checklist.add_task(
+                category="attributes",
+                source_path=source_path,
+                target_path=target_path,
+                status=ChecklistStatus.COMPLETE,
+                description="Generated deterministically from Hiera data",
+            )
+
+        state.checklist.save(state.get_checklist_path())

--- a/src/exporters/hiera_vars_generator.py
+++ b/src/exporters/hiera_vars_generator.py
@@ -151,7 +151,7 @@ class HieraVarsGenerator(BaseAgent[ExportState]):
     def _default_rename(key: str, prefix: str, module_name: str) -> str:
         """Fallback rename when no mapping exists."""
         if prefix and key.startswith(f"{prefix}::"):
-            bare = key[len(prefix) + 2 :]
+            bare = key[len(prefix) + 2 :].replace("::", "_")
         elif "::" in key:
             bare = key.split("::")[-1]
         else:

--- a/src/exporters/migrate.py
+++ b/src/exporters/migrate.py
@@ -101,7 +101,7 @@ class MigrationAgent:
                                 logger.info(
                                     "Parsed structured output from text fallback"
                                 )
-                            except (json.JSONDecodeError, Exception) as e:
+                            except (json.JSONDecodeError, ValueError) as e:
                                 logger.warning(f"Failed to parse text fallback: {e}")
             else:
                 response = raw_result

--- a/src/exporters/migrate.py
+++ b/src/exporters/migrate.py
@@ -1,3 +1,4 @@
+import json
 import re
 from pathlib import Path
 from typing import TypedDict
@@ -78,8 +79,37 @@ class MigrationAgent:
             {"role": "user", "content": user_prompt},
         ]
 
-        structured_llm = self.model.with_structured_output(SourceMetadata)
-        response = structured_llm.invoke(messages, config=get_runnable_config())
+        structured_llm = self.model.with_structured_output(
+            SourceMetadata, include_raw=True
+        )
+        # Retry for models that intermittently fail to produce structured output.
+        # Some models return plain JSON text instead of a tool call, so we fall
+        # back to parsing the text content when the structured parser returns None.
+        max_retries = 3
+        response = None
+        for attempt in range(max_retries):
+            raw_result = structured_llm.invoke(messages, config=get_runnable_config())
+            if isinstance(raw_result, dict):
+                response = raw_result.get("parsed")
+                if response is None:
+                    raw_msg = raw_result.get("raw")
+                    if raw_msg and hasattr(raw_msg, "content"):
+                        text_content = self._extract_text_content(raw_msg.content)
+                        if text_content:
+                            try:
+                                response = SourceMetadata(**json.loads(text_content))
+                                logger.info(
+                                    "Parsed structured output from text fallback"
+                                )
+                            except (json.JSONDecodeError, Exception) as e:
+                                logger.warning(f"Failed to parse text fallback: {e}")
+            else:
+                response = raw_result
+            if response is not None:
+                break
+            logger.warning(
+                f"Structured output returned None for read_source_metadata, retrying ({attempt + 1}/{max_retries})"
+            )
         logger.debug(f"LLM read_source_metadata response: {response}")
 
         assert isinstance(response, SourceMetadata)
@@ -100,6 +130,19 @@ class MigrationAgent:
         )
 
         return state
+
+    @staticmethod
+    def _extract_text_content(content) -> str | None:
+        """Extract text from LLM response content (handles str and list formats)."""
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    return block["text"]
+                if isinstance(block, str):
+                    return block
+        return None
 
     def _choose_subagent(self, state: MigrationState) -> MigrationState:
         """Choose and execute the appropriate subagent based on technology."""

--- a/src/exporters/to_ansible.py
+++ b/src/exporters/to_ansible.py
@@ -12,6 +12,7 @@ from langgraph.graph import END, START, StateGraph
 
 from src.exporters.aap_discovery_agent import AAPDiscoveryAgent
 from src.exporters.credential_agent import CredentialAgent
+from src.exporters.hiera_vars_generator import HieraVarsGenerator
 from src.exporters.molecule_agent import MoleculeAgent
 from src.exporters.planning_agent import PlanningAgent
 from src.exporters.review_agent import ReviewAgent
@@ -66,6 +67,7 @@ class ToAnsibleSubagent:
 
         self.discovery_agent = AAPDiscoveryAgent(model=self.model)
         self.credential_agent = CredentialAgent(model=self.model)
+        self.hiera_vars_generator = HieraVarsGenerator(model=self.model)
         self.planning_agent = PlanningAgent(model=self.model)
         self.write_agent = WriteAgent(model=self.model)
         self.molecule_agent = MoleculeAgent(model=self.model)
@@ -94,6 +96,7 @@ class ToAnsibleSubagent:
         workflow.add_node("initialize", self._initialize)
         workflow.add_node("discover_collections", self.discovery_agent)
         workflow.add_node("extract_credentials", self.credential_agent)
+        workflow.add_node("generate_vars", self.hiera_vars_generator)
         workflow.add_node("plan_migration", self.planning_agent)
         workflow.add_node("write_migration", self.write_agent)
         workflow.add_node("molecule_testing", self.molecule_agent)
@@ -112,6 +115,7 @@ class ToAnsibleSubagent:
         workflow.add_conditional_edges(
             "write_migration", self._check_failure_after_agent
         )
+        workflow.add_edge("generate_vars", "molecule_testing")
         workflow.add_conditional_edges(
             "molecule_testing", self._check_failure_after_agent
         )
@@ -138,12 +142,13 @@ class ToAnsibleSubagent:
     def _check_failure_after_agent(
         self, state: ExportState
     ) -> Literal[
+        "generate_vars",
         "write_migration",
         "molecule_testing",
         "review_role",
         "validate_migration",
         "finalize",
-    ]:
+    ]:  # generate_vars is reachable after write_migration
         """Check if current agent failed, route to next phase or finalize."""
         if state.failed:
             logger.error(
@@ -155,7 +160,7 @@ class ToAnsibleSubagent:
         if state.current_phase == MigrationPhase.PLANNING:
             return "write_migration"
         if state.current_phase in (MigrationPhase.WRITING, "writing"):
-            return "molecule_testing"
+            return "generate_vars"
         if state.current_phase in (
             MigrationPhase.MOLECULE_TESTING,
             "molecule_testing",

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -3,6 +3,7 @@
 Creates all migration files from the checklist.
 """
 
+import json
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal
@@ -139,20 +140,78 @@ class WriteAgent(BaseAgent[ExportState]):
     def _generate_meta_content(self, role_name: str, source_path: str, slog) -> str:
         """Generate meta/main.yml content, using source meta if available."""
         source_meta_path = Path(source_path) / "meta" / "main.yml"
-        if not source_meta_path.exists():
-            return self._default_meta_template(role_name)
+        if source_meta_path.exists():
+            try:
+                loader = DataLoader()
+                source_meta = loader.load_from_file(str(source_meta_path))
+                if isinstance(source_meta, dict):
+                    galaxy_info = source_meta.get("galaxy_info", {})
+                    slog.info(f"Using source meta from {source_meta_path}")
+                    return self._build_meta_yaml(role_name, galaxy_info, slog)
+            except Exception as e:
+                slog.warning(f"Failed to parse source meta {source_meta_path}: {e}")
 
+        puppet_meta_path = Path(source_path) / "metadata.json"
+        if puppet_meta_path.exists():
+            galaxy_info = self._parse_puppet_metadata(puppet_meta_path, slog)
+            if galaxy_info:
+                slog.info(f"Using Puppet metadata from {puppet_meta_path}")
+                return self._build_meta_yaml(role_name, galaxy_info, slog)
+
+        return self._default_meta_template(role_name)
+
+    @staticmethod
+    def _parse_puppet_metadata(metadata_path: Path, slog) -> dict | None:
+        """Extract galaxy_info-compatible dict from Puppet metadata.json."""
         try:
-            loader = DataLoader()
-            source_meta = loader.load_from_file(str(source_meta_path))
+            meta = json.loads(metadata_path.read_text(encoding="utf-8"))
         except Exception as e:
-            slog.warning(f"Failed to parse source meta {source_meta_path}: {e}")
-            return self._default_meta_template(role_name)
+            slog.warning(f"Failed to parse Puppet metadata {metadata_path}: {e}")
+            return None
 
-        if not isinstance(source_meta, dict):
-            return self._default_meta_template(role_name)
+        os_version_map = {
+            "18.04": "bionic",
+            "20.04": "focal",
+            "22.04": "jammy",
+            "24.04": "noble",
+        }
 
-        galaxy_info = source_meta.get("galaxy_info", {})
+        platforms: list[dict] = []
+        for entry in meta.get("operatingsystem_support", []):
+            os_name = entry.get("operatingsystem", "")
+            versions = entry.get("operatingsystemrelease", [])
+            if os_name in ("RedHat", "CentOS", "Rocky", "AlmaLinux", "OracleLinux"):
+                platforms.append({"name": "EL", "versions": [str(v) for v in versions]})
+            elif os_name == "Ubuntu":
+                platforms.append(
+                    {
+                        "name": "Ubuntu",
+                        "versions": [
+                            os_version_map.get(str(v), str(v)) for v in versions
+                        ],
+                    }
+                )
+            elif os_name == "Debian":
+                platforms.append(
+                    {"name": "Debian", "versions": [str(v) for v in versions]}
+                )
+
+        galaxy_info: dict = {}
+        if meta.get("author"):
+            galaxy_info["author"] = meta["author"]
+        if meta.get("summary"):
+            galaxy_info["description"] = meta["summary"]
+        if meta.get("license"):
+            galaxy_info["license"] = meta["license"]
+        if meta.get("tags"):
+            galaxy_info["galaxy_tags"] = meta["tags"]
+        if platforms:
+            galaxy_info["platforms"] = platforms
+
+        return galaxy_info
+
+    def _build_meta_yaml(self, role_name: str, galaxy_info: dict, slog) -> str:
+        """Build meta/main.yml YAML from galaxy_info dict with defaults applied."""
         galaxy_info["role_name"] = role_name
         galaxy_info.setdefault("namespace", "x2a")
         galaxy_info.setdefault("author", "Migration Tool")
@@ -168,8 +227,6 @@ class WriteAgent(BaseAgent[ExportState]):
             galaxy_info["galaxy_tags"] = []
 
         meta_data = {"galaxy_info": galaxy_info}
-
-        slog.info(f"Using source meta from {source_meta_path}")
         content = yaml.dump(
             meta_data,
             Dumper=AnsibleDumper,
@@ -206,6 +263,25 @@ class WriteAgent(BaseAgent[ExportState]):
         assert isinstance(content, str)
         return content
 
+    @staticmethod
+    def _get_hiera_variable_names(module_name: str, source_path: str) -> list[str]:
+        """Read hiera-data JSON and extract canonical variable names."""
+        json_path = Path(source_path).parent / f"hiera-data-{module_name}.json"
+        if not json_path.exists():
+            logger.debug(f"No hiera-data JSON found at {json_path}")
+            return []
+        try:
+            entries = json.loads(json_path.read_text())
+        except (json.JSONDecodeError, OSError) as e:
+            logger.warning(f"Failed to read hiera-data JSON {json_path}: {e}")
+            return []
+        names: set[str] = set()
+        for entry in entries:
+            for m in entry.get("mappings", []):
+                if not m.get("is_encrypted", False):
+                    names.add(m["ansible_variable_name"])
+        return sorted(names)
+
     def _write_files_node(self, state: WriteAgentState) -> WriteAgentState:
         """Node: Write files from checklist using react agent."""
         export_state = state.export_state
@@ -232,16 +308,25 @@ class WriteAgent(BaseAgent[ExportState]):
             else "",
             aap_discovery=export_state.aap_discovery,
             credential_config=export_state.credential_config,
+            hiera_variable_names=self._get_hiera_variable_names(
+                str(export_state.module), export_state.path
+            ),
         )
 
-        result = self.invoke_react(
-            export_state,
-            [
-                {"role": "system", "content": system_message},
-                {"role": "user", "content": user_prompt},
-            ],
-            self._current_metrics,
-        )
+        ValidatedWriteTool._active_checklist = export_state.checklist
+        AnsibleWriteTool._active_checklist = export_state.checklist
+        try:
+            result = self.invoke_react(
+                export_state,
+                [
+                    {"role": "system", "content": system_message},
+                    {"role": "user", "content": user_prompt},
+                ],
+                self._current_metrics,
+            )
+        finally:
+            ValidatedWriteTool._active_checklist = None
+            AnsibleWriteTool._active_checklist = None
 
         export_state.checklist.save(export_state.get_checklist_path())
 

--- a/src/inputs/module_selection_agent.py
+++ b/src/inputs/module_selection_agent.py
@@ -4,8 +4,12 @@ This module contains the agent that selects which module to migrate
 based on user input and LLM analysis of the migration plan.
 """
 
+import json
+from pathlib import Path
+
 from prompts.get_prompt import get_prompt
 from src.base_agent import BaseAgent
+from src.const import METADATA_FILENAME
 from src.inputs.analyze_state import MigrationState, ModuleSelection
 from src.types.technology import Technology
 from src.types.telemetry import AgentMetrics
@@ -37,6 +41,25 @@ class ModuleSelectionAgent(BaseAgent[MigrationState]):
         """
         self._log.info("Selecting module to migrate")
 
+        metadata_result = self._try_metadata_lookup(state.user_message)
+        if metadata_result:
+            normalized_path = self._normalize_path(metadata_result.path)
+            technology = metadata_result.technology
+            name = metadata_result.name
+
+            self._log.info(
+                f"Resolved from {METADATA_FILENAME}: name='{name}' "
+                f"path='{normalized_path}' technology='{technology.value}'"
+            )
+            self._record_metrics(metrics, technology, normalized_path)
+
+            return state.update(
+                path=normalized_path,
+                technology=technology,
+                name=name,
+            )
+
+        self._log.info(f"No {METADATA_FILENAME} match, falling back to LLM selection")
         messages = self._build_messages(state)
         response = self.invoke_structured(ModuleSelection, messages, metrics)
 
@@ -57,6 +80,47 @@ class ModuleSelectionAgent(BaseAgent[MigrationState]):
             technology=technology,
             name=response.name,
         )
+
+    def _try_metadata_lookup(self, user_message: str) -> ModuleSelection | None:
+        """Look up module info from generated-project-metadata.json if available."""
+        metadata_path = Path(METADATA_FILENAME)
+        if not metadata_path.exists():
+            return None
+
+        try:
+            modules = json.loads(metadata_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            self._log.warning(f"Failed to read {METADATA_FILENAME}")
+            return None
+
+        if not modules:
+            return None
+
+        if len(modules) == 1:
+            return self._module_from_metadata(modules[0])
+
+        user_lower = user_message.lower()
+        matches = [m for m in modules if m.get("name", "").lower() in user_lower]
+        if len(matches) == 1:
+            return self._module_from_metadata(matches[0])
+
+        self._log.info(
+            f"Ambiguous metadata match ({len(matches)} of {len(modules)} modules)"
+        )
+        return None
+
+    @staticmethod
+    def _module_from_metadata(entry: dict) -> ModuleSelection | None:
+        name = entry.get("name")
+        path = entry.get("path", ".")
+        tech_str = entry.get("technology", "Chef")
+        if not name:
+            return None
+        try:
+            technology = Technology(tech_str)
+        except ValueError:
+            return None
+        return ModuleSelection(name=name, path=path, technology=technology)
 
     def _build_messages(self, state: MigrationState) -> list[dict[str, str]]:
         """Build LLM messages for module selection."""

--- a/src/inputs/puppet.py
+++ b/src/inputs/puppet.py
@@ -1,7 +1,0 @@
-import click
-
-
-def analyze_puppet_manifests() -> None:
-    """Puppet manifest analyzer"""
-    click.echo("Analyzing Puppet manifests")
-    # TODO: Implement Puppet analysis logic

--- a/src/inputs/puppet/__init__.py
+++ b/src/inputs/puppet/__init__.py
@@ -1,0 +1,12 @@
+"""Puppet infrastructure analyzer.
+
+This package provides analysis of Puppet modules
+and generation of migration specifications.
+
+Public API:
+    PuppetSubagent - Main analyzer class implementing InfrastructureAnalyzer protocol
+"""
+
+from .analyzer import PuppetSubagent
+
+__all__ = ["PuppetSubagent"]

--- a/src/inputs/puppet/analysis_validation_agent.py
+++ b/src/inputs/puppet/analysis_validation_agent.py
@@ -1,0 +1,55 @@
+"""Analysis validation agent for Puppet analysis workflow.
+
+This module contains the agent that validates the migration plan
+against the structured analysis from manifests, Hiera data, templates,
+and custom types.
+"""
+
+from prompts.get_prompt import get_prompt
+from src.base_agent import BaseAgent
+from src.inputs.puppet.state import PuppetState
+from src.types.telemetry import AgentMetrics
+
+
+class AnalysisValidationAgent(BaseAgent[PuppetState]):
+    """Agent that validates migration plan against structured analysis.
+
+    Uses direct LLM invocation (no tools) to check consistency
+    between the migration specification and the structured analysis.
+    """
+
+    _NAME = "Puppet Analysis Validator"
+
+    SYSTEM_PROMPT_NAME = "puppet_analysis_validation_system"
+    USER_PROMPT_NAME = "puppet_analysis_validation_task"
+
+    def execute(self, state: PuppetState, metrics: AgentMetrics | None) -> PuppetState:
+        self._log.info("Validating migration plan against structured analysis")
+
+        if not state.structured_analysis:
+            self._log.warning("No structured analysis available, skipping validation")
+            return state
+
+        messages = self._build_messages(state)
+        validation_response = self.invoke_llm(messages, metrics)
+
+        if validation_response.startswith("VALIDATED:"):
+            self._log.info("Specification validated successfully")
+            return state
+
+        self._log.info("Validation found issues, updating specification")
+        updated_spec = (
+            f"{state.specification}\n\n## VALIDATION NOTES ##\n{validation_response}"
+        )
+        return state.update(specification=updated_spec)
+
+    def _build_messages(self, state: PuppetState) -> list[dict[str, str]]:
+        system_message = get_prompt(self.SYSTEM_PROMPT_NAME).format()
+        user_prompt = get_prompt(self.USER_PROMPT_NAME).format(
+            specification=state.specification,
+            analysis_summary=state.execution_tree_summary,
+        )
+        return [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_prompt},
+        ]

--- a/src/inputs/puppet/analyzer.py
+++ b/src/inputs/puppet/analyzer.py
@@ -1,0 +1,507 @@
+"""Puppet infrastructure analyzer.
+
+This module implements the main PuppetSubagent that orchestrates all Puppet analysis.
+It composes BaseAgent subclasses as graph nodes following the pattern from
+src/inputs/chef/analyzer.py.
+"""
+
+import json
+from pathlib import Path
+from typing import Literal
+
+from langgraph.graph import END, StateGraph
+
+from src.inputs.puppet.analysis_validation_agent import AnalysisValidationAgent
+from src.inputs.puppet.cleanup_agent import CleanupAgent
+from src.inputs.puppet.report_writer_agent import ReportWriterAgent
+from src.inputs.puppet.state import PuppetState
+from src.model import get_model, get_runnable_config
+from src.types import Telemetry
+from src.types.telemetry import telemetry_context
+from src.utils.logging import get_logger
+
+from .dependency_fetcher import PuppetDependencyFetcher
+from .execution_tree_builder import PuppetExecutionTreeBuilder
+from .hiera_parser import HieraConfigParser
+from .models import (
+    CredentialAnalysisResult,
+    CustomTypeAnalysisResult,
+    HieraDataAnalysisResult,
+    ManifestAnalysisResult,
+    PuppetStructuredAnalysis,
+    TemplateAnalysisResult,
+)
+from .services import (
+    CredentialDetectionService,
+    CustomTypeAnalysisService,
+    HieraDataAnalysisService,
+    ManifestAnalysisService,
+    TemplateAnalysisService,
+)
+
+logger = get_logger(__name__)
+
+
+class PuppetSubagent:
+    """Main Puppet analyzer - implements InfrastructureAnalyzer protocol.
+
+    Workflow phases:
+    1. fetch_dependencies - Parse Puppetfile, catalog external modules
+    2. scan_hiera_config - Parse hiera.yaml, resolve data files on disk
+    3. analyze_structure - Run all services across all files
+    4. write_report - Generate migration plan using ReportWriterAgent
+    5. validate_with_analysis - Validate plan using AnalysisValidationAgent
+    6. cleanup_specification - Clean up using CleanupAgent
+    """
+
+    def __init__(self, model=None) -> None:
+        self.model = model or get_model()
+
+        # Non-LLM components
+        self._hiera_parser: HieraConfigParser | None = None
+        self._dependency_fetcher: PuppetDependencyFetcher | None = None
+
+        # Services (Dependency Injection)
+        self._manifest_service = ManifestAnalysisService(self.model)
+        self._hiera_service = HieraDataAnalysisService(self.model)
+        self._template_service = TemplateAnalysisService(self.model)
+        self._custom_type_service = CustomTypeAnalysisService(self.model)
+        self._credential_service = CredentialDetectionService(self.model)
+
+        # Agents
+        self._report_writer = ReportWriterAgent(model=self.model)
+        self._analysis_validator = AnalysisValidationAgent(model=self.model)
+        self._cleanup = CleanupAgent(model=self.model)
+
+        self._workflow = self._create_workflow()
+
+        logger.debug(self._workflow.get_graph().draw_mermaid())
+
+    def _create_workflow(self):
+        workflow = StateGraph(PuppetState)
+
+        workflow.add_node(
+            "fetch_dependencies", lambda state: self._fetch_dependencies(state)
+        )
+        workflow.add_node(
+            "scan_hiera_config", lambda state: self._scan_hiera_config(state)
+        )
+        workflow.add_node(
+            "analyze_structure", lambda state: self._analyze_structure(state)
+        )
+        workflow.add_node("write_report", self._report_writer)
+        workflow.add_node("validate_with_analysis", self._analysis_validator)
+        workflow.add_node("cleanup_specification", self._cleanup)
+        workflow.add_node("save_hiera_data", lambda state: self._save_hiera_data(state))
+
+        workflow.set_entry_point("fetch_dependencies")
+        workflow.add_edge("fetch_dependencies", "scan_hiera_config")
+        workflow.add_edge("scan_hiera_config", "analyze_structure")
+        workflow.add_edge("analyze_structure", "write_report")
+        workflow.add_conditional_edges(
+            "write_report",
+            self._check_failure_after_agent,
+            {"continue": "validate_with_analysis", "failed": END},
+        )
+        workflow.add_conditional_edges(
+            "validate_with_analysis",
+            self._check_failure_after_agent,
+            {"continue": "cleanup_specification", "failed": END},
+        )
+        workflow.add_edge("cleanup_specification", "save_hiera_data")
+        workflow.add_edge("save_hiera_data", END)
+
+        return workflow.compile()
+
+    def _check_failure_after_agent(
+        self, state: PuppetState
+    ) -> Literal["continue", "failed"]:
+        if state.failed:
+            logger.error(f"Agent failed: {state.failure_reason}")
+            return "failed"
+        return "continue"
+
+    def _fetch_dependencies(self, state: PuppetState) -> PuppetState:
+        slog = logger.bind(phase="fetch_dependencies")
+        slog.info(f"Checking for external dependencies for {state.path}")
+
+        with telemetry_context(state.telemetry, "fetch_dependencies") as metrics:
+            self._dependency_fetcher = PuppetDependencyFetcher(state.path)
+            has_deps, _deps = self._dependency_fetcher.has_dependencies()
+
+            if not has_deps:
+                slog.info("No Puppetfile found or no dependencies")
+                if metrics:
+                    metrics.record_metric("dependencies_found", 0)
+                return state.update(dependency_paths=[], dependency_info=[])
+
+            dep_info = self._dependency_fetcher.get_dependency_info()
+            slog.info(f"Found {len(dep_info)} dependencies in Puppetfile")
+            for dep in dep_info:
+                slog.info(f"  {dep['name']} ({dep['source']}: {dep['version']})")
+
+            if metrics:
+                metrics.record_metric("dependencies_found", len(dep_info))
+
+        return state.update(
+            dependency_paths=[d["name"] for d in dep_info],
+            dependency_info=dep_info,
+        )
+
+    def _scan_hiera_config(self, state: PuppetState) -> PuppetState:
+        slog = logger.bind(phase="scan_hiera_config")
+        slog.info(f"Scanning Hiera configuration for {state.path}")
+
+        with telemetry_context(state.telemetry, "scan_hiera_config") as metrics:
+            self._hiera_parser = HieraConfigParser(state.path)
+            hierarchy = self._hiera_parser.parse()
+
+            slog.info(
+                f"Found {len(hierarchy.levels)} hierarchy levels, "
+                f"{hierarchy.total_data_files} data files"
+            )
+
+            if metrics:
+                metrics.record_metric("hiera_levels", len(hierarchy.levels))
+                metrics.record_metric("hiera_data_files", hierarchy.total_data_files)
+
+        return state.update(hiera_hierarchy=hierarchy)
+
+    def _analyze_structure(self, state: PuppetState) -> PuppetState:
+        slog = logger.bind(phase="analyze_structure")
+        slog.info("Starting structured analysis of Puppet module files")
+
+        with telemetry_context(state.telemetry, "analyze_structure") as metrics:
+            module_path = Path(state.path)
+
+            slog.info("Step 1: Analyzing manifests")
+            manifests = self._analyze_manifests(module_path, slog)
+
+            slog.info("Step 2: Analyzing Hiera data files")
+            hiera_data = self._analyze_hiera_data(state, slog)
+
+            slog.info("Step 3: Analyzing templates")
+            templates = self._analyze_templates(module_path, slog)
+
+            slog.info("Step 4: Analyzing custom types and components")
+            custom_types = self._analyze_custom_types(module_path, slog)
+
+            structured_analysis = PuppetStructuredAnalysis(
+                manifests=manifests,
+                hiera_data=hiera_data,
+                templates=templates,
+                custom_types=custom_types,
+            )
+
+            slog.info(
+                f"Analyzed {len(manifests)} manifests, {len(hiera_data)} Hiera files, "
+                f"{len(templates)} templates, {len(custom_types)} custom components"
+            )
+
+            slog.info("Step 5: Detecting credentials")
+            credentials_analysis = self._detect_credentials(hiera_data, manifests, slog)
+
+            slog.info("Step 6: Building execution tree")
+            tree_builder = PuppetExecutionTreeBuilder(structured_analysis)
+            tree_root = tree_builder.build_tree()
+            execution_tree_summary = self._format_execution_tree(
+                tree_builder, tree_root, structured_analysis
+            )
+
+            variables_summary = self._build_variables_summary(hiera_data)
+
+            if metrics:
+                metrics.record_metric("manifests_analyzed", len(manifests))
+                metrics.record_metric("hiera_files_analyzed", len(hiera_data))
+                metrics.record_metric("templates_analyzed", len(templates))
+                metrics.record_metric("custom_types_analyzed", len(custom_types))
+                metrics.record_metric(
+                    "total_files", structured_analysis.get_total_files_analyzed()
+                )
+
+        return state.update(
+            structured_analysis=structured_analysis,
+            execution_tree_summary=execution_tree_summary,
+            credentials_analysis=credentials_analysis,
+            variables_summary=variables_summary,
+        )
+
+    def _analyze_manifests(
+        self, module_path: Path, slog
+    ) -> list[ManifestAnalysisResult]:
+        results: list[ManifestAnalysisResult] = []
+        for pp_file in sorted(module_path.glob("**/manifests/**/*.pp")):
+            try:
+                slog.debug(f"Analyzing manifest: {pp_file}")
+                analysis = self._manifest_service.analyze(pp_file)
+                results.append(
+                    ManifestAnalysisResult(file_path=str(pp_file), analysis=analysis)
+                )
+            except Exception as e:
+                slog.warning(f"Failed to analyze manifest {pp_file}: {e}")
+        return results
+
+    def _analyze_hiera_data(
+        self, state: PuppetState, slog
+    ) -> list[HieraDataAnalysisResult]:
+        results: list[HieraDataAnalysisResult] = []
+
+        if not state.hiera_hierarchy or not state.hiera_hierarchy.levels:
+            slog.info("No Hiera hierarchy to analyze")
+            return results
+
+        full_hierarchy = "\n".join(
+            f"  {level.name}: {level.path_pattern}"
+            for level in state.hiera_hierarchy.levels
+        )
+
+        for level in state.hiera_hierarchy.levels:
+            for file_path in level.resolved_files:
+                try:
+                    slog.debug(
+                        f"Analyzing Hiera data: {file_path} (level: {level.name})"
+                    )
+                    analysis = self._hiera_service.analyze(
+                        file_path=Path(file_path),
+                        hierarchy_level=level.name,
+                        full_hierarchy=full_hierarchy,
+                    )
+                    raw_content = ""
+                    try:
+                        raw_content = Path(file_path).read_text()
+                    except OSError as e:
+                        slog.warning(
+                            f"Could not read resolved Hiera file {file_path}: {e}"
+                        )
+                    results.append(
+                        HieraDataAnalysisResult(
+                            file_path=file_path,
+                            hierarchy_level=level.name,
+                            raw_content=raw_content,
+                            analysis=analysis,
+                        )
+                    )
+                except Exception as e:
+                    slog.warning(f"Failed to analyze Hiera data {file_path}: {e}")
+
+        return results
+
+    def _analyze_templates(
+        self, module_path: Path, slog
+    ) -> list[TemplateAnalysisResult]:
+        results: list[TemplateAnalysisResult] = []
+        patterns = ["**/templates/**/*.erb", "**/templates/**/*.epp"]
+
+        for pattern in patterns:
+            for tpl_file in sorted(module_path.glob(pattern)):
+                try:
+                    slog.debug(f"Analyzing template: {tpl_file}")
+                    analysis = self._template_service.analyze(tpl_file)
+                    results.append(
+                        TemplateAnalysisResult(
+                            file_path=str(tpl_file), analysis=analysis
+                        )
+                    )
+                except Exception as e:
+                    slog.warning(f"Failed to analyze template {tpl_file}: {e}")
+
+        return results
+
+    def _analyze_custom_types(
+        self, module_path: Path, slog
+    ) -> list[CustomTypeAnalysisResult]:
+        results: list[CustomTypeAnalysisResult] = []
+        patterns = {
+            "lib/puppet/type/*.rb": "type",
+            "lib/puppet/provider/**/*.rb": "provider",
+            "lib/facter/*.rb": "fact",
+            "lib/puppet/functions/*.rb": "function",
+        }
+
+        for pattern, component_type in patterns.items():
+            for rb_file in sorted(module_path.glob(pattern)):
+                try:
+                    slog.debug(f"Analyzing {component_type}: {rb_file}")
+                    analysis = self._custom_type_service.analyze(rb_file)
+                    results.append(
+                        CustomTypeAnalysisResult(
+                            file_path=str(rb_file),
+                            component_type=component_type,
+                            analysis=analysis,
+                        )
+                    )
+                except Exception as e:
+                    slog.warning(f"Failed to analyze {component_type} {rb_file}: {e}")
+
+        return results
+
+    def _detect_credentials(
+        self,
+        hiera_data: list[HieraDataAnalysisResult],
+        manifests: list[ManifestAnalysisResult],
+        slog,
+    ) -> list[CredentialAnalysisResult]:
+        hiera_vars_lines: list[str] = []
+        for h in hiera_data:
+            hiera_vars_lines.append(f"File: {h.file_path} (level: {h.hierarchy_level})")
+            for var in h.analysis.variables:
+                encrypted_marker = " [ENCRYPTED]" if var.is_encrypted else ""
+                hiera_vars_lines.append(
+                    f"  {var.puppet_key} ({var.value_type}){encrypted_marker}"
+                )
+
+        manifest_params_lines: list[str] = []
+        for m in manifests:
+            if m.analysis.class_name and m.analysis.class_parameters:
+                manifest_params_lines.append(f"Class: {m.analysis.class_name}")
+                for param_name, param_info in m.analysis.class_parameters.items():
+                    manifest_params_lines.append(f"  {param_name}: {param_info}")
+
+        hiera_variables = "\n".join(hiera_vars_lines) if hiera_vars_lines else "None"
+        manifest_params = (
+            "\n".join(manifest_params_lines) if manifest_params_lines else "None"
+        )
+
+        try:
+            analysis = self._credential_service.analyze(
+                hiera_variables=hiera_variables,
+                manifest_params=manifest_params,
+            )
+            return [CredentialAnalysisResult(analysis=analysis)]
+        except Exception as e:
+            slog.warning(f"Failed to detect credentials: {e}")
+            return []
+
+    def _format_execution_tree(
+        self,
+        tree_builder: PuppetExecutionTreeBuilder,
+        tree_root,
+        analysis: PuppetStructuredAnalysis,
+    ) -> str:
+        lines = [
+            "=" * 80,
+            "PUPPET CLASS EXECUTION TREE",
+            "=" * 80,
+            "",
+            f"Total files analyzed: {analysis.get_total_files_analyzed()}",
+            "",
+            "Execution flow starting from entry class:",
+            "",
+            tree_builder.format_tree(tree_root),
+            "",
+            "=" * 80,
+            "",
+        ]
+        return "\n".join(lines)
+
+    def _build_variables_summary(
+        self, hiera_data: list[HieraDataAnalysisResult]
+    ) -> str:
+        if not hiera_data:
+            return "No Hiera variables detected."
+
+        lines: list[str] = []
+        lines.append("HIERA VARIABLE MAPPING SUMMARY")
+        lines.append("=" * 60)
+
+        total_vars = sum(len(h.analysis.variables) for h in hiera_data)
+        levels_with_data = {h.hierarchy_level for h in hiera_data}
+        lines.append(
+            f"Total: {total_vars} variables across {len(levels_with_data)} Hiera levels"
+        )
+        lines.append("")
+
+        lines.append(
+            f"{'Puppet Variable':<45} {'Hiera Level':<25} {'Ansible Target':<30} {'Ansible Name'}"
+        )
+        lines.append("-" * 140)
+
+        for h in hiera_data:
+            for var in h.analysis.variables:
+                lines.append(
+                    f"{var.puppet_key:<45} {h.hierarchy_level:<25} "
+                    f"{var.ansible_target:<30} {var.ansible_variable_name}"
+                )
+
+        cross_overrides: set[str] = set()
+        for h in hiera_data:
+            for key in h.analysis.cross_level_overrides:
+                cross_overrides.add(key)
+
+        if cross_overrides:
+            lines.append("")
+            lines.append("CROSS-LEVEL OVERRIDES (same key at multiple levels):")
+            for key in sorted(cross_overrides):
+                levels = [
+                    h.hierarchy_level
+                    for h in hiera_data
+                    if key in h.analysis.cross_level_overrides
+                ]
+                lines.append(f"  {key}: overridden at {', '.join(levels)}")
+
+        lines.append("")
+        lines.append("RAW HIERA DATA FILES (use these EXACT values)")
+        lines.append("=" * 60)
+        for h in hiera_data:
+            if h.raw_content.strip():
+                lines.append(f"\n--- {h.file_path} (level: {h.hierarchy_level}) ---")
+                lines.append(h.raw_content)
+
+        return "\n".join(lines)
+
+    def _save_hiera_data(self, state: PuppetState) -> PuppetState:
+        """Save Hiera analysis data as JSON for deterministic vars generation."""
+        if not state.structured_analysis or not state.structured_analysis.hiera_data:
+            logger.info("No Hiera data to save")
+            return state
+
+        data = []
+        for h in state.structured_analysis.hiera_data:
+            mappings = [
+                {
+                    "puppet_key": v.puppet_key,
+                    "ansible_variable_name": v.ansible_variable_name,
+                    "ansible_target": v.ansible_target,
+                    "value_type": v.value_type,
+                    "is_encrypted": v.is_encrypted,
+                }
+                for v in h.analysis.variables
+            ]
+            data.append(
+                {
+                    "file_path": h.file_path,
+                    "hierarchy_level": h.hierarchy_level,
+                    "raw_content": h.raw_content,
+                    "mappings": mappings,
+                    "merge_behavior": h.analysis.merge_behavior,
+                }
+            )
+
+        module_name = Path(state.path).name
+        json_path = Path(state.path).parent / f"hiera-data-{module_name}.json"
+        json_path.write_text(json.dumps(data, indent=2))
+        logger.info(f"Saved Hiera data ({len(data)} files) to {json_path}")
+        return state
+
+    def invoke(
+        self, path: str, user_message: str, telemetry: Telemetry | None = None
+    ) -> str:
+        logger.info("Using Puppet agent for migration analysis...")
+
+        initial_state = PuppetState(
+            path=path,
+            user_message=user_message,
+            specification="",
+            dependency_paths=[],
+            export_path=None,
+            telemetry=telemetry,
+        )
+
+        result = self._workflow.invoke(initial_state, config=get_runnable_config())
+
+        if result.get("failed"):
+            logger.error(
+                f"Puppet analysis failed: {result.get('failure_reason', 'unknown')}"
+            )
+
+        return result["specification"]

--- a/src/inputs/puppet/analyzer.py
+++ b/src/inputs/puppet/analyzer.py
@@ -477,7 +477,7 @@ class PuppetSubagent:
                 }
             )
 
-        module_name = Path(state.path).name
+        module_name = Path(state.path).resolve().name
         json_path = Path(state.path).parent / f"hiera-data-{module_name}.json"
         json_path.write_text(json.dumps(data, indent=2))
         logger.info(f"Saved Hiera data ({len(data)} files) to {json_path}")

--- a/src/inputs/puppet/cleanup_agent.py
+++ b/src/inputs/puppet/cleanup_agent.py
@@ -1,0 +1,45 @@
+"""Cleanup agent for Puppet analysis workflow.
+
+This module contains the agent that cleans up the migration
+specification after validation notes have been appended.
+"""
+
+from prompts.get_prompt import get_prompt
+from src.base_agent import BaseAgent
+from src.inputs.puppet.state import PuppetState
+from src.types.telemetry import AgentMetrics
+
+
+class CleanupAgent(BaseAgent[PuppetState]):
+    """Agent that cleans up the migration specification.
+
+    Uses direct LLM invocation (no tools) to consolidate and clean
+    the specification after validation notes have been appended.
+    """
+
+    _NAME = "Puppet Analysis Cleanup"
+
+    SYSTEM_PROMPT_NAME = "puppet_analysis_cleanup_system"
+    USER_PROMPT_NAME = "puppet_analysis_cleanup_task"
+
+    def execute(self, state: PuppetState, metrics: AgentMetrics | None) -> PuppetState:
+        self._log.info("Cleaning up migration specification")
+
+        messages = self._build_messages(state.specification)
+        cleaned = self.invoke_llm(messages, metrics)
+
+        if not cleaned:
+            self._log.warning("No valid response from cleanup agent")
+            return state
+
+        return state.update(specification=cleaned)
+
+    def _build_messages(self, specification: str) -> list[dict[str, str]]:
+        system_message = get_prompt(self.SYSTEM_PROMPT_NAME).format()
+        user_prompt = get_prompt(self.USER_PROMPT_NAME).format(
+            messy_specification=specification
+        )
+        return [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_prompt},
+        ]

--- a/src/inputs/puppet/dependency_fetcher.py
+++ b/src/inputs/puppet/dependency_fetcher.py
@@ -1,0 +1,142 @@
+"""Puppet dependency fetcher.
+
+Parses Puppetfile to catalog external module dependencies.
+Does NOT fetch modules (unlike Chef's berks/policyfile) —
+Puppet Forge modules map to known Ansible collections and
+don't need to be downloaded for analysis.
+"""
+
+from pathlib import Path
+
+import tree_sitter_ruby as tsruby
+from tree_sitter import Language, Node, Parser
+
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+_VERSION_SYMBOLS = frozenset({":tag", ":ref", ":branch"})
+
+
+class PuppetDependencyFetcher:
+    """Parse Puppetfile to catalog module dependencies."""
+
+    def __init__(self, module_path: str):
+        self._module_path = Path(module_path)
+        self._puppetfile_path = self._module_path / "Puppetfile"
+        self._dependencies: list[dict] | None = None
+        self._parser = Parser(Language(tsruby.language()))
+
+    def has_dependencies(self) -> tuple[bool, list[str]]:
+        if not self._puppetfile_path.exists():
+            return False, []
+        deps = self.get_dependency_info()
+        return bool(deps), [d["name"] for d in deps]
+
+    def get_dependency_info(self) -> list[dict]:
+        if self._dependencies is not None:
+            return self._dependencies
+
+        if not self._puppetfile_path.exists():
+            logger.info("No Puppetfile found")
+            self._dependencies = []
+            return self._dependencies
+
+        content = self._puppetfile_path.read_text()
+        self._dependencies = self._parse_puppetfile(content)
+        logger.info(f"Found {len(self._dependencies)} dependencies in Puppetfile")
+        return self._dependencies
+
+    def _parse_puppetfile(self, content: str) -> list[dict]:
+        content_bytes = content.encode()
+        tree = self._parser.parse(content_bytes)
+        return self._extract_mod_calls(tree.root_node, content_bytes)
+
+    def _extract_mod_calls(self, root: Node, content_bytes: bytes) -> list[dict]:
+        deps: list[dict] = []
+        git_names: set[str] = set()
+
+        for node in root.children:
+            if node.type != "call":
+                continue
+
+            identifier = node.child_by_field_name("method")
+            if identifier is None:
+                for child in node.children:
+                    if child.type == "identifier":
+                        identifier = child
+                        break
+
+            if identifier is None or self._text(identifier, content_bytes) != "mod":
+                continue
+
+            dep = self._parse_mod_arguments(node, content_bytes)
+            if dep:
+                deps.append(dep)
+                if dep["source"] == "git":
+                    git_names.add(dep["name"])
+
+        return [d for d in deps if d["source"] == "git" or d["name"] not in git_names]
+
+    def _parse_mod_arguments(
+        self, call_node: Node, content_bytes: bytes
+    ) -> dict | None:
+        args = call_node.child_by_field_name("arguments")
+        if args is None:
+            for child in call_node.children:
+                if child.type == "argument_list":
+                    args = child
+                    break
+
+        if args is None:
+            return None
+
+        strings: list[str] = []
+        pairs: dict[str, str] = {}
+
+        for child in args.children:
+            if child.type == "string":
+                strings.append(self._string_content(child, content_bytes))
+            elif child.type == "pair":
+                key_node = child.children[0] if child.children else None
+                val_node = child.children[-1] if len(child.children) >= 3 else None
+                if key_node and val_node:
+                    key = self._text(key_node, content_bytes)
+                    val = self._string_content(val_node, content_bytes)
+                    pairs[key] = val
+
+        if not strings:
+            return None
+
+        name = strings[0]
+
+        if ":git" in pairs:
+            version = "HEAD"
+            for sym in _VERSION_SYMBOLS:
+                if sym in pairs:
+                    version = pairs[sym]
+                    break
+            return {
+                "name": name,
+                "source": "git",
+                "url": pairs[":git"],
+                "version": version,
+            }
+
+        return {
+            "name": name,
+            "source": "forge",
+            "url": "",
+            "version": strings[1] if len(strings) > 1 else "",
+        }
+
+    @staticmethod
+    def _text(node: Node, content_bytes: bytes) -> str:
+        return content_bytes[node.start_byte : node.end_byte].decode()
+
+    @staticmethod
+    def _string_content(node: Node, content_bytes: bytes) -> str:
+        for child in node.children:
+            if child.type == "string_content":
+                return content_bytes[child.start_byte : child.end_byte].decode()
+        return content_bytes[node.start_byte : node.end_byte].decode().strip("'\"")

--- a/src/inputs/puppet/execution_tree_builder.py
+++ b/src/inputs/puppet/execution_tree_builder.py
@@ -1,0 +1,226 @@
+"""Build hierarchical execution tree from Puppet structured analysis.
+
+This module builds a visual tree showing the complete class execution flow
+with iterations expanded and resource details inline.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from src.utils.logging import get_logger
+
+from .models import (
+    ManifestAnalysisResult,
+    ManifestExecutionAnalysis,
+    PuppetStructuredAnalysis,
+)
+
+logger = get_logger(__name__)
+
+
+def _format_class(n: "ExecutionTreeNode") -> str:
+    label = f"[class] {n.name}"
+    if n.file_path:
+        label += f"  # {n.file_path}"
+    if n.details:
+        label += f" ({n.details})"
+    return label
+
+
+_LABEL_FORMATTERS: dict[str, Callable[["ExecutionTreeNode"], str]] = {
+    "class": _format_class,
+    "resource": lambda n: f"[resource] {n.name}",
+    "iteration": lambda n: f"LOOP {n.name}",
+    "conditional": lambda n: f"[conditional] {n.name}",
+    "exported": lambda n: f"[exported @@] {n.name}",
+    "virtual": lambda n: f"[virtual @] {n.name}",
+    "relationship": lambda n: f"[ordering] {n.name}",
+}
+
+
+@dataclass
+class ExecutionTreeNode:
+    """Node in the Puppet execution tree."""
+
+    node_type: (
+        str  # "class", "resource", "iteration", "conditional", "exported", "virtual"
+    )
+    name: str
+    file_path: str | None = None
+    details: str | None = None
+    children: list["ExecutionTreeNode"] = field(default_factory=list)
+
+    def format_label(self) -> str:
+        formatter = _LABEL_FORMATTERS.get(self.node_type)
+        if formatter:
+            return formatter(self)
+        return f"{self.name} ({self.details})" if self.details else self.name
+
+
+class PuppetExecutionTreeBuilder:
+    """Builds execution tree from Puppet manifest analysis results."""
+
+    def __init__(self, structured_analysis: PuppetStructuredAnalysis):
+        self.analysis = structured_analysis
+        self._visited: set[str] = set()
+
+        self._manifest_map: dict[str, ManifestAnalysisResult] = {}
+        for m in structured_analysis.manifests:
+            if m.analysis.class_name:
+                self._manifest_map[m.analysis.class_name] = m
+
+    def build_tree(self, entry_class: str | None = None) -> ExecutionTreeNode:
+        if entry_class is None:
+            entry_class = self._find_entry_class()
+
+        if entry_class is None:
+            return ExecutionTreeNode(
+                node_type="class",
+                name="(no entry class found)",
+                details="No init.pp or main class detected",
+            )
+
+        logger.info(f"Building execution tree from {entry_class}")
+        return self._expand_class(entry_class)
+
+    def format_tree(
+        self, node: ExecutionTreeNode, prefix: str = "", is_last: bool = True
+    ) -> str:
+        lines: list[str] = []
+        connector = "└── " if is_last else "├── "
+        if not prefix:
+            connector = ""
+
+        lines.append(f"{prefix}{connector}{node.format_label()}")
+
+        for idx, child in enumerate(node.children):
+            is_last_child = idx == len(node.children) - 1
+            extension = "    " if is_last else "│   "
+            child_prefix = prefix + extension
+            lines.append(self.format_tree(child, child_prefix, is_last_child))
+
+        return "\n".join(lines)
+
+    def _find_entry_class(self) -> str | None:
+        for m in self.analysis.manifests:
+            if m.analysis.class_name and "init.pp" in m.file_path:
+                return m.analysis.class_name
+        if self.analysis.manifests and self.analysis.manifests[0].analysis.class_name:
+            return self.analysis.manifests[0].analysis.class_name
+        return None
+
+    def _expand_class(self, class_name: str) -> ExecutionTreeNode:
+        if class_name in self._visited:
+            return ExecutionTreeNode(
+                node_type="class",
+                name=class_name,
+                details="[CIRCULAR - already visited]",
+            )
+
+        self._visited.add(class_name)
+
+        manifest = self._manifest_map.get(class_name)
+        if manifest is None:
+            return ExecutionTreeNode(
+                node_type="class",
+                name=class_name,
+                details="class not analyzed",
+            )
+
+        analysis = manifest.analysis
+        node = ExecutionTreeNode(
+            node_type="class",
+            name=class_name,
+            file_path=manifest.file_path,
+        )
+
+        if analysis.class_inherits:
+            node.children.append(
+                ExecutionTreeNode(
+                    node_type="class",
+                    name=f"inherits {analysis.class_inherits.parent_class}",
+                    details=f"overrides: {', '.join(analysis.class_inherits.overridden_params)}"
+                    if analysis.class_inherits.overridden_params
+                    else None,
+                )
+            )
+
+        node.children.extend(self._build_resource_nodes(analysis))
+
+        for include in analysis.class_includes:
+            child = self._expand_class(include.class_name)
+            node.children.append(child)
+
+        if analysis.relationship_chains:
+            for chain in analysis.relationship_chains:
+                node.children.append(
+                    ExecutionTreeNode(node_type="relationship", name=chain)
+                )
+
+        return node
+
+    def _build_resource_nodes(
+        self, analysis: ManifestExecutionAnalysis
+    ) -> list[ExecutionTreeNode]:
+        nodes: list[ExecutionTreeNode] = []
+
+        for res in analysis.resources:
+            details_parts = []
+            for key in ["ensure", "action", "command", "source"]:
+                if key in res.attributes:
+                    details_parts.append(f"{key}: {res.attributes[key]}")
+            detail = ", ".join(details_parts) if details_parts else None
+
+            nodes.append(
+                ExecutionTreeNode(
+                    node_type="resource",
+                    name=f"{res.resource_type}[{res.title}]",
+                    details=detail,
+                )
+            )
+
+        for cond in analysis.conditionals:
+            cond_node = ExecutionTreeNode(
+                node_type="conditional",
+                name=f"{cond.condition_type} {cond.condition}",
+            )
+            for res in cond.resources:
+                cond_node.children.append(
+                    ExecutionTreeNode(
+                        node_type="resource",
+                        name=f"{res.resource_type}[{res.title}]",
+                    )
+                )
+            nodes.append(cond_node)
+
+        for iteration in analysis.iterations:
+            iter_node = ExecutionTreeNode(
+                node_type="iteration",
+                name=f"{iteration.collection_variable}.{iteration.iterator_type} |{iteration.item_variable}|",
+            )
+            for res in iteration.resources:
+                iter_node.children.append(
+                    ExecutionTreeNode(
+                        node_type="resource",
+                        name=f"{res.resource_type}[{res.title}]",
+                    )
+                )
+            nodes.append(iter_node)
+
+        for exp in analysis.exported_resources:
+            nodes.append(
+                ExecutionTreeNode(
+                    node_type="exported",
+                    name=f"{exp.resource_type}[{exp.title}]",
+                )
+            )
+
+        for virt in analysis.virtual_resources:
+            nodes.append(
+                ExecutionTreeNode(
+                    node_type="virtual",
+                    name=f"{virt.resource_type}[{virt.title}]",
+                )
+            )
+
+        return nodes

--- a/src/inputs/puppet/hiera_parser.py
+++ b/src/inputs/puppet/hiera_parser.py
@@ -1,0 +1,176 @@
+"""Deterministic Hiera configuration parser.
+
+Parses hiera.yaml to discover the hierarchy structure and resolve
+which data files actually exist on disk. No LLM involved — this is
+purely structural (YAML parsing + file globbing).
+
+Semantic analysis of file contents is handled by HieraDataAnalysisService.
+"""
+
+import re
+from pathlib import Path
+
+import yaml
+
+from src.utils.logging import get_logger
+
+from .models import HieraHierarchy, HieraLevel
+
+logger = get_logger(__name__)
+
+HIERA_INTERPOLATION_PATTERN = re.compile(r"%\{[^}]+\}")
+
+
+class HieraConfigParser:
+    """Parse hiera.yaml and resolve data files on disk."""
+
+    def __init__(self, module_path: str):
+        self._module_path = Path(module_path)
+        self._hiera_config: dict | None = None
+        self._hierarchy: HieraHierarchy | None = None
+
+    def parse(self) -> HieraHierarchy:
+        if self._hierarchy is not None:
+            return self._hierarchy
+
+        config_path = self._find_hiera_config()
+        if config_path is None:
+            logger.info("No hiera.yaml found, returning empty hierarchy")
+            self._hierarchy = HieraHierarchy()
+            return self._hierarchy
+
+        logger.info(f"Parsing Hiera config: {config_path}")
+        with Path(config_path).open() as f:
+            self._hiera_config = yaml.safe_load(f)
+
+        if self._hiera_config is None:
+            self._hierarchy = HieraHierarchy()
+            return self._hierarchy
+
+        version = self._detect_version()
+        if version >= 5:
+            self._hierarchy = self._parse_v5(config_path)
+        else:
+            self._hierarchy = self._parse_v3(config_path)
+
+        logger.info(
+            f"Parsed {len(self._hierarchy.levels)} hierarchy levels, "
+            f"{self._hierarchy.total_data_files} data files found"
+        )
+        return self._hierarchy
+
+    def get_data_files_by_level(self) -> dict[str, list[str]]:
+        hierarchy = self.parse()
+        return {
+            level.name: level.resolved_files
+            for level in hierarchy.levels
+            if level.resolved_files
+        }
+
+    def _find_hiera_config(self) -> Path | None:
+        candidates = [
+            self._module_path / "hiera.yaml",
+            self._module_path / "hiera.yml",
+        ]
+        current = self._module_path.parent
+        for _ in range(3):
+            candidates.append(current / "hiera.yaml")
+            candidates.append(current / "hiera.yml")
+            current = current.parent
+
+        for candidate in candidates:
+            if candidate.exists():
+                return candidate
+        return None
+
+    def _detect_version(self) -> int:
+        if self._hiera_config is None:
+            return 5
+        if "version" in self._hiera_config:
+            return int(self._hiera_config["version"])
+        if ":hierarchy:" in str(self._hiera_config) or isinstance(
+            self._hiera_config.get(":hierarchy:"), list
+        ):
+            return 3
+        return 5
+
+    def _parse_v5(self, config_path: Path) -> HieraHierarchy:
+        assert self._hiera_config is not None
+        defaults = self._hiera_config.get("defaults", {})
+        default_datadir = defaults.get("datadir", "data")
+        hierarchy_entries = self._hiera_config.get("hierarchy", [])
+
+        levels: list[HieraLevel] = []
+        total_files = 0
+
+        for entry in hierarchy_entries:
+            name = entry.get("name", "unnamed")
+            datadir = entry.get("datadir", default_datadir)
+            paths = entry.get("paths", [])
+            if not paths and "path" in entry:
+                paths = [entry["path"]]
+
+            for path_pattern in paths:
+                base_path = config_path.parent / datadir
+                resolved = self._resolve_data_files(path_pattern, base_path)
+                total_files += len(resolved)
+                levels.append(
+                    HieraLevel(
+                        name=name,
+                        path_pattern=path_pattern,
+                        datadir=datadir,
+                        resolved_files=resolved,
+                    )
+                )
+
+        return HieraHierarchy(
+            version=5,
+            defaults=defaults,
+            levels=levels,
+            total_data_files=total_files,
+        )
+
+    def _parse_v3(self, config_path: Path) -> HieraHierarchy:
+        assert self._hiera_config is not None
+        hierarchy_list = self._hiera_config.get(":hierarchy:", [])
+        if isinstance(hierarchy_list, str):
+            hierarchy_list = [hierarchy_list]
+
+        datadir = self._hiera_config.get(":yaml:", {}).get(":datadir:", "data")
+        if isinstance(datadir, str) and datadir.startswith("/"):
+            datadir = "data"
+
+        levels: list[HieraLevel] = []
+        total_files = 0
+
+        for idx, entry in enumerate(hierarchy_list):
+            path_pattern = f"{entry}.yaml"
+            base_path = config_path.parent / datadir
+            resolved = self._resolve_data_files(path_pattern, base_path)
+            total_files += len(resolved)
+            levels.append(
+                HieraLevel(
+                    name=f"Level {idx + 1}: {entry}",
+                    path_pattern=path_pattern,
+                    datadir=datadir,
+                    resolved_files=resolved,
+                )
+            )
+
+        return HieraHierarchy(
+            version=3,
+            defaults={},
+            levels=levels,
+            total_data_files=total_files,
+        )
+
+    def _resolve_data_files(self, path_pattern: str, base_path: Path) -> list[str]:
+        glob_pattern = HIERA_INTERPOLATION_PATTERN.sub("*", path_pattern)
+        resolved: list[str] = []
+        try:
+            for match in base_path.glob(glob_pattern):
+                if match.is_file():
+                    resolved.append(str(match))
+        except Exception as e:
+            logger.warning(f"Failed to glob {glob_pattern} in {base_path}: {e}")
+        return sorted(resolved)

--- a/src/inputs/puppet/models.py
+++ b/src/inputs/puppet/models.py
@@ -1,0 +1,246 @@
+"""Puppet analysis domain models.
+
+This module defines Pydantic models for representing Puppet module analysis.
+These are pure data structures used for LLM structured outputs.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+# ============================================================================
+# Manifest Analysis Models
+# ============================================================================
+
+
+class PuppetResourceDeclaration(BaseModel):
+    """A single Puppet resource declaration."""
+
+    resource_type: str
+    title: str
+    attributes: dict[str, Any] = Field(default_factory=dict)
+    note: str | None = None
+
+
+class ClassInclude(BaseModel):
+    """An include/contain/require of another class."""
+
+    class_name: str
+    relationship: str  # "include", "contain", "require"
+
+
+class ClassInheritance(BaseModel):
+    """Class inheritance via the 'inherits' keyword."""
+
+    parent_class: str
+    child_class: str
+    overridden_params: list[str] = Field(default_factory=list)
+
+
+class ConditionalBlock(BaseModel):
+    """A conditional (if/unless/case/selector) in Puppet code."""
+
+    condition: str
+    condition_type: str  # "if", "unless", "case", "selector"
+    resources: list[PuppetResourceDeclaration] = Field(default_factory=list)
+    note: str | None = None
+
+
+class IterationBlock(BaseModel):
+    """An iteration construct (.each, .map, .filter, .reduce)."""
+
+    iterator_type: str  # "each", "map", "filter", "reduce"
+    collection_variable: str
+    item_variable: str
+    resources: list[PuppetResourceDeclaration] = Field(default_factory=list)
+    note: str | None = None
+
+
+class ManifestExecutionAnalysis(BaseModel):
+    """LLM structured output for a single .pp manifest."""
+
+    class_name: str | None = None
+    class_parameters: dict[str, Any] = Field(default_factory=dict)
+    class_inherits: ClassInheritance | None = None
+    resources: list[PuppetResourceDeclaration] = Field(default_factory=list)
+    class_includes: list[ClassInclude] = Field(default_factory=list)
+    conditionals: list[ConditionalBlock] = Field(default_factory=list)
+    iterations: list[IterationBlock] = Field(default_factory=list)
+    exported_resources: list[PuppetResourceDeclaration] = Field(default_factory=list)
+    virtual_resources: list[PuppetResourceDeclaration] = Field(default_factory=list)
+    collectors: list[str] = Field(default_factory=list)
+    puppetdb_queries: list[str] = Field(default_factory=list)
+    relationship_chains: list[str] = Field(default_factory=list)
+
+
+# ============================================================================
+# Hiera Data Analysis Models
+# ============================================================================
+
+
+class HieraVariableMapping(BaseModel):
+    """Mapping of a single Hiera variable to its Ansible target."""
+
+    puppet_key: str
+    value_type: str  # "string", "hash", "array", "integer", "boolean"
+    is_encrypted: bool = False
+    ansible_target: str = ""
+    ansible_variable_name: str = ""
+
+
+class HieraDataAnalysis(BaseModel):
+    """LLM structured output for a single Hiera data file."""
+
+    variables: list[HieraVariableMapping] = Field(default_factory=list)
+    merge_behavior: dict[str, Any] = Field(default_factory=dict)
+    lookup_options: dict[str, Any] = Field(default_factory=dict)
+    cross_level_overrides: list[str] = Field(default_factory=list)
+    notes: str = ""
+
+
+# ============================================================================
+# Template Analysis Models
+# ============================================================================
+
+
+class PuppetTemplateAnalysis(BaseModel):
+    """LLM structured output for an ERB (.erb) or EPP (.epp) template."""
+
+    template_type: str  # "erb" or "epp"
+    variables_used: list[str] = Field(default_factory=list)
+    hiera_lookups: list[str] = Field(default_factory=list)
+    loops: list[str] = Field(default_factory=list)
+    ruby_logic: list[str] = Field(default_factory=list)
+    jinja2_equivalent_notes: str = ""
+
+
+# ============================================================================
+# Custom Type/Provider/Fact Analysis Models
+# ============================================================================
+
+
+class CustomTypeAnalysis(BaseModel):
+    """LLM structured output for custom types, providers, facts, and functions."""
+
+    component_type: str  # "type", "provider", "fact", "function"
+    name: str
+    parameters: list[dict[str, Any]] = Field(default_factory=list)
+    ansible_equivalent: str = ""
+    requires_custom_module: bool = False
+    note: str | None = None
+
+
+# ============================================================================
+# Credential Analysis Models
+# ============================================================================
+
+
+class CredentialEntry(BaseModel):
+    """A single detected credential or secret."""
+
+    purpose: str
+    variable_names: list[str] = Field(default_factory=list)
+    source_files: list[str] = Field(default_factory=list)
+    storage_method: str  # "eyaml", "hiera plaintext", "exec", "file source"
+    usage_context: str
+    ansible_recommendation: str  # "ansible-vault", "CyberArk lookup", "env var"
+
+
+class CredentialAnalysis(BaseModel):
+    """LLM structured output for credential detection."""
+
+    credentials: list[CredentialEntry] = Field(default_factory=list)
+    provider_info: str = ""
+    total_detected: int = 0
+
+
+# ============================================================================
+# Hiera Hierarchy Models (from deterministic parser)
+# ============================================================================
+
+
+class HieraLevel(BaseModel):
+    """A single level in the Hiera hierarchy."""
+
+    name: str
+    path_pattern: str
+    datadir: str = "data"
+    resolved_files: list[str] = Field(default_factory=list)
+
+
+class HieraHierarchy(BaseModel):
+    """Parsed hiera.yaml structure."""
+
+    version: int = 5
+    defaults: dict[str, Any] = Field(default_factory=dict)
+    levels: list[HieraLevel] = Field(default_factory=list)
+    total_data_files: int = 0
+
+
+# ============================================================================
+# Analysis Result Models (for workflow)
+# ============================================================================
+
+
+class ManifestAnalysisResult(BaseModel):
+    """Manifest file analysis result."""
+
+    file_path: str
+    file_type: str = "manifest"
+    analysis: ManifestExecutionAnalysis
+
+
+class HieraDataAnalysisResult(BaseModel):
+    """Hiera data file analysis result."""
+
+    file_path: str
+    hierarchy_level: str
+    raw_content: str = ""
+    analysis: HieraDataAnalysis
+
+
+class TemplateAnalysisResult(BaseModel):
+    """Template file analysis result."""
+
+    file_path: str
+    analysis: PuppetTemplateAnalysis
+
+
+class CustomTypeAnalysisResult(BaseModel):
+    """Custom type/provider/fact/function analysis result."""
+
+    file_path: str
+    component_type: str
+    analysis: CustomTypeAnalysis
+
+
+class CredentialAnalysisResult(BaseModel):
+    """Credential detection result."""
+
+    analysis: CredentialAnalysis
+
+
+class PuppetStructuredAnalysis(BaseModel):
+    """Aggregate of all analysis results from a Puppet module."""
+
+    manifests: list[ManifestAnalysisResult] = Field(default_factory=list)
+    hiera_data: list[HieraDataAnalysisResult] = Field(default_factory=list)
+    templates: list[TemplateAnalysisResult] = Field(default_factory=list)
+    custom_types: list[CustomTypeAnalysisResult] = Field(default_factory=list)
+
+    def get_total_files_analyzed(self) -> int:
+        return (
+            len(self.manifests)
+            + len(self.hiera_data)
+            + len(self.templates)
+            + len(self.custom_types)
+        )
+
+    @property
+    def analyzed_file_paths(self) -> list[str]:
+        files: list[str] = []
+        files.extend(m.file_path for m in self.manifests)
+        files.extend(h.file_path for h in self.hiera_data)
+        files.extend(t.file_path for t in self.templates)
+        files.extend(c.file_path for c in self.custom_types)
+        return sorted(set(files))

--- a/src/inputs/puppet/report_writer_agent.py
+++ b/src/inputs/puppet/report_writer_agent.py
@@ -1,0 +1,141 @@
+"""Report writer agent for Puppet analysis workflow.
+
+This module contains the ReAct agent that generates migration
+specifications using structured analysis and file exploration tools.
+"""
+
+from collections.abc import Callable
+from typing import ClassVar
+
+from langchain_community.tools.file_management.file_search import FileSearchTool
+from langchain_community.tools.file_management.list_dir import ListDirectoryTool
+from langchain_community.tools.file_management.read import ReadFileTool
+from langchain_core.tools import BaseTool
+
+from prompts.get_prompt import get_prompt
+from src.base_agent import BaseAgent
+from src.inputs.puppet.state import PuppetState
+from src.inputs.tree_analysis import TreeSitterAnalyzer
+from src.types.telemetry import AgentMetrics
+
+
+class ReportWriterAgent(BaseAgent[PuppetState]):
+    """Agent that generates migration specification using structured analysis.
+
+    Uses file management tools to explore the module and generates
+    a detailed migration specification based on the structured analysis.
+    """
+
+    _NAME = "Puppet Report Writer"
+
+    BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
+        lambda: FileSearchTool(),
+        lambda: ListDirectoryTool(),
+        lambda: ReadFileTool(),
+    ]
+
+    SYSTEM_PROMPT_NAME = "puppet_analysis_system"
+    USER_PROMPT_NAME = "puppet_analysis_task"
+
+    def execute(self, state: PuppetState, metrics: AgentMetrics | None) -> PuppetState:
+        self._log.info("Generating migration specification")
+
+        data_list = self._build_file_listing(state)
+        tree_sitter_report = self._generate_tree_sitter_report(state.path)
+        variables_summary = state.variables_summary or "No Hiera variables detected."
+        credentials_summary = self._build_credentials_summary(state)
+        dependencies_summary = self._build_dependencies_summary(state)
+
+        messages = self._build_messages(
+            state,
+            data_list,
+            tree_sitter_report,
+            variables_summary,
+            credentials_summary,
+            dependencies_summary,
+        )
+
+        result = self.invoke_react(state, messages, metrics)
+
+        response_messages = result.get("messages", [])
+        if len(response_messages) < 2:
+            return state.mark_failed("Invalid response from Puppet agent")
+
+        self._log.info("Migration specification generated")
+        return state.update(specification=response_messages[-1].content)
+
+    def _build_file_listing(self, state: PuppetState) -> str:
+        if not state.structured_analysis:
+            return ""
+        return "\n".join(state.structured_analysis.analyzed_file_paths)
+
+    def _generate_tree_sitter_report(self, path: str) -> str:
+        analyzer = TreeSitterAnalyzer()
+        try:
+            return analyzer.report_directory(path)
+        except Exception as e:
+            self._log.warning(f"Failed to generate tree-sitter report: {e}")
+            return "Tree-sitter analysis not available"
+
+    def _build_credentials_summary(self, state: PuppetState) -> str:
+        if not state.credentials_analysis:
+            return "No credentials detected."
+
+        lines: list[str] = []
+        for cred_result in state.credentials_analysis:
+            analysis = cred_result.analysis
+            if analysis.total_detected == 0:
+                continue
+            lines.append(f"Total detected: {analysis.total_detected}")
+            if analysis.provider_info:
+                lines.append(f"Provider: {analysis.provider_info}")
+            for cred in analysis.credentials:
+                lines.append(f"\n### {cred.purpose}")
+                lines.append(f"  Variables: {', '.join(cred.variable_names)}")
+                lines.append(f"  Source files: {', '.join(cred.source_files)}")
+                lines.append(f"  Storage: {cred.storage_method}")
+                lines.append(f"  Usage: {cred.usage_context}")
+                lines.append(f"  Ansible recommendation: {cred.ansible_recommendation}")
+
+        return "\n".join(lines) if lines else "No credentials detected."
+
+    def _build_dependencies_summary(self, state: PuppetState) -> str:
+        if not state.dependency_info:
+            return "No external dependencies (no Puppetfile found)."
+
+        lines: list[str] = []
+        for dep in state.dependency_info:
+            source = dep.get("source", "unknown")
+            version = dep.get("version", "")
+            url = dep.get("url", "")
+            if source == "git":
+                lines.append(f"  {dep['name']} (git: {url}, ref: {version})")
+            else:
+                lines.append(f"  {dep['name']} (forge, version: {version})")
+
+        return f"Found {len(state.dependency_info)} dependencies:\n" + "\n".join(lines)
+
+    def _build_messages(
+        self,
+        state: PuppetState,
+        data_list: str,
+        tree_sitter_report: str,
+        variables_summary: str,
+        credentials_summary: str,
+        dependencies_summary: str,
+    ) -> list[dict[str, str]]:
+        system_message = get_prompt(self.SYSTEM_PROMPT_NAME).format()
+        user_prompt = get_prompt(self.USER_PROMPT_NAME).format(
+            path=state.path,
+            user_message=state.user_message,
+            directory_listing=data_list,
+            tree_sitter_report=tree_sitter_report,
+            execution_tree=state.execution_tree_summary,
+            variables_summary=variables_summary,
+            credentials_summary=credentials_summary,
+            dependencies_summary=dependencies_summary,
+        )
+        return [
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": user_prompt},
+        ]

--- a/src/inputs/puppet/services.py
+++ b/src/inputs/puppet/services.py
@@ -1,0 +1,269 @@
+"""Puppet analysis services.
+
+This module provides services for analyzing Puppet files using LLM.
+Each service has a single responsibility (SRP).
+"""
+
+from pathlib import Path
+
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from prompts.get_prompt import get_prompt
+from src.model import get_runnable_config
+from src.utils.logging import get_logger
+
+from .models import (
+    CredentialAnalysis,
+    CustomTypeAnalysis,
+    HieraDataAnalysis,
+    ManifestExecutionAnalysis,
+    PuppetTemplateAnalysis,
+)
+
+logger = get_logger(__name__)
+
+MAX_STRUCTURED_RETRIES = 3
+
+
+class ManifestAnalysisService:
+    """Analyze Puppet manifest (.pp) files using LLM."""
+
+    def __init__(self, model):
+        self._model = model
+
+    def analyze(self, file_path: Path) -> ManifestExecutionAnalysis:
+        if not file_path.exists():
+            logger.warning(f"File not found: {file_path}")
+            return ManifestExecutionAnalysis()
+
+        file_content = file_path.read_text()
+        system_prompt = get_prompt("puppet_manifest_analysis_system").format()
+        task_prompt = get_prompt("puppet_manifest_analysis_task").format(
+            file_path=str(file_path), file_content=file_content
+        )
+
+        try:
+            structured_model = self._model.with_structured_output(
+                ManifestExecutionAnalysis
+            )
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=task_prompt),
+            ]
+            result = None
+            for attempt in range(MAX_STRUCTURED_RETRIES):
+                result = structured_model.invoke(messages, config=get_runnable_config())
+                if result is not None:
+                    break
+                logger.warning(
+                    f"Structured output returned None for {file_path.name}, retrying ({attempt + 1}/{MAX_STRUCTURED_RETRIES})"
+                )
+            if result is None:
+                logger.error(
+                    f"Structured output returned None after {MAX_STRUCTURED_RETRIES} retries for {file_path.name}"
+                )
+                return ManifestExecutionAnalysis()
+            logger.info(
+                f"Extracted {len(result.resources)} resources, "
+                f"{len(result.class_includes)} includes from {file_path.name}"
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Failed to analyze manifest {file_path}: {e}", exc_info=True)
+            return ManifestExecutionAnalysis()
+
+
+class HieraDataAnalysisService:
+    """Analyze Hiera data files using LLM.
+
+    Non-deterministic: reasons about variable mapping to Ansible targets,
+    merge behavior, and cross-level overrides.
+    """
+
+    def __init__(self, model):
+        self._model = model
+
+    def analyze(
+        self,
+        file_path: Path,
+        hierarchy_level: str = "",
+        full_hierarchy: str = "",
+    ) -> HieraDataAnalysis:
+        if not file_path.exists():
+            logger.warning(f"Hiera data file not found: {file_path}")
+            return HieraDataAnalysis()
+
+        file_content = file_path.read_text()
+        system_prompt = get_prompt("puppet_hiera_analysis_system").format()
+        task_prompt = get_prompt("puppet_hiera_analysis_task").format(
+            file_path=str(file_path),
+            file_content=file_content,
+            hierarchy_level=hierarchy_level,
+            full_hierarchy=full_hierarchy,
+        )
+
+        try:
+            structured_model = self._model.with_structured_output(HieraDataAnalysis)
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=task_prompt),
+            ]
+            result = None
+            for attempt in range(MAX_STRUCTURED_RETRIES):
+                result = structured_model.invoke(messages, config=get_runnable_config())
+                if result is not None:
+                    break
+                logger.warning(
+                    f"Structured output returned None for {file_path.name}, retrying ({attempt + 1}/{MAX_STRUCTURED_RETRIES})"
+                )
+            if result is None:
+                logger.error(
+                    f"Structured output returned None after {MAX_STRUCTURED_RETRIES} retries for {file_path.name}"
+                )
+                return HieraDataAnalysis()
+            logger.info(
+                f"Extracted {len(result.variables)} variables from {file_path.name} "
+                f"(level: {hierarchy_level})"
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                f"Failed to analyze Hiera data {file_path}: {e}", exc_info=True
+            )
+            return HieraDataAnalysis()
+
+
+class TemplateAnalysisService:
+    """Analyze ERB (.erb) and EPP (.epp) template files using LLM."""
+
+    def __init__(self, model):
+        self._model = model
+
+    def analyze(self, file_path: Path) -> PuppetTemplateAnalysis:
+        if not file_path.exists():
+            logger.warning(f"Template not found: {file_path}")
+            return PuppetTemplateAnalysis(template_type="unknown")
+
+        file_content = file_path.read_text()
+        template_type = "epp" if file_path.suffix == ".epp" else "erb"
+        system_prompt = get_prompt("puppet_template_analysis_system").format()
+        task_prompt = get_prompt("puppet_template_analysis_task").format(
+            file_path=str(file_path), file_content=file_content
+        )
+
+        try:
+            structured_model = self._model.with_structured_output(
+                PuppetTemplateAnalysis
+            )
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=task_prompt),
+            ]
+            result = None
+            for attempt in range(MAX_STRUCTURED_RETRIES):
+                result = structured_model.invoke(messages, config=get_runnable_config())
+                if result is not None:
+                    break
+                logger.warning(
+                    f"Structured output returned None for {file_path.name}, retrying ({attempt + 1}/{MAX_STRUCTURED_RETRIES})"
+                )
+            if result is None:
+                logger.error(
+                    f"Structured output returned None after {MAX_STRUCTURED_RETRIES} retries for {file_path.name}"
+                )
+                return PuppetTemplateAnalysis(template_type=template_type)
+            logger.info(
+                f"Analyzed {template_type} template {file_path.name}: "
+                f"{len(result.variables_used)} variables, "
+                f"{len(result.ruby_logic)} complex blocks"
+            )
+            return result
+        except Exception as e:
+            logger.error(f"Failed to analyze template {file_path}: {e}", exc_info=True)
+            return PuppetTemplateAnalysis(template_type=template_type)
+
+
+class CustomTypeAnalysisService:
+    """Analyze custom types, providers, facts, and functions using LLM."""
+
+    def __init__(self, model):
+        self._model = model
+
+    def analyze(self, file_path: Path) -> CustomTypeAnalysis:
+        if not file_path.exists():
+            logger.warning(f"Custom type file not found: {file_path}")
+            return CustomTypeAnalysis(component_type="unknown", name="unknown")
+
+        file_content = file_path.read_text()
+        system_prompt = get_prompt("puppet_custom_type_analysis_system").format()
+        task_prompt = get_prompt("puppet_custom_type_analysis_task").format(
+            file_path=str(file_path), file_content=file_content
+        )
+
+        try:
+            structured_model = self._model.with_structured_output(CustomTypeAnalysis)
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=task_prompt),
+            ]
+            result = None
+            for attempt in range(MAX_STRUCTURED_RETRIES):
+                result = structured_model.invoke(messages, config=get_runnable_config())
+                if result is not None:
+                    break
+                logger.warning(
+                    f"Structured output returned None for {file_path.name}, retrying ({attempt + 1}/{MAX_STRUCTURED_RETRIES})"
+                )
+            if result is None:
+                logger.error(
+                    f"Structured output returned None after {MAX_STRUCTURED_RETRIES} retries for {file_path.name}"
+                )
+                return CustomTypeAnalysis(component_type="unknown", name=file_path.stem)
+            logger.info(
+                f"Analyzed {result.component_type} '{result.name}' from {file_path.name}"
+            )
+            return result
+        except Exception as e:
+            logger.error(
+                f"Failed to analyze custom type {file_path}: {e}", exc_info=True
+            )
+            return CustomTypeAnalysis(component_type="unknown", name=file_path.stem)
+
+
+class CredentialDetectionService:
+    """Detect credentials and secrets across Hiera data and manifests."""
+
+    def __init__(self, model):
+        self._model = model
+
+    def analyze(self, hiera_variables: str, manifest_params: str) -> CredentialAnalysis:
+        system_prompt = get_prompt("puppet_credential_detection_system").format()
+        task_prompt = get_prompt("puppet_credential_detection_task").format(
+            hiera_variables=hiera_variables,
+            manifest_params=manifest_params,
+        )
+
+        try:
+            structured_model = self._model.with_structured_output(CredentialAnalysis)
+            messages = [
+                SystemMessage(content=system_prompt),
+                HumanMessage(content=task_prompt),
+            ]
+            result = None
+            for attempt in range(MAX_STRUCTURED_RETRIES):
+                result = structured_model.invoke(messages, config=get_runnable_config())
+                if result is not None:
+                    break
+                logger.warning(
+                    f"Structured output returned None for credentials, retrying ({attempt + 1}/{MAX_STRUCTURED_RETRIES})"
+                )
+            if result is None:
+                logger.error(
+                    f"Structured output returned None after {MAX_STRUCTURED_RETRIES} retries for credentials"
+                )
+                return CredentialAnalysis()
+            logger.info(f"Detected {result.total_detected} credentials")
+            return result
+        except Exception as e:
+            logger.error(f"Failed to detect credentials: {e}", exc_info=True)
+            return CredentialAnalysis()

--- a/src/inputs/puppet/state.py
+++ b/src/inputs/puppet/state.py
@@ -1,0 +1,49 @@
+"""State management for Puppet analysis workflow.
+
+This module defines the state object for the Puppet analysis phase,
+following the pattern from src/inputs/chef/state.py.
+"""
+
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+
+from src.types import BaseState
+
+from .models import (
+    CredentialAnalysisResult,
+    HieraHierarchy,
+    PuppetStructuredAnalysis,
+)
+
+
+@dataclass
+class PuppetState(BaseState):
+    """State object for Puppet analysis workflow.
+
+    Inherits from BaseState for common fields (user_message, path, telemetry,
+    failed, failure_reason).
+    """
+
+    specification: str = field(kw_only=True)
+    dependency_paths: list[str] = field(kw_only=True, default_factory=list)
+    dependency_info: list[dict] = field(kw_only=True, default_factory=list)
+    export_path: str | None = field(default=None, kw_only=True)
+    hiera_hierarchy: HieraHierarchy | None = field(default=None, kw_only=True)
+    structured_analysis: PuppetStructuredAnalysis | None = field(
+        default=None, kw_only=True
+    )
+    execution_tree_summary: str = field(default="", kw_only=True)
+    credentials_analysis: list[CredentialAnalysisResult] | None = field(
+        default=None, kw_only=True
+    )
+    variables_summary: str = field(default="", kw_only=True)
+
+    @property
+    def all_paths(self) -> list[Path]:
+        return [Path(x) for x in [self.path, *self.dependency_paths]]
+
+    def update(self, **kwargs) -> "PuppetState":
+        return replace(self, **kwargs)
+
+    def mark_failed(self, reason: str) -> "PuppetState":
+        return self.update(failed=True, failure_reason=reason)

--- a/src/types/credential.py
+++ b/src/types/credential.py
@@ -121,8 +121,8 @@ class CredentialConfig:
         if not credentials:
             return cls.empty()
 
-        variable_names = _collect_variable_names(credentials)
-        credential_types_yaml = _render_credential_types(credentials)
+        variable_names = _collect_variable_names(credentials, module_name)
+        credential_types_yaml = _render_credential_types(credentials, module_name)
         credentials_yaml = _render_credentials(credentials, module_name)
         validate_tasks_yaml = _render_validate_tasks(variable_names)
 
@@ -140,14 +140,32 @@ class CredentialConfig:
 # ---------------------------------------------------------------------------
 
 
-def _collect_variable_names(credentials: list[ExtractedCredential]) -> list[str]:
-    """Collect all variable names from credential fields."""
-    return [field.id for cred in credentials for field in cred.fields]
+def _module_prefix(module_name: str) -> str:
+    """Derive a variable-safe prefix from the module name.
+
+    Strips common Puppet profile/role prefixes so that
+    'profile_haproxy' → 'haproxy', matching Ansible conventions.
+    """
+    prefix = module_name.replace("-", "_")
+    for strip in ("profile_", "role_"):
+        if prefix.startswith(strip):
+            return prefix[len(strip) :]
+    return prefix
 
 
-def _render_credential_types(credentials: list[ExtractedCredential]) -> str:
+def _collect_variable_names(
+    credentials: list[ExtractedCredential], module_name: str
+) -> list[str]:
+    """Collect all variable names from credential fields, prefixed with module name."""
+    prefix = _module_prefix(module_name)
+    return [f"{prefix}_{field.id}" for cred in credentials for field in cred.fields]
+
+
+def _render_credential_types(
+    credentials: list[ExtractedCredential], module_name: str
+) -> str:
     """Render controller_credential_types.yml content."""
-    types = [_build_credential_type_entry(cred) for cred in credentials]
+    types = [_build_credential_type_entry(cred, module_name) for cred in credentials]
 
     content = str(
         yaml.dump(
@@ -163,12 +181,16 @@ def _render_credential_types(credentials: list[ExtractedCredential]) -> str:
     return "---\n" + content
 
 
-def _build_credential_type_entry(cred: ExtractedCredential) -> dict:
+def _build_credential_type_entry(cred: ExtractedCredential, module_name: str) -> dict:
     """Build a single credential type entry for controller_credential_types.yml."""
     fields = [_build_field_entry(f) for f in cred.fields]
+    prefix = _module_prefix(module_name)
 
     injectors = {
-        "extra_vars": {f.id: f"UNSAFE_PLACEHOLDER {{{{{f.id}}}}}" for f in cred.fields}
+        "extra_vars": {
+            f"{prefix}_{f.id}": f"UNSAFE_PLACEHOLDER {{{{{f.id}}}}}"
+            for f in cred.fields
+        }
     }
 
     entry: dict = {

--- a/src/utils/technology_registry.py
+++ b/src/utils/technology_registry.py
@@ -94,6 +94,7 @@ def register_defaults() -> None:
     from src.inputs.ansible import AnsibleSubagent
     from src.inputs.chef import ChefSubagent
     from src.inputs.powershell import PowerShellSubagent
+    from src.inputs.puppet import PuppetSubagent
 
     TechnologyRegistry.register_analyzer(Technology.CHEF, ChefSubagent)
     TechnologyRegistry.register_exporter(Technology.CHEF, ToAnsibleSubagent)
@@ -103,6 +104,9 @@ def register_defaults() -> None:
 
     TechnologyRegistry.register_analyzer(Technology.ANSIBLE, AnsibleSubagent)
     TechnologyRegistry.register_exporter(Technology.ANSIBLE, ToAnsibleSubagent)
+
+    TechnologyRegistry.register_analyzer(Technology.PUPPET, PuppetSubagent)
+    TechnologyRegistry.register_exporter(Technology.PUPPET, ToAnsibleSubagent)
 
 
 register_defaults()

--- a/tests/exporters/test_migrate.py
+++ b/tests/exporters/test_migrate.py
@@ -1,0 +1,54 @@
+"""Tests for MigrationAgent — text fallback and extract_text_content."""
+
+from src.exporters.migrate import MigrationAgent, SourceMetadata
+
+
+class TestExtractTextContent:
+    def test_string_input(self):
+        assert MigrationAgent._extract_text_content('{"path": "."}') == '{"path": "."}'
+
+    def test_list_with_text_block(self):
+        content = [
+            {"type": "reasoning_content", "reasoning_content": {"text": "thinking..."}},
+            {"type": "text", "text": '{"path": "profile_haproxy"}'},
+        ]
+        assert (
+            MigrationAgent._extract_text_content(content)
+            == '{"path": "profile_haproxy"}'
+        )
+
+    def test_list_with_string_element(self):
+        content = ['{"path": "."}']
+        assert MigrationAgent._extract_text_content(content) == '{"path": "."}'
+
+    def test_list_without_text_block(self):
+        content = [
+            {"type": "reasoning_content", "reasoning_content": {"text": "thinking..."}},
+        ]
+        assert MigrationAgent._extract_text_content(content) is None
+
+    def test_none_input(self):
+        assert MigrationAgent._extract_text_content(None) is None
+
+    def test_empty_list(self):
+        assert MigrationAgent._extract_text_content([]) is None
+
+    def test_integer_input(self):
+        assert MigrationAgent._extract_text_content(42) is None
+
+    def test_list_prefers_text_type_over_string(self):
+        content = [
+            {"type": "text", "text": "first"},
+            "second",
+        ]
+        assert MigrationAgent._extract_text_content(content) == "first"
+
+
+class TestSourceMetadata:
+    def test_from_valid_json(self):
+        m = SourceMetadata(path=".")
+        assert m.path == "."
+
+    def test_from_module_path(self):
+        m = SourceMetadata(path="profile_haproxy")
+        assert m.path == "profile_haproxy"

--- a/tests/inputs/puppet/test_dependency_fetcher.py
+++ b/tests/inputs/puppet/test_dependency_fetcher.py
@@ -1,0 +1,155 @@
+"""Tests for Puppet dependency fetcher (Puppetfile parser)."""
+
+from src.inputs.puppet.dependency_fetcher import PuppetDependencyFetcher
+
+
+class TestPuppetDependencyFetcher:
+    """Test Puppetfile parsing via tree-sitter."""
+
+    def test_no_puppetfile(self, tmp_path):
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+        has_deps, deps = fetcher.has_dependencies()
+        assert has_deps is False
+        assert deps == []
+
+    def test_empty_puppetfile(self, tmp_path):
+        (tmp_path / "Puppetfile").write_text("")
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+        has_deps, deps = fetcher.has_dependencies()
+        assert has_deps is False
+        assert deps == []
+
+    def test_forge_modules(self, tmp_path):
+        puppetfile = """
+mod 'puppetlabs-stdlib', '9.7.0'
+mod 'puppetlabs-concat', '9.0.2'
+mod 'puppetlabs-firewall', '8.1.3'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        has_deps, dep_names = fetcher.has_dependencies()
+        assert has_deps is True
+        assert len(dep_names) == 3
+        assert "puppetlabs-stdlib" in dep_names
+        assert "puppetlabs-concat" in dep_names
+
+    def test_forge_module_details(self, tmp_path):
+        puppetfile = "mod 'puppetlabs-stdlib', '9.7.0'\n"
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 1
+        assert deps[0]["name"] == "puppetlabs-stdlib"
+        assert deps[0]["source"] == "forge"
+        assert deps[0]["version"] == "9.7.0"
+
+    def test_forge_module_no_version(self, tmp_path):
+        puppetfile = "mod 'puppetlabs-stdlib'\n"
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 1
+        assert deps[0]["name"] == "puppetlabs-stdlib"
+        assert deps[0]["version"] == ""
+
+    def test_git_module(self, tmp_path):
+        puppetfile = """
+mod 'custom_module',
+  :git => 'https://github.com/example/custom_module.git',
+  :tag => 'v1.2.0'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 1
+        assert deps[0]["name"] == "custom_module"
+        assert deps[0]["source"] == "git"
+        assert deps[0]["url"] == "https://github.com/example/custom_module.git"
+        assert deps[0]["version"] == "v1.2.0"
+
+    def test_git_module_with_branch(self, tmp_path):
+        puppetfile = """
+mod 'my_module',
+  :git => 'https://git.example.com/my_module.git',
+  :branch => 'main'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 1
+        assert deps[0]["version"] == "main"
+
+    def test_git_module_with_ref(self, tmp_path):
+        puppetfile = """
+mod 'my_module',
+  :git => 'https://git.example.com/my_module.git',
+  :ref => 'abc123'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 1
+        assert deps[0]["version"] == "abc123"
+
+    def test_mixed_forge_and_git(self, tmp_path):
+        puppetfile = """
+mod 'puppetlabs-stdlib', '9.7.0'
+mod 'custom_module',
+  :git => 'https://github.com/example/custom_module.git',
+  :tag => 'v2.0.0'
+mod 'puppetlabs-concat', '9.0.2'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 3
+        forge_deps = [d for d in deps if d["source"] == "forge"]
+        git_deps = [d for d in deps if d["source"] == "git"]
+        assert len(forge_deps) == 2
+        assert len(git_deps) == 1
+
+    def test_caching(self, tmp_path):
+        puppetfile = "mod 'puppetlabs-stdlib', '9.0.0'\n"
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps1 = fetcher.get_dependency_info()
+        deps2 = fetcher.get_dependency_info()
+        assert deps1 is deps2
+
+    def test_git_overrides_forge_duplicate(self, tmp_path):
+        """When a module appears as both forge and git, git takes priority."""
+        puppetfile = """
+mod 'stdlib', '9.0.0'
+mod 'stdlib',
+  :git => 'https://github.com/custom/stdlib.git',
+  :tag => 'custom-v1'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        stdlib_deps = [d for d in deps if d["name"] == "stdlib"]
+        assert len(stdlib_deps) == 1
+        assert stdlib_deps[0]["source"] == "git"
+
+    def test_comments_and_blank_lines(self, tmp_path):
+        puppetfile = """
+# This is a comment
+mod 'puppetlabs-stdlib', '9.0.0'
+
+# Another comment
+mod 'puppetlabs-concat', '9.0.2'
+"""
+        (tmp_path / "Puppetfile").write_text(puppetfile)
+        fetcher = PuppetDependencyFetcher(str(tmp_path))
+
+        deps = fetcher.get_dependency_info()
+        assert len(deps) == 2

--- a/tests/inputs/puppet/test_execution_tree_builder.py
+++ b/tests/inputs/puppet/test_execution_tree_builder.py
@@ -1,0 +1,404 @@
+"""Tests for Puppet execution tree builder."""
+
+from src.inputs.puppet.execution_tree_builder import (
+    ExecutionTreeNode,
+    PuppetExecutionTreeBuilder,
+)
+from src.inputs.puppet.models import (
+    ClassInclude,
+    ClassInheritance,
+    ConditionalBlock,
+    IterationBlock,
+    ManifestAnalysisResult,
+    ManifestExecutionAnalysis,
+    PuppetResourceDeclaration,
+    PuppetStructuredAnalysis,
+)
+
+
+def _make_manifest(class_name, file_path, **kwargs) -> ManifestAnalysisResult:
+    return ManifestAnalysisResult(
+        file_path=file_path,
+        analysis=ManifestExecutionAnalysis(class_name=class_name, **kwargs),
+    )
+
+
+class TestExecutionTreeNode:
+    def test_class_format(self):
+        node = ExecutionTreeNode(
+            node_type="class",
+            name="profile_haproxy",
+            file_path="manifests/init.pp",
+        )
+        label = node.format_label()
+        assert "[class] profile_haproxy" in label
+        assert "manifests/init.pp" in label
+
+    def test_class_with_details(self):
+        node = ExecutionTreeNode(
+            node_type="class",
+            name="profile_haproxy",
+            file_path="manifests/init.pp",
+            details="entry point",
+        )
+        label = node.format_label()
+        assert "(entry point)" in label
+
+    def test_resource_format(self):
+        node = ExecutionTreeNode(node_type="resource", name="package[haproxy]")
+        assert node.format_label() == "[resource] package[haproxy]"
+
+    def test_iteration_format(self):
+        node = ExecutionTreeNode(node_type="iteration", name="$backends.each |$name|")
+        assert "LOOP" in node.format_label()
+
+    def test_conditional_format(self):
+        node = ExecutionTreeNode(node_type="conditional", name="if $ssl_enabled")
+        assert "[conditional]" in node.format_label()
+
+    def test_exported_format(self):
+        node = ExecutionTreeNode(node_type="exported", name="nagios_host[web01]")
+        assert "@@" in node.format_label()
+
+    def test_virtual_format(self):
+        node = ExecutionTreeNode(node_type="virtual", name="user[deploy]")
+        assert "@" in node.format_label()
+
+    def test_unknown_type_format(self):
+        node = ExecutionTreeNode(node_type="unknown", name="something")
+        assert node.format_label() == "something"
+
+    def test_unknown_type_with_details(self):
+        node = ExecutionTreeNode(node_type="unknown", name="something", details="extra")
+        assert node.format_label() == "something (extra)"
+
+
+class TestPuppetExecutionTreeBuilder:
+    def test_simple_tree(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "profile_haproxy",
+                    "manifests/init.pp",
+                    class_includes=[
+                        ClassInclude(
+                            class_name="profile_haproxy::install",
+                            relationship="include",
+                        ),
+                    ],
+                ),
+                _make_manifest(
+                    "profile_haproxy::install",
+                    "manifests/install.pp",
+                    resources=[
+                        PuppetResourceDeclaration(
+                            resource_type="package",
+                            title="haproxy",
+                            attributes={"ensure": "installed"},
+                        ),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        assert root.name == "profile_haproxy"
+        assert root.node_type == "class"
+        assert len(root.children) == 1
+        child = root.children[0]
+        assert child.name == "profile_haproxy::install"
+        assert len(child.children) == 1
+        assert "package" in child.children[0].name
+
+    def test_entry_class_detection_via_init_pp(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest("profile_haproxy::config", "manifests/config.pp"),
+                _make_manifest("profile_haproxy", "manifests/init.pp"),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+        assert root.name == "profile_haproxy"
+
+    def test_entry_class_fallback_to_first(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest("profile_haproxy::config", "manifests/config.pp"),
+                _make_manifest("profile_haproxy::install", "manifests/install.pp"),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+        assert root.name == "profile_haproxy::config"
+
+    def test_no_manifests(self):
+        analysis = PuppetStructuredAnalysis()
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+        assert "(no entry class found)" in root.name
+
+    def test_circular_reference_detection(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "a",
+                    "manifests/a.pp",
+                    class_includes=[
+                        ClassInclude(class_name="b", relationship="include"),
+                    ],
+                ),
+                _make_manifest(
+                    "b",
+                    "manifests/b.pp",
+                    class_includes=[
+                        ClassInclude(class_name="a", relationship="include"),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree(entry_class="a")
+
+        assert root.name == "a"
+        b_node = root.children[0]
+        assert b_node.name == "b"
+        circular_ref = b_node.children[0]
+        assert "CIRCULAR" in (circular_ref.details or "")
+
+    def test_unanalyzed_class_reference(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    class_includes=[
+                        ClassInclude(
+                            class_name="external::module",
+                            relationship="include",
+                        ),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        ext_node = root.children[0]
+        assert ext_node.name == "external::module"
+        assert "not analyzed" in (ext_node.details or "")
+
+    def test_inheritance(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "child",
+                    "manifests/init.pp",
+                    class_inherits=ClassInheritance(
+                        parent_class="parent",
+                        child_class="child",
+                        overridden_params=["package_name"],
+                    ),
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        assert any("inherits parent" in c.name for c in root.children)
+
+    def test_conditionals_in_tree(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    conditionals=[
+                        ConditionalBlock(
+                            condition="$ssl_enabled",
+                            condition_type="if",
+                            resources=[
+                                PuppetResourceDeclaration(
+                                    resource_type="file", title="/etc/ssl/cert.pem"
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        cond_nodes = [c for c in root.children if c.node_type == "conditional"]
+        assert len(cond_nodes) == 1
+        assert "ssl_enabled" in cond_nodes[0].name
+        assert len(cond_nodes[0].children) == 1
+
+    def test_iterations_in_tree(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    iterations=[
+                        IterationBlock(
+                            iterator_type="each",
+                            collection_variable="$backends",
+                            item_variable="$name, $config",
+                            resources=[
+                                PuppetResourceDeclaration(
+                                    resource_type="file", title="backend.cfg"
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        iter_nodes = [c for c in root.children if c.node_type == "iteration"]
+        assert len(iter_nodes) == 1
+        assert "$backends" in iter_nodes[0].name
+        assert len(iter_nodes[0].children) == 1
+
+    def test_exported_and_virtual_resources(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    exported_resources=[
+                        PuppetResourceDeclaration(
+                            resource_type="nagios_host", title="web01"
+                        ),
+                    ],
+                    virtual_resources=[
+                        PuppetResourceDeclaration(resource_type="user", title="deploy"),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        exported = [c for c in root.children if c.node_type == "exported"]
+        virtual = [c for c in root.children if c.node_type == "virtual"]
+        assert len(exported) == 1
+        assert "nagios_host" in exported[0].name
+        assert len(virtual) == 1
+        assert "user" in virtual[0].name
+
+    def test_relationship_chains(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    relationship_chains=[
+                        "Package[haproxy] -> File[haproxy.cfg] ~> Service[haproxy]"
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        rel_nodes = [c for c in root.children if c.node_type == "relationship"]
+        assert len(rel_nodes) == 1
+        assert "Package[haproxy]" in rel_nodes[0].name
+
+    def test_resource_details_extraction(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    resources=[
+                        PuppetResourceDeclaration(
+                            resource_type="file",
+                            title="/etc/haproxy/haproxy.cfg",
+                            attributes={
+                                "ensure": "file",
+                                "owner": "root",
+                                "mode": "0640",
+                            },
+                        ),
+                        PuppetResourceDeclaration(
+                            resource_type="exec",
+                            title="reload_config",
+                            attributes={"command": "/usr/sbin/haproxy -c"},
+                        ),
+                    ],
+                ),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+
+        file_node = root.children[0]
+        assert "ensure: file" in (file_node.details or "")
+        exec_node = root.children[1]
+        assert "command:" in (exec_node.details or "")
+
+
+class TestFormatTree:
+    def test_format_simple_tree(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "main",
+                    "manifests/init.pp",
+                    resources=[
+                        PuppetResourceDeclaration(
+                            resource_type="package", title="haproxy"
+                        ),
+                    ],
+                    class_includes=[
+                        ClassInclude(class_name="main::config", relationship="include"),
+                    ],
+                ),
+                _make_manifest("main::config", "manifests/config.pp"),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree()
+        output = builder.format_tree(root)
+
+        assert "[class] main" in output
+        assert "[resource] package[haproxy]" in output
+        assert "[class] main::config" in output
+        assert "├── " in output or "└── " in output
+
+    def test_format_deep_nesting(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                _make_manifest(
+                    "a",
+                    "manifests/a.pp",
+                    class_includes=[
+                        ClassInclude(class_name="b", relationship="include")
+                    ],
+                ),
+                _make_manifest(
+                    "b",
+                    "manifests/b.pp",
+                    class_includes=[
+                        ClassInclude(class_name="c", relationship="include")
+                    ],
+                ),
+                _make_manifest("c", "manifests/c.pp"),
+            ]
+        )
+        builder = PuppetExecutionTreeBuilder(analysis)
+        root = builder.build_tree(entry_class="a")
+        output = builder.format_tree(root)
+
+        lines = output.strip().split("\n")
+        assert len(lines) == 3
+        assert "[class] a" in lines[0]
+        assert "[class] b" in lines[1]
+        assert "[class] c" in lines[2]

--- a/tests/inputs/puppet/test_hiera_parser.py
+++ b/tests/inputs/puppet/test_hiera_parser.py
@@ -1,0 +1,267 @@
+"""Tests for deterministic Hiera configuration parser."""
+
+import yaml
+
+from src.inputs.puppet.hiera_parser import HieraConfigParser
+
+
+class TestHieraConfigParserV5:
+    """Test parsing of Hiera v5 configs."""
+
+    def _create_module(self, tmp_path, hiera_config, data_files=None):
+        """Create a puppet module with hiera config and optional data files."""
+        module_path = tmp_path / "profile_test"
+        module_path.mkdir()
+        (module_path / "hiera.yaml").write_text(yaml.dump(hiera_config))
+
+        if data_files:
+            for rel_path, content in data_files.items():
+                full_path = module_path / rel_path
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_text(content)
+
+        return module_path
+
+    def test_parse_basic_v5(self, tmp_path):
+        config = {
+            "version": 5,
+            "defaults": {"datadir": "data", "data_hash": "yaml_data"},
+            "hierarchy": [
+                {"name": "Common defaults", "path": "common.yaml"},
+            ],
+        }
+        data_files = {"data/common.yaml": "---\npackage_name: haproxy\n"}
+        module = self._create_module(tmp_path, config, data_files)
+
+        parser = HieraConfigParser(str(module))
+        hierarchy = parser.parse()
+
+        assert hierarchy.version == 5
+        assert len(hierarchy.levels) == 1
+        assert hierarchy.levels[0].name == "Common defaults"
+        assert hierarchy.total_data_files == 1
+        assert len(hierarchy.levels[0].resolved_files) == 1
+
+    def test_parse_multi_level_hierarchy(self, tmp_path):
+        config = {
+            "version": 5,
+            "defaults": {"datadir": "data", "data_hash": "yaml_data"},
+            "hierarchy": [
+                {"name": "Per-node", "path": "nodes/%{trusted.certname}.yaml"},
+                {"name": "OS family", "path": "os/%{facts.os.family}.yaml"},
+                {"name": "Common", "path": "common.yaml"},
+            ],
+        }
+        data_files = {
+            "data/common.yaml": "---\nkey: value\n",
+            "data/os/RedHat.yaml": "---\nfirewall: firewalld\n",
+            "data/os/Debian.yaml": "---\nfirewall: ufw\n",
+            "data/nodes/web01.yaml": "---\nport: 8080\n",
+        }
+        module = self._create_module(tmp_path, config, data_files)
+
+        parser = HieraConfigParser(str(module))
+        hierarchy = parser.parse()
+
+        assert len(hierarchy.levels) == 3
+        assert hierarchy.total_data_files == 4
+
+        node_level = hierarchy.levels[0]
+        assert node_level.name == "Per-node"
+        assert len(node_level.resolved_files) == 1
+
+        os_level = hierarchy.levels[1]
+        assert os_level.name == "OS family"
+        assert len(os_level.resolved_files) == 2
+
+        common_level = hierarchy.levels[2]
+        assert common_level.name == "Common"
+        assert len(common_level.resolved_files) == 1
+
+    def test_parse_paths_vs_path(self, tmp_path):
+        """Test that 'paths' (plural) is handled correctly."""
+        config = {
+            "version": 5,
+            "defaults": {"datadir": "data", "data_hash": "yaml_data"},
+            "hierarchy": [
+                {
+                    "name": "Environment",
+                    "paths": [
+                        "environment/%{environment}.yaml",
+                        "environment/default.yaml",
+                    ],
+                },
+            ],
+        }
+        data_files = {
+            "data/environment/production.yaml": "---\nmax: 16384\n",
+            "data/environment/staging.yaml": "---\nmax: 4096\n",
+            "data/environment/default.yaml": "---\nmax: 2048\n",
+        }
+        module = self._create_module(tmp_path, config, data_files)
+
+        parser = HieraConfigParser(str(module))
+        hierarchy = parser.parse()
+
+        assert len(hierarchy.levels) == 2
+        env_level = hierarchy.levels[0]
+        assert env_level.name == "Environment"
+        assert len(env_level.resolved_files) == 3  # all files match the glob pattern
+
+        default_level = hierarchy.levels[1]
+        assert default_level.name == "Environment"
+        assert len(default_level.resolved_files) == 1
+
+    def test_parse_custom_datadir(self, tmp_path):
+        """Test per-hierarchy-entry datadir override."""
+        config = {
+            "version": 5,
+            "defaults": {"datadir": "data"},
+            "hierarchy": [
+                {
+                    "name": "Module data",
+                    "datadir": "module_data",
+                    "path": "common.yaml",
+                },
+            ],
+        }
+        data_files = {"module_data/common.yaml": "---\nkey: val\n"}
+        module = self._create_module(tmp_path, config, data_files)
+
+        parser = HieraConfigParser(str(module))
+        hierarchy = parser.parse()
+
+        assert hierarchy.levels[0].datadir == "module_data"
+        assert len(hierarchy.levels[0].resolved_files) == 1
+
+    def test_no_matching_data_files(self, tmp_path):
+        config = {
+            "version": 5,
+            "hierarchy": [
+                {"name": "Missing", "path": "nonexistent/%{something}.yaml"},
+            ],
+        }
+        module = self._create_module(tmp_path, config)
+
+        parser = HieraConfigParser(str(module))
+        hierarchy = parser.parse()
+
+        assert hierarchy.levels[0].resolved_files == []
+        assert hierarchy.total_data_files == 0
+
+    def test_caching(self, tmp_path):
+        config = {"version": 5, "hierarchy": []}
+        module = self._create_module(tmp_path, config)
+
+        parser = HieraConfigParser(str(module))
+        h1 = parser.parse()
+        h2 = parser.parse()
+        assert h1 is h2
+
+
+class TestHieraConfigParserV3:
+    """Test parsing of Hiera v3 configs (legacy)."""
+
+    def _create_module(self, tmp_path, hiera_content, data_files=None):
+        module_path = tmp_path / "profile_test"
+        module_path.mkdir()
+        (module_path / "hiera.yaml").write_text(hiera_content)
+
+        if data_files:
+            for rel_path, content in data_files.items():
+                full_path = module_path / rel_path
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_text(content)
+
+        return module_path
+
+    def test_parse_v3(self, tmp_path):
+        hiera_content = yaml.dump(
+            {
+                ":backends:": ["yaml"],
+                ":yaml:": {":datadir:": "data"},
+                ":hierarchy:": ["common", "os/%{::osfamily}"],
+            }
+        )
+        data_files = {
+            "data/common.yaml": "---\nkey: val\n",
+            "data/os/RedHat.yaml": "---\nfw: firewalld\n",
+        }
+        module = self._create_module(tmp_path, hiera_content, data_files)
+
+        parser = HieraConfigParser(str(module))
+        hierarchy = parser.parse()
+
+        assert hierarchy.version == 3
+        assert len(hierarchy.levels) == 2
+        assert hierarchy.total_data_files == 2
+
+
+class TestHieraConfigParserEdgeCases:
+    """Test edge cases."""
+
+    def test_no_hiera_config(self, tmp_path):
+        module_path = tmp_path / "no_hiera"
+        module_path.mkdir()
+
+        parser = HieraConfigParser(str(module_path))
+        hierarchy = parser.parse()
+
+        assert hierarchy.levels == []
+        assert hierarchy.total_data_files == 0
+
+    def test_empty_hiera_config(self, tmp_path):
+        module_path = tmp_path / "empty_hiera"
+        module_path.mkdir()
+        (module_path / "hiera.yaml").write_text("")
+
+        parser = HieraConfigParser(str(module_path))
+        hierarchy = parser.parse()
+
+        assert hierarchy.levels == []
+
+    def test_get_data_files_by_level(self, tmp_path):
+        module_path = tmp_path / "profile_test"
+        module_path.mkdir()
+        config = {
+            "version": 5,
+            "defaults": {"datadir": "data"},
+            "hierarchy": [
+                {"name": "OS", "path": "os/%{facts.os.family}.yaml"},
+                {"name": "Common", "path": "common.yaml"},
+            ],
+        }
+        (module_path / "hiera.yaml").write_text(yaml.dump(config))
+        (module_path / "data").mkdir()
+        (module_path / "data" / "common.yaml").write_text("---\n")
+        os_dir = module_path / "data" / "os"
+        os_dir.mkdir()
+        (os_dir / "RedHat.yaml").write_text("---\n")
+
+        parser = HieraConfigParser(str(module_path))
+        by_level = parser.get_data_files_by_level()
+
+        assert "OS" in by_level
+        assert "Common" in by_level
+        assert len(by_level["OS"]) == 1
+        assert len(by_level["Common"]) == 1
+
+    def test_hiera_config_in_parent_dir(self, tmp_path):
+        """Test finding hiera.yaml in parent directories."""
+        (tmp_path / "hiera.yaml").write_text(
+            yaml.dump(
+                {
+                    "version": 5,
+                    "defaults": {"datadir": "data"},
+                    "hierarchy": [{"name": "Common", "path": "common.yaml"}],
+                }
+            )
+        )
+        module_path = tmp_path / "modules" / "profile_test"
+        module_path.mkdir(parents=True)
+
+        parser = HieraConfigParser(str(module_path))
+        hierarchy = parser.parse()
+
+        assert hierarchy.version == 5
+        assert len(hierarchy.levels) == 1

--- a/tests/inputs/puppet/test_hiera_vars_generator.py
+++ b/tests/inputs/puppet/test_hiera_vars_generator.py
@@ -1,0 +1,383 @@
+"""Tests for deterministic Hiera-to-Ansible vars file generator."""
+
+import json
+
+import yaml
+
+from src.exporters.hiera_vars_generator import HieraVarsGenerator
+
+
+class TestTargetPath:
+    """Test _target_path routing logic."""
+
+    def test_common_level_goes_to_defaults(self, tmp_path):
+        result = HieraVarsGenerator._target_path(
+            "Common defaults", "data/common.yaml", tmp_path
+        )
+        assert result == tmp_path / "defaults" / "main.yml"
+
+    def test_global_level_goes_to_defaults(self, tmp_path):
+        result = HieraVarsGenerator._target_path(
+            "Global settings", "data/global.yaml", tmp_path
+        )
+        assert result == tmp_path / "defaults" / "main.yml"
+
+    def test_default_level_goes_to_defaults(self, tmp_path):
+        result = HieraVarsGenerator._target_path(
+            "Default values", "data/default.yaml", tmp_path
+        )
+        assert result == tmp_path / "defaults" / "main.yml"
+
+    def test_os_level_goes_to_vars(self, tmp_path):
+        result = HieraVarsGenerator._target_path(
+            "OS family", "data/os/RedHat.yaml", tmp_path
+        )
+        assert result == tmp_path / "vars" / "RedHat.yml"
+
+    def test_environment_level_goes_to_vars(self, tmp_path):
+        result = HieraVarsGenerator._target_path(
+            "Environment", "data/environment/production.yaml", tmp_path
+        )
+        assert result == tmp_path / "vars" / "production.yml"
+
+    def test_node_level_goes_to_vars(self, tmp_path):
+        result = HieraVarsGenerator._target_path(
+            "Per-node data", "data/nodes/lb01.fra.example.com.yaml", tmp_path
+        )
+        assert result == tmp_path / "vars" / "lb01.fra.example.com.yml"
+
+
+class TestDefaultRename:
+    """Test _default_rename key transformation."""
+
+    def test_strips_module_prefix(self):
+        result = HieraVarsGenerator._default_rename(
+            "profile_haproxy::package_name", "profile_haproxy", "profile_haproxy"
+        )
+        assert result == "haproxy_package_name"
+
+    def test_strips_profile_prefix_from_module(self):
+        result = HieraVarsGenerator._default_rename(
+            "profile_haproxy::ssl_enabled", "profile_haproxy", "profile_haproxy"
+        )
+        assert result == "haproxy_ssl_enabled"
+
+    def test_strips_role_prefix_from_module(self):
+        result = HieraVarsGenerator._default_rename(
+            "role_webserver::port", "role_webserver", "role_webserver"
+        )
+        assert result == "webserver_port"
+
+    def test_different_prefix(self):
+        result = HieraVarsGenerator._default_rename(
+            "other_module::setting", "other_module", "other_module"
+        )
+        assert result == "other_module_setting"
+
+    def test_nested_namespace(self):
+        result = HieraVarsGenerator._default_rename(
+            "some::deeply::nested::key", "some", "mymod"
+        )
+        assert result == "mymod_deeply::nested::key"
+
+    def test_nested_namespace_no_prefix_match(self):
+        result = HieraVarsGenerator._default_rename(
+            "other::deeply::nested::key", "some", "mymod"
+        )
+        assert result == "mymod_key"
+
+    def test_no_namespace(self):
+        result = HieraVarsGenerator._default_rename("simple_key", "", "mymod")
+        assert result == "mymod_simple_key"
+
+    def test_hyphen_in_module_name(self):
+        result = HieraVarsGenerator._default_rename(
+            "my_mod::setting", "my_mod", "my-mod"
+        )
+        assert result == "my_mod_setting"
+
+
+class TestDetectPrefix:
+    """Test _detect_prefix."""
+
+    def test_detects_puppet_prefix(self):
+        data = {
+            "profile_haproxy::package_name": "haproxy",
+            "profile_haproxy::config_dir": "/etc/haproxy",
+        }
+        assert HieraVarsGenerator._detect_prefix(data) == "profile_haproxy"
+
+    def test_no_prefix(self):
+        data = {"simple_key": "value"}
+        assert HieraVarsGenerator._detect_prefix(data) == ""
+
+    def test_empty_dict(self):
+        assert HieraVarsGenerator._detect_prefix({}) == ""
+
+
+class TestTransform:
+    """Test the _transform method (key renaming + filtering)."""
+
+    def _make_generator(self):
+        return HieraVarsGenerator.__new__(HieraVarsGenerator)
+
+    def test_basic_transform(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+
+        raw = str(
+            yaml.dump(
+                {
+                    "profile_haproxy::package_name": "haproxy",
+                    "profile_haproxy::config_dir": "/etc/haproxy",
+                }
+            )
+        )
+        mappings = [
+            {
+                "puppet_key": "profile_haproxy::package_name",
+                "ansible_variable_name": "haproxy_package_name",
+            },
+            {
+                "puppet_key": "profile_haproxy::config_dir",
+                "ansible_variable_name": "haproxy_config_dir",
+            },
+        ]
+
+        result = gen._transform(raw, mappings, "profile_haproxy")
+        assert result is not None
+        parsed = yaml.safe_load(result)
+        assert parsed["haproxy_package_name"] == "haproxy"
+        assert parsed["haproxy_config_dir"] == "/etc/haproxy"
+
+    def test_skips_encrypted_values(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+
+        raw = str(
+            yaml.dump(
+                {
+                    "profile_haproxy::package_name": "haproxy",
+                    "profile_haproxy::secret": "ENC[PKCS7,MIIBygExample]",
+                }
+            )
+        )
+        mappings = [
+            {
+                "puppet_key": "profile_haproxy::package_name",
+                "ansible_variable_name": "haproxy_package_name",
+            },
+            {
+                "puppet_key": "profile_haproxy::secret",
+                "ansible_variable_name": "haproxy_secret",
+            },
+        ]
+
+        result = gen._transform(raw, mappings, "profile_haproxy")
+        parsed = yaml.safe_load(result)
+        assert "haproxy_package_name" in parsed
+        assert "haproxy_secret" not in parsed
+
+    def test_skips_lookup_options(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+
+        raw = str(
+            yaml.dump(
+                {
+                    "profile_haproxy::package_name": "haproxy",
+                    "lookup_options": {"profile_haproxy::backends": {"merge": "deep"}},
+                }
+            )
+        )
+        mappings = [
+            {
+                "puppet_key": "profile_haproxy::package_name",
+                "ansible_variable_name": "haproxy_package_name",
+            },
+        ]
+
+        result = gen._transform(raw, mappings, "profile_haproxy")
+        parsed = yaml.safe_load(result)
+        assert "haproxy_package_name" in parsed
+        assert "lookup_options" not in parsed
+
+    def test_empty_content_returns_none(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+        assert gen._transform("", [], "mod") is None
+        assert gen._transform("   \n  ", [], "mod") is None
+
+    def test_non_dict_content_returns_none(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+        assert gen._transform("- item1\n- item2\n", [], "mod") is None
+
+    def test_all_encrypted_returns_none(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+
+        raw = str(
+            yaml.dump(
+                {
+                    "mod::secret1": "ENC[PKCS7,abc]",
+                    "mod::secret2": "ENC[PKCS7,def]",
+                }
+            )
+        )
+        result = gen._transform(raw, [], "mod")
+        assert result is None
+
+    def test_fallback_rename_when_no_mapping(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+
+        raw = str(yaml.dump({"profile_haproxy::unmapped_key": "value"}))
+        result = gen._transform(raw, [], "profile_haproxy")
+        parsed = yaml.safe_load(result)
+        assert "haproxy_unmapped_key" in parsed
+
+    def test_preserves_complex_values(self):
+        gen = self._make_generator()
+        gen._log = type("Log", (), {"warning": lambda self, msg: None})()
+
+        raw = str(
+            yaml.dump(
+                {
+                    "profile_haproxy::backends": {
+                        "web": {"balance": "roundrobin", "port": 8080},
+                        "api": {"balance": "leastconn", "port": 3000},
+                    },
+                }
+            )
+        )
+        mappings = [
+            {
+                "puppet_key": "profile_haproxy::backends",
+                "ansible_variable_name": "haproxy_backends",
+            },
+        ]
+
+        result = gen._transform(raw, mappings, "profile_haproxy")
+        parsed = yaml.safe_load(result)
+        assert isinstance(parsed["haproxy_backends"], dict)
+        assert parsed["haproxy_backends"]["web"]["balance"] == "roundrobin"
+        assert parsed["haproxy_backends"]["api"]["port"] == 3000
+
+
+class TestNormalizePath:
+    def test_strips_dot_slash(self):
+        assert (
+            HieraVarsGenerator._normalize_path("./ansible/roles/foo")
+            == "ansible/roles/foo"
+        )
+
+    def test_preserves_na(self):
+        assert HieraVarsGenerator._normalize_path("N/A") == "N/A"
+
+    def test_preserves_empty(self):
+        assert HieraVarsGenerator._normalize_path("") == ""
+
+    def test_no_dot_slash(self):
+        assert (
+            HieraVarsGenerator._normalize_path("ansible/roles/foo")
+            == "ansible/roles/foo"
+        )
+
+
+class TestHieraVarsGeneratorIntegration:
+    """Integration test using the full execute method with a real JSON file."""
+
+    def test_generates_vars_files(self, tmp_path):
+        module_path = tmp_path / "profile_haproxy"
+        module_path.mkdir()
+
+        hiera_data = [
+            {
+                "file_path": "data/common.yaml",
+                "hierarchy_level": "Common defaults",
+                "raw_content": yaml.dump(
+                    {
+                        "profile_haproxy::package_name": "haproxy",
+                        "profile_haproxy::config_dir": "/etc/haproxy",
+                    }
+                ),
+                "mappings": [
+                    {
+                        "puppet_key": "profile_haproxy::package_name",
+                        "ansible_variable_name": "haproxy_package_name",
+                        "ansible_target": "defaults/main.yml",
+                        "value_type": "string",
+                        "is_encrypted": False,
+                    },
+                    {
+                        "puppet_key": "profile_haproxy::config_dir",
+                        "ansible_variable_name": "haproxy_config_dir",
+                        "ansible_target": "defaults/main.yml",
+                        "value_type": "string",
+                        "is_encrypted": False,
+                    },
+                ],
+                "merge_behavior": {},
+            },
+            {
+                "file_path": "data/os/RedHat.yaml",
+                "hierarchy_level": "OS family",
+                "raw_content": yaml.dump(
+                    {
+                        "profile_haproxy::firewall_provider": "firewalld",
+                    }
+                ),
+                "mappings": [
+                    {
+                        "puppet_key": "profile_haproxy::firewall_provider",
+                        "ansible_variable_name": "haproxy_firewall_provider",
+                        "ansible_target": "vars/RedHat.yml",
+                        "value_type": "string",
+                        "is_encrypted": False,
+                    },
+                ],
+                "merge_behavior": {},
+            },
+        ]
+
+        json_path = tmp_path / "hiera-data-profile_haproxy.json"
+        json_path.write_text(json.dumps(hiera_data))
+
+        ansible_path = tmp_path / "ansible" / "roles" / "profile_haproxy"
+        ansible_path.mkdir(parents=True)
+
+        from unittest.mock import MagicMock
+
+        state = MagicMock()
+        state.module = "profile_haproxy"
+        state.path = str(module_path)
+        state.checklist = None
+
+        def get_ansible_path():
+            return str(ansible_path)
+
+        state.get_ansible_path = get_ansible_path
+
+        gen = HieraVarsGenerator.__new__(HieraVarsGenerator)
+        gen._log = type(
+            "Log",
+            (),
+            {
+                "info": lambda self, msg: None,
+                "warning": lambda self, msg: None,
+            },
+        )()
+
+        gen.execute(state, metrics=None)
+
+        defaults = ansible_path / "defaults" / "main.yml"
+        assert defaults.exists()
+        defaults_data = yaml.safe_load(defaults.read_text())
+        assert defaults_data["haproxy_package_name"] == "haproxy"
+        assert defaults_data["haproxy_config_dir"] == "/etc/haproxy"
+
+        redhat_vars = ansible_path / "vars" / "RedHat.yml"
+        assert redhat_vars.exists()
+        redhat_data = yaml.safe_load(redhat_vars.read_text())
+        assert redhat_data["haproxy_firewall_provider"] == "firewalld"

--- a/tests/inputs/puppet/test_hiera_vars_generator.py
+++ b/tests/inputs/puppet/test_hiera_vars_generator.py
@@ -78,7 +78,7 @@ class TestDefaultRename:
         result = HieraVarsGenerator._default_rename(
             "some::deeply::nested::key", "some", "mymod"
         )
-        assert result == "mymod_deeply::nested::key"
+        assert result == "mymod_deeply_nested_key"
 
     def test_nested_namespace_no_prefix_match(self):
         result = HieraVarsGenerator._default_rename(

--- a/tests/inputs/puppet/test_models.py
+++ b/tests/inputs/puppet/test_models.py
@@ -1,0 +1,311 @@
+"""Tests for Puppet analysis domain models."""
+
+from src.inputs.puppet.models import (
+    ClassInclude,
+    ClassInheritance,
+    ConditionalBlock,
+    CredentialAnalysis,
+    CredentialAnalysisResult,
+    CredentialEntry,
+    CustomTypeAnalysis,
+    CustomTypeAnalysisResult,
+    HieraDataAnalysis,
+    HieraDataAnalysisResult,
+    HieraHierarchy,
+    HieraLevel,
+    HieraVariableMapping,
+    IterationBlock,
+    ManifestAnalysisResult,
+    ManifestExecutionAnalysis,
+    PuppetResourceDeclaration,
+    PuppetStructuredAnalysis,
+    PuppetTemplateAnalysis,
+    TemplateAnalysisResult,
+)
+
+
+class TestPuppetResourceDeclaration:
+    def test_defaults(self):
+        res = PuppetResourceDeclaration(resource_type="package", title="haproxy")
+        assert res.resource_type == "package"
+        assert res.title == "haproxy"
+        assert res.attributes == {}
+        assert res.note is None
+
+    def test_with_attributes(self):
+        res = PuppetResourceDeclaration(
+            resource_type="file",
+            title="/etc/haproxy/haproxy.cfg",
+            attributes={"ensure": "file", "owner": "root", "mode": "0640"},
+            note="main config",
+        )
+        assert res.attributes["ensure"] == "file"
+        assert res.attributes["mode"] == "0640"
+        assert res.note == "main config"
+
+
+class TestManifestExecutionAnalysis:
+    def test_defaults(self):
+        analysis = ManifestExecutionAnalysis()
+        assert analysis.class_name is None
+        assert analysis.class_parameters == {}
+        assert analysis.resources == []
+        assert analysis.class_includes == []
+        assert analysis.conditionals == []
+        assert analysis.iterations == []
+        assert analysis.exported_resources == []
+        assert analysis.virtual_resources == []
+        assert analysis.collectors == []
+        assert analysis.puppetdb_queries == []
+        assert analysis.relationship_chains == []
+
+    def test_with_full_manifest(self):
+        analysis = ManifestExecutionAnalysis(
+            class_name="profile_haproxy",
+            class_parameters={"package_name": "String", "config_dir": "String"},
+            resources=[
+                PuppetResourceDeclaration(resource_type="package", title="haproxy"),
+            ],
+            class_includes=[
+                ClassInclude(
+                    class_name="profile_haproxy::config", relationship="include"
+                ),
+                ClassInclude(
+                    class_name="profile_haproxy::service", relationship="contain"
+                ),
+            ],
+            conditionals=[
+                ConditionalBlock(
+                    condition="$ssl_enabled",
+                    condition_type="if",
+                    resources=[
+                        PuppetResourceDeclaration(
+                            resource_type="file", title="/etc/ssl/cert.pem"
+                        )
+                    ],
+                ),
+            ],
+            iterations=[
+                IterationBlock(
+                    iterator_type="each",
+                    collection_variable="$backends",
+                    item_variable="$name, $config",
+                    resources=[
+                        PuppetResourceDeclaration(
+                            resource_type="file", title="backend.cfg"
+                        )
+                    ],
+                ),
+            ],
+            relationship_chains=[
+                "Package[haproxy] -> File[haproxy.cfg] ~> Service[haproxy]"
+            ],
+        )
+        assert analysis.class_name == "profile_haproxy"
+        assert len(analysis.class_parameters) == 2
+        assert len(analysis.resources) == 1
+        assert len(analysis.class_includes) == 2
+        assert analysis.class_includes[0].relationship == "include"
+        assert analysis.class_includes[1].relationship == "contain"
+        assert len(analysis.conditionals) == 1
+        assert analysis.conditionals[0].condition_type == "if"
+        assert len(analysis.iterations) == 1
+        assert analysis.iterations[0].iterator_type == "each"
+        assert len(analysis.relationship_chains) == 1
+
+
+class TestClassInheritance:
+    def test_basic(self):
+        inh = ClassInheritance(
+            parent_class="profile_haproxy::params",
+            child_class="profile_haproxy",
+        )
+        assert inh.parent_class == "profile_haproxy::params"
+        assert inh.overridden_params == []
+
+    def test_with_overrides(self):
+        inh = ClassInheritance(
+            parent_class="base",
+            child_class="derived",
+            overridden_params=["package_name", "service_name"],
+        )
+        assert len(inh.overridden_params) == 2
+
+
+class TestHieraVariableMapping:
+    def test_defaults(self):
+        var = HieraVariableMapping(
+            puppet_key="profile_haproxy::package_name", value_type="string"
+        )
+        assert var.puppet_key == "profile_haproxy::package_name"
+        assert var.is_encrypted is False
+        assert var.ansible_target == ""
+        assert var.ansible_variable_name == ""
+
+    def test_encrypted(self):
+        var = HieraVariableMapping(
+            puppet_key="profile_haproxy::stats_password",
+            value_type="string",
+            is_encrypted=True,
+            ansible_target="defaults/main.yml",
+            ansible_variable_name="haproxy_stats_password",
+        )
+        assert var.is_encrypted is True
+        assert var.ansible_variable_name == "haproxy_stats_password"
+
+
+class TestHieraHierarchy:
+    def test_empty(self):
+        h = HieraHierarchy()
+        assert h.version == 5
+        assert h.levels == []
+        assert h.total_data_files == 0
+
+    def test_with_levels(self):
+        h = HieraHierarchy(
+            version=5,
+            levels=[
+                HieraLevel(
+                    name="Per-node", path_pattern="nodes/%{trusted.certname}.yaml"
+                ),
+                HieraLevel(
+                    name="Common",
+                    path_pattern="common.yaml",
+                    resolved_files=["/tmp/data/common.yaml"],
+                ),
+            ],
+            total_data_files=1,
+        )
+        assert len(h.levels) == 2
+        assert h.levels[0].resolved_files == []
+        assert h.levels[1].resolved_files == ["/tmp/data/common.yaml"]
+
+
+class TestPuppetStructuredAnalysis:
+    def _make_analysis(self):
+        return PuppetStructuredAnalysis(
+            manifests=[
+                ManifestAnalysisResult(
+                    file_path="manifests/init.pp",
+                    analysis=ManifestExecutionAnalysis(class_name="profile_haproxy"),
+                ),
+                ManifestAnalysisResult(
+                    file_path="manifests/config.pp",
+                    analysis=ManifestExecutionAnalysis(
+                        class_name="profile_haproxy::config"
+                    ),
+                ),
+            ],
+            hiera_data=[
+                HieraDataAnalysisResult(
+                    file_path="data/common.yaml",
+                    hierarchy_level="Common defaults",
+                    raw_content="---\nprofile_haproxy::package_name: haproxy\n",
+                    analysis=HieraDataAnalysis(
+                        variables=[
+                            HieraVariableMapping(
+                                puppet_key="profile_haproxy::package_name",
+                                value_type="string",
+                            )
+                        ]
+                    ),
+                ),
+            ],
+            templates=[
+                TemplateAnalysisResult(
+                    file_path="templates/haproxy.cfg.erb",
+                    analysis=PuppetTemplateAnalysis(
+                        template_type="erb",
+                        variables_used=["@log_server", "@maxconn"],
+                    ),
+                ),
+            ],
+            custom_types=[
+                CustomTypeAnalysisResult(
+                    file_path="lib/facter/haproxy_version.rb",
+                    component_type="fact",
+                    analysis=CustomTypeAnalysis(
+                        component_type="fact",
+                        name="haproxy_version",
+                        ansible_equivalent="ansible.builtin.command: haproxy -v",
+                    ),
+                ),
+            ],
+        )
+
+    def test_total_files(self):
+        analysis = self._make_analysis()
+        assert analysis.get_total_files_analyzed() == 5
+
+    def test_total_files_empty(self):
+        analysis = PuppetStructuredAnalysis()
+        assert analysis.get_total_files_analyzed() == 0
+
+    def test_analyzed_file_paths(self):
+        analysis = self._make_analysis()
+        paths = analysis.analyzed_file_paths
+        assert "manifests/init.pp" in paths
+        assert "manifests/config.pp" in paths
+        assert "data/common.yaml" in paths
+        assert "templates/haproxy.cfg.erb" in paths
+        assert "lib/facter/haproxy_version.rb" in paths
+        assert len(paths) == 5
+
+    def test_analyzed_file_paths_sorted(self):
+        analysis = self._make_analysis()
+        paths = analysis.analyzed_file_paths
+        assert paths == sorted(paths)
+
+    def test_analyzed_file_paths_deduplication(self):
+        analysis = PuppetStructuredAnalysis(
+            manifests=[
+                ManifestAnalysisResult(
+                    file_path="manifests/init.pp",
+                    analysis=ManifestExecutionAnalysis(),
+                ),
+                ManifestAnalysisResult(
+                    file_path="manifests/init.pp",
+                    analysis=ManifestExecutionAnalysis(),
+                ),
+            ],
+        )
+        paths = analysis.analyzed_file_paths
+        assert len(paths) == 1
+
+
+class TestCredentialModels:
+    def test_credential_entry(self):
+        entry = CredentialEntry(
+            purpose="HAProxy stats page authentication",
+            variable_names=["profile_haproxy::stats_password"],
+            source_files=["data/common.yaml"],
+            storage_method="eyaml",
+            usage_context="HAProxy stats listen section",
+            ansible_recommendation="ansible-vault",
+        )
+        assert entry.storage_method == "eyaml"
+        assert len(entry.variable_names) == 1
+
+    def test_credential_analysis(self):
+        analysis = CredentialAnalysis(
+            credentials=[
+                CredentialEntry(
+                    purpose="Stats password",
+                    variable_names=["stats_password"],
+                    source_files=["common.yaml"],
+                    storage_method="eyaml",
+                    usage_context="stats",
+                    ansible_recommendation="vault",
+                )
+            ],
+            total_detected=1,
+        )
+        assert analysis.total_detected == 1
+        assert len(analysis.credentials) == 1
+
+    def test_credential_analysis_result(self):
+        result = CredentialAnalysisResult(
+            analysis=CredentialAnalysis(total_detected=0),
+        )
+        assert result.analysis.total_detected == 0
+        assert result.analysis.credentials == []

--- a/tests/inputs/puppet/test_services.py
+++ b/tests/inputs/puppet/test_services.py
@@ -1,0 +1,303 @@
+"""Tests for Puppet analysis services — retry logic, message format, fallbacks."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import HumanMessage, SystemMessage
+
+from src.inputs.puppet.models import (
+    ClassInclude,
+    CredentialAnalysis,
+    HieraDataAnalysis,
+    ManifestExecutionAnalysis,
+    PuppetTemplateAnalysis,
+)
+from src.inputs.puppet.services import (
+    MAX_STRUCTURED_RETRIES,
+    CredentialDetectionService,
+    CustomTypeAnalysisService,
+    HieraDataAnalysisService,
+    ManifestAnalysisService,
+    TemplateAnalysisService,
+)
+
+
+@pytest.fixture
+def mock_model():
+    model = MagicMock()
+    structured = MagicMock()
+    model.with_structured_output.return_value = structured
+    return model, structured
+
+
+@pytest.fixture
+def manifest_file(tmp_path):
+    f = tmp_path / "init.pp"
+    f.write_text("class profile_haproxy { }")
+    return f
+
+
+@pytest.fixture
+def hiera_file(tmp_path):
+    f = tmp_path / "common.yaml"
+    f.write_text("profile_haproxy::package_name: haproxy")
+    return f
+
+
+@pytest.fixture
+def template_file(tmp_path):
+    f = tmp_path / "haproxy.cfg.erb"
+    f.write_text("<%= @haproxy_user %>")
+    return f
+
+
+@pytest.fixture
+def custom_type_file(tmp_path):
+    f = tmp_path / "haproxy_version.rb"
+    f.write_text("Facter.add(:haproxy_version) { }")
+    return f
+
+
+class TestManifestAnalysisService:
+    def test_file_not_found_returns_empty(self, mock_model):
+        model, _ = mock_model
+        svc = ManifestAnalysisService(model)
+        result = svc.analyze(Path("/nonexistent/init.pp"))
+        assert isinstance(result, ManifestExecutionAnalysis)
+        assert result.resources == []
+        model.with_structured_output.assert_not_called()
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_successful_analysis(
+        self, mock_prompt, mock_config, mock_model, manifest_file
+    ):
+        model, structured = mock_model
+        expected = ManifestExecutionAnalysis(
+            resources=[],
+            class_includes=[
+                ClassInclude(class_name="install", relationship="include"),
+                ClassInclude(class_name="config", relationship="include"),
+            ],
+        )
+        structured.invoke.return_value = expected
+        mock_prompt.return_value.format.return_value = "prompt text"
+
+        svc = ManifestAnalysisService(model)
+        result = svc.analyze(manifest_file)
+        assert result == expected
+        structured.invoke.assert_called_once()
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_uses_system_and_human_messages(
+        self, mock_prompt, mock_config, mock_model, manifest_file
+    ):
+        model, structured = mock_model
+        structured.invoke.return_value = ManifestExecutionAnalysis()
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = ManifestAnalysisService(model)
+        svc.analyze(manifest_file)
+
+        messages = structured.invoke.call_args[0][0]
+        assert len(messages) == 2
+        assert isinstance(messages[0], SystemMessage)
+        assert isinstance(messages[1], HumanMessage)
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_retry_on_none(self, mock_prompt, mock_config, mock_model, manifest_file):
+        model, structured = mock_model
+        expected = ManifestExecutionAnalysis(
+            class_includes=[ClassInclude(class_name="install", relationship="include")]
+        )
+        structured.invoke.side_effect = [None, expected]
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = ManifestAnalysisService(model)
+        result = svc.analyze(manifest_file)
+        assert result == expected
+        assert structured.invoke.call_count == 2
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_all_retries_exhausted_returns_empty(
+        self, mock_prompt, mock_config, mock_model, manifest_file
+    ):
+        model, structured = mock_model
+        structured.invoke.return_value = None
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = ManifestAnalysisService(model)
+        result = svc.analyze(manifest_file)
+        assert isinstance(result, ManifestExecutionAnalysis)
+        assert result.resources == []
+        assert structured.invoke.call_count == MAX_STRUCTURED_RETRIES
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_exception_returns_empty(
+        self, mock_prompt, mock_config, mock_model, manifest_file
+    ):
+        model, structured = mock_model
+        structured.invoke.side_effect = RuntimeError("LLM error")
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = ManifestAnalysisService(model)
+        result = svc.analyze(manifest_file)
+        assert isinstance(result, ManifestExecutionAnalysis)
+        assert result.resources == []
+
+
+class TestHieraDataAnalysisService:
+    def test_file_not_found_returns_empty(self, mock_model):
+        model, _ = mock_model
+        svc = HieraDataAnalysisService(model)
+        result = svc.analyze(Path("/nonexistent/common.yaml"))
+        assert isinstance(result, HieraDataAnalysis)
+        assert result.variables == []
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_retry_on_none_then_succeeds(
+        self, mock_prompt, mock_config, mock_model, hiera_file
+    ):
+        model, structured = mock_model
+        expected = HieraDataAnalysis(variables=[])
+        structured.invoke.side_effect = [None, None, expected]
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = HieraDataAnalysisService(model)
+        result = svc.analyze(hiera_file, hierarchy_level="Common")
+        assert result == expected
+        assert structured.invoke.call_count == 3
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_uses_split_messages(
+        self, mock_prompt, mock_config, mock_model, hiera_file
+    ):
+        model, structured = mock_model
+        structured.invoke.return_value = HieraDataAnalysis()
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = HieraDataAnalysisService(model)
+        svc.analyze(hiera_file, hierarchy_level="Common", full_hierarchy="common.yaml")
+
+        messages = structured.invoke.call_args[0][0]
+        assert isinstance(messages[0], SystemMessage)
+        assert isinstance(messages[1], HumanMessage)
+
+
+class TestTemplateAnalysisService:
+    def test_file_not_found_returns_empty(self, mock_model):
+        model, _ = mock_model
+        svc = TemplateAnalysisService(model)
+        result = svc.analyze(Path("/nonexistent/template.erb"))
+        assert isinstance(result, PuppetTemplateAnalysis)
+        assert result.template_type == "unknown"
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_erb_template_type(
+        self, mock_prompt, mock_config, mock_model, template_file
+    ):
+        model, structured = mock_model
+        structured.invoke.return_value = PuppetTemplateAnalysis(template_type="erb")
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = TemplateAnalysisService(model)
+        result = svc.analyze(template_file)
+        assert result.template_type == "erb"
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_epp_template_type(self, mock_prompt, mock_config, mock_model, tmp_path):
+        model, structured = mock_model
+        epp_file = tmp_path / "backend.conf.epp"
+        epp_file.write_text("<%= $port %>")
+        structured.invoke.return_value = PuppetTemplateAnalysis(template_type="epp")
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = TemplateAnalysisService(model)
+        result = svc.analyze(epp_file)
+        assert result.template_type == "epp"
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_retry_exhausted_returns_correct_template_type(
+        self, mock_prompt, mock_config, mock_model, template_file
+    ):
+        model, structured = mock_model
+        structured.invoke.return_value = None
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = TemplateAnalysisService(model)
+        result = svc.analyze(template_file)
+        assert result.template_type == "erb"
+        assert structured.invoke.call_count == MAX_STRUCTURED_RETRIES
+
+
+class TestCustomTypeAnalysisService:
+    def test_file_not_found_returns_unknown(self, mock_model):
+        model, _ = mock_model
+        svc = CustomTypeAnalysisService(model)
+        result = svc.analyze(Path("/nonexistent/custom.rb"))
+        assert result.component_type == "unknown"
+        assert result.name == "unknown"
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_retry_exhausted_uses_file_stem(
+        self, mock_prompt, mock_config, mock_model, custom_type_file
+    ):
+        model, structured = mock_model
+        structured.invoke.return_value = None
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = CustomTypeAnalysisService(model)
+        result = svc.analyze(custom_type_file)
+        assert result.component_type == "unknown"
+        assert result.name == "haproxy_version"
+
+
+class TestCredentialDetectionService:
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_successful_detection(self, mock_prompt, mock_config, mock_model):
+        model, structured = mock_model
+        expected = CredentialAnalysis(total_detected=2)
+        structured.invoke.return_value = expected
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = CredentialDetectionService(model)
+        result = svc.analyze("vars", "params")
+        assert result.total_detected == 2
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_retry_on_none(self, mock_prompt, mock_config, mock_model):
+        model, structured = mock_model
+        expected = CredentialAnalysis(total_detected=1)
+        structured.invoke.side_effect = [None, expected]
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = CredentialDetectionService(model)
+        result = svc.analyze("vars", "params")
+        assert result.total_detected == 1
+        assert structured.invoke.call_count == 2
+
+    @patch("src.inputs.puppet.services.get_runnable_config", return_value={})
+    @patch("src.inputs.puppet.services.get_prompt")
+    def test_all_retries_exhausted(self, mock_prompt, mock_config, mock_model):
+        model, structured = mock_model
+        structured.invoke.return_value = None
+        mock_prompt.return_value.format.return_value = "prompt"
+
+        svc = CredentialDetectionService(model)
+        result = svc.analyze("vars", "params")
+        assert isinstance(result, CredentialAnalysis)
+        assert result.total_detected == 0
+        assert structured.invoke.call_count == MAX_STRUCTURED_RETRIES

--- a/tests/inputs/puppet/test_state.py
+++ b/tests/inputs/puppet/test_state.py
@@ -1,0 +1,102 @@
+"""Tests for Puppet analysis state management."""
+
+from pathlib import Path
+
+from src.inputs.puppet.models import HieraHierarchy, HieraLevel
+from src.inputs.puppet.state import PuppetState
+
+
+class TestPuppetState:
+    """Test PuppetState dataclass."""
+
+    def _make_state(self, **overrides) -> PuppetState:
+        return PuppetState(
+            user_message=overrides.pop("user_message", "Migrate HAProxy module"),
+            path=overrides.pop("path", "profile_haproxy"),
+            specification=overrides.pop("specification", ""),
+            **overrides,
+        )
+
+    def test_defaults(self):
+        state = self._make_state()
+        assert state.user_message == "Migrate HAProxy module"
+        assert state.path == "profile_haproxy"
+        assert state.specification == ""
+        assert state.dependency_paths == []
+        assert state.dependency_info == []
+        assert state.export_path is None
+        assert state.hiera_hierarchy is None
+        assert state.structured_analysis is None
+        assert state.execution_tree_summary == ""
+        assert state.credentials_analysis is None
+        assert state.variables_summary == ""
+        assert state.failed is False
+        assert state.failure_reason == ""
+
+    def test_update_returns_new_instance(self):
+        state = self._make_state()
+        new_state = state.update(specification="# Migration Plan")
+        assert new_state is not state
+        assert new_state.specification == "# Migration Plan"
+        assert state.specification == ""
+
+    def test_update_preserves_other_fields(self):
+        state = self._make_state(
+            dependency_paths=["puppetlabs-stdlib"],
+            dependency_info=[{"name": "puppetlabs-stdlib", "source": "forge"}],
+        )
+        new_state = state.update(specification="updated")
+        assert new_state.dependency_paths == ["puppetlabs-stdlib"]
+        assert new_state.dependency_info[0]["name"] == "puppetlabs-stdlib"
+        assert new_state.path == "profile_haproxy"
+
+    def test_mark_failed(self):
+        state = self._make_state()
+        failed = state.mark_failed("No manifests/ directory found")
+        assert failed.failed is True
+        assert failed.failure_reason == "No manifests/ directory found"
+        assert state.failed is False
+
+    def test_all_paths_without_deps(self):
+        state = self._make_state()
+        paths = state.all_paths
+        assert len(paths) == 1
+        assert paths[0] == Path("profile_haproxy")
+
+    def test_all_paths_with_deps(self):
+        state = self._make_state(
+            dependency_paths=["stdlib", "concat"],
+        )
+        paths = state.all_paths
+        assert len(paths) == 3
+        assert Path("profile_haproxy") in paths
+        assert Path("stdlib") in paths
+        assert Path("concat") in paths
+
+    def test_update_hiera_hierarchy(self):
+        state = self._make_state()
+        hierarchy = HieraHierarchy(
+            version=5,
+            levels=[HieraLevel(name="Common", path_pattern="common.yaml")],
+            total_data_files=1,
+        )
+        new_state = state.update(hiera_hierarchy=hierarchy)
+        assert new_state.hiera_hierarchy is hierarchy
+        assert new_state.hiera_hierarchy.version == 5
+        assert len(new_state.hiera_hierarchy.levels) == 1
+        assert state.hiera_hierarchy is None
+
+    def test_update_dependency_info(self):
+        state = self._make_state()
+        deps = [
+            {"name": "stdlib", "source": "forge", "version": "9.0.0"},
+            {
+                "name": "custom",
+                "source": "git",
+                "url": "https://git.example.com/custom.git",
+            },
+        ]
+        new_state = state.update(dependency_info=deps)
+        assert len(new_state.dependency_info) == 2
+        assert new_state.dependency_info[0]["source"] == "forge"
+        assert new_state.dependency_info[1]["source"] == "git"

--- a/tools/ansible_write.py
+++ b/tools/ansible_write.py
@@ -636,6 +636,8 @@ class AnsibleWriteInput(BaseModel):
 class AnsibleWriteTool(X2ATool):
     """Validates and writes Ansible YAML files with Jinja2 support."""
 
+    _active_checklist: ClassVar[Any] = None
+
     name: str = "ansible_write"
     description: str = (
         "Validates and writes Ansible YAML files (.yml, .yaml). "
@@ -869,6 +871,15 @@ class AnsibleWriteTool(X2ATool):
         """Validate Ansible YAML content and write to file."""
         slog = self.log.bind(file_path=file_path)
         slog.debug(f"AnsibleWriteTool called on {file_path}")
+
+        if self._active_checklist:
+            for item in self._active_checklist.items:
+                if item.target_path == file_path and item.status.value == "complete":
+                    slog.info(f"Blocked write to completed file: {file_path}")
+                    return (
+                        f"ERROR: {file_path} is already marked 'complete' in the checklist. "
+                        "Do NOT overwrite completed files. Skip this item."
+                    )
 
         yaml_content = yaml_content.replace("\\n", "\n")
 

--- a/tools/ansible_write.py
+++ b/tools/ansible_write.py
@@ -873,8 +873,12 @@ class AnsibleWriteTool(X2ATool):
         slog.debug(f"AnsibleWriteTool called on {file_path}")
 
         if self._active_checklist:
+            norm = file_path.lstrip("./")
             for item in self._active_checklist.items:
-                if item.target_path == file_path and item.status.value == "complete":
+                if (
+                    item.target_path.lstrip("./") == norm
+                    and item.status.value == "complete"
+                ):
                     slog.info(f"Blocked write to completed file: {file_path}")
                     return (
                         f"ERROR: {file_path} is already marked 'complete' in the checklist. "

--- a/tools/validated_write.py
+++ b/tools/validated_write.py
@@ -52,8 +52,12 @@ class ValidatedWriteTool(X2ATool):
     def _run(self, file_path: str, text: str, append: bool = False) -> str:
         """Route to appropriate tool based on file extension."""
         if self._active_checklist:
+            norm = file_path.lstrip("./")
             for item in self._active_checklist.items:
-                if item.target_path == file_path and item.status.value == "complete":
+                if (
+                    item.target_path.lstrip("./") == norm
+                    and item.status.value == "complete"
+                ):
                     return (
                         f"ERROR: {file_path} is already marked 'complete' in the checklist. "
                         "Do NOT overwrite completed files. Skip this item."

--- a/tools/validated_write.py
+++ b/tools/validated_write.py
@@ -1,7 +1,7 @@
 """Validated write tool that automatically routes YAML files to ansible_write."""
 
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 from langchain_community.tools.file_management.write import WriteFileTool
 from pydantic import BaseModel, Field
@@ -33,6 +33,8 @@ class ValidatedWriteTool(X2ATool):
     returned to the model which can fix and retry.
     """
 
+    _active_checklist: ClassVar[Any] = None
+
     name: str = "write_file"
     description: str = (
         "Write text content to a file. Creates parent directories if needed. "
@@ -48,17 +50,15 @@ class ValidatedWriteTool(X2ATool):
 
     # pyrefly: ignore
     def _run(self, file_path: str, text: str, append: bool = False) -> str:
-        """Route to appropriate tool based on file extension.
+        """Route to appropriate tool based on file extension."""
+        if self._active_checklist:
+            for item in self._active_checklist.items:
+                if item.target_path == file_path and item.status.value == "complete":
+                    return (
+                        f"ERROR: {file_path} is already marked 'complete' in the checklist. "
+                        "Do NOT overwrite completed files. Skip this item."
+                    )
 
-        Args:
-            file_path: Path to write to
-            text: Content to write
-            append: Whether to append or overwrite (ignored for YAML files)
-
-        Returns:
-            Success message or validation error for YAML files
-        """
-        # Check file extension
         path = Path(file_path)
 
         # YAML files get automatic validation via ansible_write


### PR DESCRIPTION
## Summary

Adds a **Puppet input agent** — Puppet modules (manifests, Hiera data, templates, custom types/facts) can now be migrated to Ansible roles.

### What's included

- **Puppet analyzer** (`src/inputs/puppet/`): Multi-stage pipeline that parses Puppet modules using deterministic parsers + LLM-powered structured analysis, followed by validation and cleanup agents that produce the final report.
- **Deterministic parsers**: `hiera_parser.py` for `hiera.yaml` hierarchy, `execution_tree_builder.py` for class dependency trees, `dependency_fetcher.py` for Puppet Forge resolution.
- **Analysis services** (`services.py`): Five services (manifest, hiera, template, custom type, credential detection) with retry logic and `SystemMessage`/`HumanMessage` splitting for broad model compatibility.
- **Hiera-to-Ansible vars generator** (`hiera_vars_generator.py`): Maps Hiera hierarchy levels to `defaults/main.yml`, `vars/main.yml`, `group_vars/`.
- **Puppet-aware write agent**: Extended `WriteAgent` with `write_from_puppet.md` prompt for Puppet-specific migration guidance.
- **Structured output resilience** (`migrate.py`): Text fallback + retry for `_read_source_metadata` so models that return plain JSON instead of tool calls still work.
- **Prompts**: 12 new prompt files for Puppet analysis, credential detection, and migration.

### Testing

- 28 new tests across 8 files covering parsers, models, services (retry/fallback/message format), state, and migrate text fallback.
- Validated end-to-end with a synthetic `profile_haproxy` module across 3 models (Claude, devstral, gpt-oss).
- Example for migrated puppet code: https://github.com/elai-shalev/puppet-to-ansible-example

### Model compatibility fixes

Non-Claude models intermittently (tested: mistral.devstral-2-123b, openai.gpt-oss-120b-1:0) fail `with_structured_output()` — returning plain JSON text instead of tool calls. This PR adds retry loops, proper message splitting, and text fallback parsing to handle it gracefully.

#### Note
openai.gpt-oss-120b-1:0 is unable to fully perform the migration