### PR TITLE
Clean-up Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,6 @@ run-migrate:
 	rm -rf ./examples/$(name)/ansible
 	uv run app.py migrate \
 	  --source-dir ./examples/$(name) \
-	  --module $(module) \
 	  --source-technology Chef --high-level-migration-plan migration-plan.md \
 	  --module-migration-plan migration-plan-hello_world.md \
 	  "Convert the hello_world cookbook"


### PR DESCRIPTION
Makefile: removing `--module` from the `migrate` phase, not used anymore