### PR TITLE
fix: Input agents services using BaseAgent

### DIFF
--- a/src/inputs/ansible/analyzer.py
+++ b/src/inputs/ansible/analyzer.py
@@ -29,6 +29,7 @@ from src.inputs.ansible.services import (
 from src.inputs.ansible.state import AnsibleAnalysisState
 from src.model import get_model, get_runnable_config
 from src.types import Telemetry
+from src.types.file_analysis_state import FileAnalysisState
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -163,26 +164,32 @@ class AnsibleSubagent:
         base_path = Path(state.path)
 
         # Analyze tasks
-        tasks_files = self._analyze_yaml_files(base_path / "tasks", "tasks", slog)
+        tasks_files = self._analyze_yaml_files(
+            base_path / "tasks", "tasks", slog, telemetry=state.telemetry
+        )
 
         # Analyze handlers
         handlers_files = self._analyze_yaml_files(
-            base_path / "handlers", "handlers", slog
+            base_path / "handlers", "handlers", slog, telemetry=state.telemetry
         )
 
         # Analyze defaults
         defaults_files = self._analyze_vars_files(
-            base_path / "defaults", "defaults", slog
+            base_path / "defaults", "defaults", slog, telemetry=state.telemetry
         )
 
         # Analyze vars
-        vars_files = self._analyze_vars_files(base_path / "vars", "vars", slog)
+        vars_files = self._analyze_vars_files(
+            base_path / "vars", "vars", slog, telemetry=state.telemetry
+        )
 
         # Analyze meta
-        meta = self._analyze_meta(base_path / "meta", slog)
+        meta = self._analyze_meta(base_path / "meta", slog, telemetry=state.telemetry)
 
         # Analyze templates
-        templates = self._analyze_templates(base_path / "templates", slog)
+        templates = self._analyze_templates(
+            base_path / "templates", slog, telemetry=state.telemetry
+        )
 
         # Collect static files
         static_files = self._collect_static_files(base_path / "files", slog)
@@ -214,7 +221,11 @@ class AnsibleSubagent:
         )
 
     def _analyze_yaml_files(
-        self, directory: Path, file_type: str, slog
+        self,
+        directory: Path,
+        file_type: str,
+        slog,
+        telemetry: Telemetry | None = None,
     ) -> list[TaskFileAnalysisResult]:
         """Analyze YAML task/handler files in a directory."""
         results: list[TaskFileAnalysisResult] = []
@@ -228,12 +239,17 @@ class AnsibleSubagent:
 
             try:
                 slog.debug(f"Analyzing {file_type}: {file_path}")
-                analysis = self._task_service.analyze(file_path)
+                file_state = FileAnalysisState(
+                    path=str(file_path),
+                    user_message="",
+                    telemetry=telemetry,
+                )
+                result_state = self._task_service(file_state)
                 results.append(
                     TaskFileAnalysisResult(
                         file_path=str(file_path),
                         file_type=file_type,
-                        analysis=analysis,
+                        analysis=result_state.result,
                     )
                 )
             except Exception as e:
@@ -242,7 +258,11 @@ class AnsibleSubagent:
         return results
 
     def _analyze_vars_files(
-        self, directory: Path, file_type: str, slog
+        self,
+        directory: Path,
+        file_type: str,
+        slog,
+        telemetry: Telemetry | None = None,
     ) -> list[VariablesAnalysisResult]:
         """Analyze defaults/vars YAML files in a directory."""
         results: list[VariablesAnalysisResult] = []
@@ -256,12 +276,17 @@ class AnsibleSubagent:
 
             try:
                 slog.debug(f"Analyzing {file_type}: {file_path}")
-                analysis = self._vars_service.analyze(file_path)
+                file_state = FileAnalysisState(
+                    path=str(file_path),
+                    user_message="",
+                    telemetry=telemetry,
+                )
+                result_state = self._vars_service(file_state)
                 results.append(
                     VariablesAnalysisResult(
                         file_path=str(file_path),
                         file_type=file_type,
-                        analysis=analysis,
+                        analysis=result_state.result,
                     )
                 )
             except Exception as e:
@@ -269,7 +294,9 @@ class AnsibleSubagent:
 
         return results
 
-    def _analyze_meta(self, directory: Path, slog) -> MetaAnalysisResult | None:
+    def _analyze_meta(
+        self, directory: Path, slog, telemetry: Telemetry | None = None
+    ) -> MetaAnalysisResult | None:
         """Analyze meta/main.yml if it exists."""
         if not directory.exists():
             return None
@@ -282,16 +309,23 @@ class AnsibleSubagent:
 
         try:
             slog.debug(f"Analyzing meta: {meta_file}")
-            analysis = self._meta_service.analyze(meta_file)
+            file_state = FileAnalysisState(
+                path=str(meta_file),
+                user_message="",
+                telemetry=telemetry,
+            )
+            result_state = self._meta_service(file_state)
             return MetaAnalysisResult(
                 file_path=str(meta_file),
-                analysis=analysis,
+                analysis=result_state.result,
             )
         except Exception as e:
             slog.warning(f"Failed to analyze meta {meta_file}: {e}")
             return None
 
-    def _analyze_templates(self, directory: Path, slog) -> list[TemplateAnalysisResult]:
+    def _analyze_templates(
+        self, directory: Path, slog, telemetry: Telemetry | None = None
+    ) -> list[TemplateAnalysisResult]:
         """Analyze .j2 template files."""
         results: list[TemplateAnalysisResult] = []
 
@@ -301,11 +335,16 @@ class AnsibleSubagent:
         for file_path in sorted(directory.rglob("*.j2")):
             try:
                 slog.debug(f"Analyzing template: {file_path}")
-                analysis = self._template_service.analyze(file_path)
+                file_state = FileAnalysisState(
+                    path=str(file_path),
+                    user_message="",
+                    telemetry=telemetry,
+                )
+                result_state = self._template_service(file_state)
                 results.append(
                     TemplateAnalysisResult(
                         file_path=str(file_path),
-                        analysis=analysis,
+                        analysis=result_state.result,
                     )
                 )
             except Exception as e:

--- a/src/inputs/ansible/services.py
+++ b/src/inputs/ansible/services.py
@@ -7,7 +7,9 @@ Each service has a single responsibility (SRP).
 from pathlib import Path
 
 from prompts.get_prompt import get_prompt
-from src.model import get_runnable_config
+from src.inputs.input_agent import InputAgent
+from src.types.file_analysis_state import FileAnalysisState
+from src.types.telemetry import AgentMetrics
 from src.utils.logging import get_logger
 
 from .models import (
@@ -20,20 +22,19 @@ from .models import (
 logger = get_logger(__name__)
 
 
-class TaskFileAnalysisService:
+class TaskFileAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Ansible task/handler files using LLM.
 
     Responsibility: Extract execution structure from tasks/*.yml and handlers/*.yml files.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> TaskFileExecutionAnalysis:
-        """Analyze task/handler file and extract execution structure."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return TaskFileExecutionAnalysis(tasks=[])
+            return state.update(result=TaskFileExecutionAnalysis(tasks=[]))
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("ansible_task_analysis_system").format()
@@ -42,34 +43,33 @@ class TaskFileAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(
-                TaskFileExecutionAnalysis
-            )
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(
+                TaskFileExecutionAnalysis, messages, metrics
             )
             logger.info(f"Extracted {len(result.tasks)} tasks from {file_path.name}")
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze {file_path}: {e}")
-            return TaskFileExecutionAnalysis(tasks=[])
+            return state.update(result=TaskFileExecutionAnalysis(tasks=[]))
 
 
-class VariablesAnalysisService:
+class VariablesAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Ansible defaults/vars files using LLM.
 
     Responsibility: Extract variables and flag legacy patterns from defaults/vars YAML files.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> VariablesAnalysis:
-        """Analyze defaults/vars file and extract variables."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return VariablesAnalysis()
+            return state.update(result=VariablesAnalysis())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("ansible_defaults_analysis_system").format()
@@ -78,34 +78,33 @@ class VariablesAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(VariablesAnalysis)
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(VariablesAnalysis, messages, metrics)
             logger.info(
                 f"Extracted {len(result.variables)} variables from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze {file_path}: {e}")
-            return VariablesAnalysis()
+            return state.update(result=VariablesAnalysis())
 
 
-class MetaAnalysisService:
+class MetaAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Ansible meta/main.yml files using LLM.
 
     Responsibility: Extract role metadata and dependencies.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> MetaAnalysis:
-        """Analyze meta/main.yml and extract metadata."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return MetaAnalysis()
+            return state.update(result=MetaAnalysis())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("ansible_meta_analysis_system").format()
@@ -114,34 +113,34 @@ class MetaAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(MetaAnalysis)
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(MetaAnalysis, messages, metrics)
             logger.info(
-                f"Extracted metadata for role '{result.role_name}' from {file_path.name}"
+                f"Extracted metadata for role '{result.role_name}' "
+                f"from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze {file_path}: {e}")
-            return MetaAnalysis()
+            return state.update(result=MetaAnalysis())
 
 
-class TemplateAnalysisService:
+class TemplateAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Jinja2 template files using LLM.
 
     Responsibility: Extract variables and flag deprecated Jinja2 patterns from .j2 files.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> TemplateAnalysis:
-        """Analyze .j2 template and extract variables and patterns."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return TemplateAnalysis()
+            return state.update(result=TemplateAnalysis())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("ansible_template_analysis_system").format()
@@ -150,15 +149,16 @@ class TemplateAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(TemplateAnalysis)
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(TemplateAnalysis, messages, metrics)
             logger.info(
-                f"Extracted {len(result.variables_used)} variables from template {file_path.name}"
+                f"Extracted {len(result.variables_used)} variables "
+                f"from template {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze template {file_path}: {e}")
-            return TemplateAnalysis()
+            return state.update(result=TemplateAnalysis())

--- a/src/inputs/chef/analyzer.py
+++ b/src/inputs/chef/analyzer.py
@@ -16,6 +16,7 @@ from src.inputs.chef.report_writer_agent import ReportWriterAgent
 from src.inputs.chef.state import ChefState
 from src.model import get_model, get_runnable_config
 from src.types import Telemetry
+from src.types.file_analysis_state import FileAnalysisState
 from src.utils.logging import get_logger
 
 from .dependency_fetcher import ChefDependencyManager
@@ -169,6 +170,7 @@ class ChefSubagent:
         analysis_service,
         result_class,
         slog,
+        telemetry: Telemetry | None = None,
     ) -> list:
         """Generic method to analyze Chef files matching a pattern."""
         results = []
@@ -181,9 +183,17 @@ class ChefSubagent:
             for file_path in path.glob(pattern):
                 try:
                     slog.debug(f"Analyzing {file_type}: {file_path}")
-                    analysis = analysis_service.analyze(file_path)
+                    file_state = FileAnalysisState(
+                        path=str(file_path),
+                        user_message="",
+                        telemetry=telemetry,
+                    )
+                    result_state = analysis_service(file_state)
                     results.append(
-                        result_class(file_path=str(file_path), analysis=analysis)
+                        result_class(
+                            file_path=str(file_path),
+                            analysis=result_state.result,
+                        )
                     )
                 except Exception as e:
                     slog.warning(f"Failed to analyze {file_type} {file_path}: {e}")
@@ -262,6 +272,7 @@ class ChefSubagent:
             analysis_service=self._attribute_service,
             result_class=AttributesAnalysisResult,
             slog=slog,
+            telemetry=state.telemetry,
         )
         attribute_collections = self._build_attribute_collections(attributes, slog)
         slog.info(f"Built iteration map with {len(attribute_collections)} collections")
@@ -275,6 +286,7 @@ class ChefSubagent:
             analysis_service=self._recipe_service,
             result_class=RecipeAnalysisResult,
             slog=slog,
+            telemetry=state.telemetry,
         )
         providers = self._analyze_files_by_pattern(
             paths=state.all_paths,
@@ -283,6 +295,7 @@ class ChefSubagent:
             analysis_service=self._provider_service,
             result_class=ProviderAnalysisResult,
             slog=slog,
+            telemetry=state.telemetry,
         )
 
         structured_analysis = StructuredAnalysis(

--- a/src/inputs/chef/services.py
+++ b/src/inputs/chef/services.py
@@ -7,7 +7,9 @@ Each service has a single responsibility (SRP).
 from pathlib import Path
 
 from prompts.get_prompt import get_prompt
-from src.model import get_runnable_config
+from src.inputs.input_agent import InputAgent
+from src.types.file_analysis_state import FileAnalysisState
+from src.types.telemetry import AgentMetrics
 from src.utils.logging import get_logger
 
 from .models import (
@@ -19,27 +21,19 @@ from .models import (
 logger = get_logger(__name__)
 
 
-class RecipeAnalysisService:
+class RecipeAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Chef recipe files using LLM.
 
     Responsibility: Extract execution order from recipe files.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> RecipeExecutionAnalysis:
-        """Analyze recipe and extract execution order.
-
-        Args:
-            file_path: Path to recipe file
-
-        Returns:
-            RecipeExecutionAnalysis with execution_order
-        """
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return RecipeExecutionAnalysis(execution_order=[])
+            return state.update(result=RecipeExecutionAnalysis(execution_order=[]))
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("chef_recipe_analysis_system").format()
@@ -48,44 +42,34 @@ class RecipeAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(
-                RecipeExecutionAnalysis
-            )
-            # Combine system and task prompts into a single message
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(RecipeExecutionAnalysis, messages, metrics)
             logger.info(
-                f"✓ Extracted {len(result.execution_order)} execution items from {file_path.name}"
+                f"Extracted {len(result.execution_order)} execution items "
+                f"from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze {file_path}: {e}")
-            return RecipeExecutionAnalysis(execution_order=[])
+            return state.update(result=RecipeExecutionAnalysis(execution_order=[]))
 
 
-class ProviderAnalysisService:
+class ProviderAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Chef provider files using LLM.
 
     Responsibility: Extract templates and resources created by providers.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> ProviderAnalysisOutput:
-        """Analyze provider and extract templates/resources created.
-
-        Args:
-            file_path: Path to provider file
-
-        Returns:
-            ProviderAnalysisOutput with templates and conditionals
-        """
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"Provider not found: {file_path}")
-            return ProviderAnalysisOutput()
+            return state.update(result=ProviderAnalysisOutput())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("chef_provider_analysis_system").format()
@@ -94,45 +78,35 @@ class ProviderAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(
-                ProviderAnalysisOutput
-            )
-            # Combine system and task prompts into a single message
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(ProviderAnalysisOutput, messages, metrics)
             logger.info(
-                f"✓ Provider {file_path.name} has {len(result.unconditional_templates)} unconditional templates, "
+                f"Provider {file_path.name} has "
+                f"{len(result.unconditional_templates)} unconditional templates, "
                 f"{len(result.conditionals)} conditional branches"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze provider {file_path}: {e}")
-            return ProviderAnalysisOutput()
+            return state.update(result=ProviderAnalysisOutput())
 
 
-class AttributeAnalysisService:
+class AttributeAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing Chef attributes files using LLM.
 
     Responsibility: Extract default attribute values from attributes/default.rb.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> DefaultAttributesOutput:
-        """Analyze attributes file and extract default values.
-
-        Args:
-            file_path: Path to attributes/default.rb file
-
-        Returns:
-            DefaultAttributesOutput with extracted attributes
-        """
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"Attributes file not found: {file_path}")
-            return DefaultAttributesOutput()
+            return state.update(result=DefaultAttributesOutput())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("chef_attributes_extraction_system").format()
@@ -141,14 +115,11 @@ class AttributeAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(
-                DefaultAttributesOutput
-            )
-            # Combine system and task prompts into a single message
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(DefaultAttributesOutput, messages, metrics)
 
             if result.platform_specific_notes:
                 logger.info("Platform-specific attributes found:")
@@ -156,9 +127,10 @@ class AttributeAnalysisService:
                     logger.info(f"  - {note}")
 
             logger.info(
-                f"✓ Extracted {len(result.attributes)} top-level default attributes from {file_path.name}"
+                f"Extracted {len(result.attributes)} top-level default attributes "
+                f"from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze attributes {file_path}: {e}")
-            return DefaultAttributesOutput()
+            return state.update(result=DefaultAttributesOutput())

--- a/src/inputs/powershell/analyzer.py
+++ b/src/inputs/powershell/analyzer.py
@@ -27,6 +27,7 @@ from src.inputs.powershell.services import (
 from src.inputs.powershell.state import PowerShellAnalysisState
 from src.model import get_model, get_runnable_config
 from src.types import Telemetry
+from src.types.file_analysis_state import FileAnalysisState
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -164,8 +165,10 @@ class PowerShellSubagent:
         ps1_files = list(base_path.rglob("*.ps1"))
         psm1_files = list(base_path.rglob("*.psm1"))
 
-        scripts, dsc_configs = self._analyze_scripts_and_dsc(ps1_files, slog)
-        modules = self._analyze_modules(psm1_files, slog)
+        scripts, dsc_configs = self._analyze_scripts_and_dsc(
+            ps1_files, slog, telemetry=state.telemetry
+        )
+        modules = self._analyze_modules(psm1_files, slog, telemetry=state.telemetry)
 
         structured_analysis = PowerShellStructuredAnalysis(
             scripts=scripts,
@@ -186,7 +189,10 @@ class PowerShellSubagent:
         )
 
     def _analyze_scripts_and_dsc(
-        self, ps1_files: list[Path], slog
+        self,
+        ps1_files: list[Path],
+        slog,
+        telemetry: Telemetry | None = None,
     ) -> tuple[list[ScriptAnalysisResult], list[DSCAnalysisResult]]:
         """Classify and analyze .ps1 files as scripts or DSC configs."""
         scripts: list[ScriptAnalysisResult] = []
@@ -194,9 +200,15 @@ class PowerShellSubagent:
 
         for file_path in ps1_files:
             try:
+                file_state = FileAnalysisState(
+                    path=str(file_path),
+                    user_message="",
+                    telemetry=telemetry,
+                )
                 if self._is_dsc_file(file_path):
                     slog.debug(f"Analyzing DSC config: {file_path}")
-                    analysis = self._dsc_service.analyze(file_path)
+                    result_state = self._dsc_service(file_state)
+                    analysis = result_state.result
                     dsc_configs.append(
                         DSCAnalysisResult(
                             file_path=str(file_path),
@@ -207,7 +219,8 @@ class PowerShellSubagent:
                     )
                 else:
                     slog.debug(f"Analyzing script: {file_path}")
-                    analysis = self._script_service.analyze(file_path)
+                    result_state = self._script_service(file_state)
+                    analysis = result_state.result
                     scripts.append(
                         ScriptAnalysisResult(
                             file_path=str(file_path),
@@ -220,7 +233,10 @@ class PowerShellSubagent:
         return scripts, dsc_configs
 
     def _analyze_modules(
-        self, psm1_files: list[Path], slog
+        self,
+        psm1_files: list[Path],
+        slog,
+        telemetry: Telemetry | None = None,
     ) -> list[ModuleAnalysisResult]:
         """Analyze .psm1 module files."""
         modules: list[ModuleAnalysisResult] = []
@@ -228,7 +244,13 @@ class PowerShellSubagent:
         for file_path in psm1_files:
             try:
                 slog.debug(f"Analyzing module: {file_path}")
-                analysis = self._module_service.analyze(file_path)
+                file_state = FileAnalysisState(
+                    path=str(file_path),
+                    user_message="",
+                    telemetry=telemetry,
+                )
+                result_state = self._module_service(file_state)
+                analysis = result_state.result
                 modules.append(
                     ModuleAnalysisResult(
                         file_path=str(file_path),

--- a/src/inputs/powershell/services.py
+++ b/src/inputs/powershell/services.py
@@ -7,7 +7,9 @@ Each service has a single responsibility (SRP).
 from pathlib import Path
 
 from prompts.get_prompt import get_prompt
-from src.model import get_runnable_config
+from src.inputs.input_agent import InputAgent
+from src.types.file_analysis_state import FileAnalysisState
+from src.types.telemetry import AgentMetrics
 from src.utils.logging import get_logger
 
 from .models import (
@@ -19,20 +21,19 @@ from .models import (
 logger = get_logger(__name__)
 
 
-class ScriptAnalysisService:
+class ScriptAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing PowerShell script files using LLM.
 
     Responsibility: Extract execution order from .ps1 script files.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> ScriptExecutionAnalysis:
-        """Analyze script and extract execution order."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return ScriptExecutionAnalysis(execution_order=[])
+            return state.update(result=ScriptExecutionAnalysis(execution_order=[]))
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("powershell_script_analysis_system").format()
@@ -41,37 +42,34 @@ class ScriptAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(
-                ScriptExecutionAnalysis
-            )
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(ScriptExecutionAnalysis, messages, metrics)
             logger.info(
                 f"Extracted {len(result.execution_order)} execution items "
                 f"from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze {file_path}: {e}")
-            return ScriptExecutionAnalysis(execution_order=[])
+            return state.update(result=ScriptExecutionAnalysis(execution_order=[]))
 
 
-class DSCAnalysisService:
+class DSCAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing PowerShell DSC configuration files using LLM.
 
     Responsibility: Extract DSC resources from Configuration blocks.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> DSCExecutionAnalysis:
-        """Analyze DSC configuration and extract resources."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"File not found: {file_path}")
-            return DSCExecutionAnalysis()
+            return state.update(result=DSCExecutionAnalysis())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("powershell_dsc_analysis_system").format()
@@ -80,34 +78,33 @@ class DSCAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(DSCExecutionAnalysis)
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(DSCExecutionAnalysis, messages, metrics)
             logger.info(
                 f"Extracted {len(result.resources)} DSC resources from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze DSC {file_path}: {e}")
-            return DSCExecutionAnalysis()
+            return state.update(result=DSCExecutionAnalysis())
 
 
-class ModuleAnalysisService:
+class ModuleAnalysisService(InputAgent[FileAnalysisState]):
     """Service for analyzing PowerShell module files using LLM.
 
     Responsibility: Extract exported functions and dependencies from .psm1 files.
     """
 
-    def __init__(self, model):
-        self._model = model
-
-    def analyze(self, file_path: Path) -> ModuleExecutionAnalysis:
-        """Analyze module and extract exports and dependencies."""
+    def execute(
+        self, state: FileAnalysisState, metrics: AgentMetrics | None
+    ) -> FileAnalysisState:
+        file_path = Path(state.path)
         if not file_path.exists():
             logger.warning(f"Module not found: {file_path}")
-            return ModuleExecutionAnalysis()
+            return state.update(result=ModuleExecutionAnalysis())
 
         file_content = file_path.read_text()
         system_prompt = get_prompt("powershell_module_analysis_system").format()
@@ -116,18 +113,16 @@ class ModuleAnalysisService:
         )
 
         try:
-            structured_model = self._model.with_structured_output(
-                ModuleExecutionAnalysis
-            )
-            combined_prompt = f"{system_prompt}\n\n{task_prompt}"
-            result = structured_model.invoke(
-                combined_prompt, config=get_runnable_config()
-            )
+            messages = [
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": task_prompt},
+            ]
+            result = self.invoke_structured(ModuleExecutionAnalysis, messages, metrics)
             logger.info(
                 f"Extracted {len(result.exported_functions)} functions, "
                 f"{len(result.dependencies)} dependencies from {file_path.name}"
             )
-            return result
+            return state.update(result=result)
         except Exception as e:
             logger.error(f"Failed to analyze module {file_path}: {e}")
-            return ModuleExecutionAnalysis()
+            return state.update(result=ModuleExecutionAnalysis())

--- a/src/types/__init__.py
+++ b/src/types/__init__.py
@@ -22,6 +22,7 @@ from .checklist import (
 )
 from .credential import CredentialConfig
 from .document import DocumentFile
+from .file_analysis_state import FileAnalysisState
 from .metadata import MetadataCollection, ModuleMetadata
 from .migration_state import MigrationStateInterface
 from .rule_file import RuleCollection, RuleFile
@@ -40,6 +41,7 @@ __all__ = [
     "ChecklistStatus",
     "CredentialConfig",
     "DocumentFile",
+    "FileAnalysisState",
     "MetadataCollection",
     "MigrationStateInterface",
     "ModuleMetadata",

--- a/src/types/file_analysis_state.py
+++ b/src/types/file_analysis_state.py
@@ -1,0 +1,29 @@
+"""State for per-file analysis by InputAgent services.
+
+Wraps a single file path so that services can be invoked
+via the standard ``service(file_state)`` pattern with
+automatic telemetry from BaseAgent.__call__.
+"""
+
+from dataclasses import dataclass, field, replace
+from typing import Any
+
+from src.types.base_state import BaseState
+
+
+@dataclass
+class FileAnalysisState(BaseState):
+    """State carrying a single file path and its analysis result.
+
+    Attributes:
+        result: Typed analysis output produced by the service
+                (e.g. RecipeExecutionAnalysis, DSCExecutionAnalysis).
+    """
+
+    result: Any = field(default=None, kw_only=True)
+
+    def update(self, **kwargs) -> "FileAnalysisState":
+        return replace(self, **kwargs)
+
+    def mark_failed(self, reason: str) -> "FileAnalysisState":
+        return self.update(failed=True, failure_reason=reason)

--- a/tests/inputs/ansible/test_services.py
+++ b/tests/inputs/ansible/test_services.py
@@ -8,6 +8,11 @@ from src.inputs.ansible.services import (
     TemplateAnalysisService,
     VariablesAnalysisService,
 )
+from src.types.file_analysis_state import FileAnalysisState
+
+
+def _make_file_state(path: str) -> FileAnalysisState:
+    return FileAnalysisState(path=path, user_message="")
 
 
 class TestTaskFileAnalysisService:
@@ -16,13 +21,15 @@ class TestTaskFileAnalysisService:
     def test_returns_empty_for_missing_file(self, tmp_path):
         """Should return empty analysis when file doesn't exist."""
         service = TaskFileAnalysisService(model=None)
-        result = service.analyze(tmp_path / "nonexistent.yml")
+        state = _make_file_state(str(tmp_path / "nonexistent.yml"))
+        result = service(state).result
         assert result.tasks == []
 
     def test_returns_empty_for_missing_file_path(self):
         """Should return empty analysis for non-existent path."""
         service = TaskFileAnalysisService(model=None)
-        result = service.analyze(Path("/nonexistent/tasks/main.yml"))
+        state = _make_file_state(str(Path("/nonexistent/tasks/main.yml")))
+        result = service(state).result
         assert result.tasks == []
 
 
@@ -32,7 +39,8 @@ class TestVariablesAnalysisService:
     def test_returns_empty_for_missing_file(self, tmp_path):
         """Should return empty analysis when file doesn't exist."""
         service = VariablesAnalysisService(model=None)
-        result = service.analyze(tmp_path / "nonexistent.yml")
+        state = _make_file_state(str(tmp_path / "nonexistent.yml"))
+        result = service(state).result
         assert result.variables == {}
         assert result.notes == []
 
@@ -43,7 +51,8 @@ class TestMetaAnalysisService:
     def test_returns_empty_for_missing_file(self, tmp_path):
         """Should return empty analysis when file doesn't exist."""
         service = MetaAnalysisService(model=None)
-        result = service.analyze(tmp_path / "nonexistent.yml")
+        state = _make_file_state(str(tmp_path / "nonexistent.yml"))
+        result = service(state).result
         assert result.role_name == ""
         assert result.dependencies == []
 
@@ -54,7 +63,8 @@ class TestTemplateAnalysisService:
     def test_returns_empty_for_missing_file(self, tmp_path):
         """Should return empty analysis when file doesn't exist."""
         service = TemplateAnalysisService(model=None)
-        result = service.analyze(tmp_path / "nonexistent.j2")
+        state = _make_file_state(str(tmp_path / "nonexistent.j2"))
+        result = service(state).result
         assert result.variables_used == []
         assert result.bare_variables == []
         assert result.deprecated_tests == []


### PR DESCRIPTION
When checking the PR 204[0] I figure it out that there are some modules that are not using the BaseAgent, so skip the Telemetry information and not using the tools on top of the base agent.

This change the input agents to handle it in a better way.

Fix: FLPATH-4208
[0] https://github.com/x2ansible/x2a-convertor/pull/204