### PR TITLE
Fix analyze phase to fail on non-existing module paths

### DIFF
--- a/src/inputs/analyze.py
+++ b/src/inputs/analyze.py
@@ -64,6 +64,9 @@ class MigrationAnalysisWorkflow:
 
     def choose_subagent(self, state: MigrationState) -> MigrationState:
         """Choose and execute the appropriate subagent based on technology."""
+        if state.failed:
+            return state
+
         technology = state.technology
 
         if technology is None:
@@ -97,6 +100,9 @@ class MigrationAnalysisWorkflow:
 
     def write_migration_file(self, state: MigrationState) -> MigrationState:
         """Write the migration plan to a file."""
+        if state.failed:
+            return state
+
         migration_content = state.module_migration_plan
         if not migration_content:
             logger.error("Migration failed, no plan generated")
@@ -136,6 +142,9 @@ def analyze_project(user_requirements: str, source_dir: str = "."):
     # Stop telemetry and save
     telemetry.stop().save()
     logger.info(f"Telemetry summary:\n{telemetry.to_summary()}")
+
+    if result.get("failed"):
+        raise RuntimeError(result.get("failure_reason", "Analysis failed"))
 
     logger.info("Migration analysis completed successfully!")
     return result

--- a/src/inputs/module_selection_agent.py
+++ b/src/inputs/module_selection_agent.py
@@ -4,6 +4,8 @@ This module contains the agent that selects which module to migrate
 based on user input and LLM analysis of the migration plan.
 """
 
+from pathlib import Path
+
 from prompts.get_prompt import get_prompt
 from src.const import METADATA_FILENAME
 from src.inputs.analyze_state import MigrationState, ModuleSelection
@@ -55,6 +57,13 @@ class ModuleSelectionAgent(InputAgent[MigrationState]):
         technology = response.technology
 
         self._record_metrics(metrics, technology, normalized_path)
+
+        if not Path(normalized_path).exists():
+            self._log.error(f"Selected module path does not exist: {normalized_path}")
+            return state.mark_failed(
+                f"Module path not found: '{normalized_path}'. "
+                f"Verify the module name and path in the migration plan."
+            )
 
         self._log.info(
             f"Selected path: '{normalized_path}' technology: '{technology.value}'"


### PR DESCRIPTION
Fixes: FLPATH-4206

The analyze workflow silently produced empty migration plans when given a non-existent module path, reporting success.

Adding path validation after LLM module selection (aligned with the existing check in migrate) and propagate failures to exit with a non-zero code.

---

related to: https://github.com/redhat-developer/rhdh-plugins/pull/3196