### PR TITLE
Adding support for puppet migration - write changes

### DIFF
--- a/prompts/export_ansible_planning_system.md
+++ b/prompts/export_ansible_planning_system.md
@@ -22,33 +22,24 @@ Checklist categories:
 
 Structure Files:
 - List required Ansible role structure files (meta/main.yml, handlers/main.yml, etc.)
-- For meta/main.yml, use metadata.rb (Chef) or metadata.json (Puppet) as source if it exists, otherwise use N/A
-- Format: metadata.rb → meta/main.yml  OR  metadata.json → meta/main.yml  OR  N/A → meta/main.yml
+- For meta/main.yml, use metadata.rb as source if it exists, otherwise use N/A
+- Format: metadata.rb → meta/main.yml  OR  N/A → meta/main.yml
 
 Templates:
-- List all templates that need conversion to Jinja2 (.j2 files)
-- Chef ERB (.erb) and Puppet ERB (.erb) or EPP (.epp) templates
+- List all Chef ERB templates (.erb files) that need conversion to Jinja2 (.j2 files)
 - Format: source/path/template.erb → target/path/template.j2
-- Format: source/path/template.epp → target/path/template.j2
 
 Attributes → Variables:
-- Chef: List all attributes files that need conversion to Ansible variables
-  - Format: attributes/default.rb → defaults/main.yml
-- Puppet: List Hiera data files that need conversion to Ansible variables
-  - Format: data/common.yaml → defaults/main.yml
-  - Format: data/os/Debian.yaml → vars/Debian.yml
-  - Format: data/environment/production.yaml → vars/production.yml
+- List all Chef attributes files that need conversion to Ansible variables
+- Format: attributes/default.rb → defaults/main.yml
 
 Static Files:
 - List all static files that need to be copied from files/ directory
 - Format: files/default/file.conf → files/file.conf
 
 Recipes → Tasks:
-- Chef: List all recipes (.rb files) that need conversion to Ansible tasks (.yml files)
-  - Format: recipes/recipe_name.rb → tasks/recipe_name.yml
-- Puppet: List all manifests (.pp files) that need conversion to Ansible tasks (.yml files)
-  - Format: manifests/install.pp → tasks/install.yml
-  - Format: manifests/config.pp → tasks/config.yml
+- List all Chef recipes (.rb files) that need conversion to Ansible tasks (.yml files)
+- Format: recipes/recipe_name.rb → tasks/recipe_name.yml
 
 
 Dependencies (requirements.yml):

--- a/prompts/export_ansible_planning_system.md
+++ b/prompts/export_ansible_planning_system.md
@@ -1,4 +1,4 @@
-You are a migration planning expert. Your job is to analyze a migration plan (from Chef cookbook or legacy Ansible role) and create a detailed checklist of all files that need to be migrated to modern Ansible.
+You are a migration planning expert. Your job is to analyze a migration plan (from Chef cookbook, Puppet module, or legacy Ansible role) and create a detailed checklist of all files that need to be migrated to modern Ansible.
 
 You have these tools available:
 - list_directory: List directory contents
@@ -10,7 +10,7 @@ You have these tools available:
 
 You will receive:
 1. A migration plan document that describes what needs to be migrated
-2. A directory listing of the Chef cookbook source files
+2. A directory listing of the source files (Chef cookbook, Puppet module, or Ansible role)
 3. An existing checklist (if loaded from a previous run)
 
 Your task is to ensure the checklist is complete:
@@ -22,24 +22,33 @@ Checklist categories:
 
 Structure Files:
 - List required Ansible role structure files (meta/main.yml, handlers/main.yml, etc.)
-- For meta/main.yml, use metadata.rb as source if it exists, otherwise use N/A
-- Format: metadata.rb → meta/main.yml  OR  N/A → meta/main.yml
+- For meta/main.yml, use metadata.rb (Chef) or metadata.json (Puppet) as source if it exists, otherwise use N/A
+- Format: metadata.rb → meta/main.yml  OR  metadata.json → meta/main.yml  OR  N/A → meta/main.yml
 
 Templates:
-- List all Chef ERB templates (.erb files) that need conversion to Jinja2 (.j2 files)
+- List all templates that need conversion to Jinja2 (.j2 files)
+- Chef ERB (.erb) and Puppet ERB (.erb) or EPP (.epp) templates
 - Format: source/path/template.erb → target/path/template.j2
+- Format: source/path/template.epp → target/path/template.j2
 
 Attributes → Variables:
-- List all Chef attributes files that need conversion to Ansible variables
-- Format: attributes/default.rb → defaults/main.yml
+- Chef: List all attributes files that need conversion to Ansible variables
+  - Format: attributes/default.rb → defaults/main.yml
+- Puppet: List Hiera data files that need conversion to Ansible variables
+  - Format: data/common.yaml → defaults/main.yml
+  - Format: data/os/Debian.yaml → vars/Debian.yml
+  - Format: data/environment/production.yaml → vars/production.yml
 
 Static Files:
 - List all static files that need to be copied from files/ directory
 - Format: files/default/file.conf → files/file.conf
 
 Recipes → Tasks:
-- List all Chef recipes (.rb files) that need conversion to Ansible tasks (.yml files)
-- Format: recipes/recipe_name.rb → tasks/recipe_name.yml
+- Chef: List all recipes (.rb files) that need conversion to Ansible tasks (.yml files)
+  - Format: recipes/recipe_name.rb → tasks/recipe_name.yml
+- Puppet: List all manifests (.pp files) that need conversion to Ansible tasks (.yml files)
+  - Format: manifests/install.pp → tasks/install.yml
+  - Format: manifests/config.pp → tasks/config.yml
 
 
 Dependencies (requirements.yml):

--- a/prompts/export_ansible_planning_task.j2
+++ b/prompts/export_ansible_planning_task.j2
@@ -1,12 +1,12 @@
 Create a migration checklist for the module: {{module}}
 
-A high-level migration plan describing all cookbooks in the repository is available at: {{ high_level_migration_plan.path }}
-(Read this file if you need context about how this module relates to other cookbooks in the migration)
+A high-level migration plan describing all modules in the repository is available at: {{ high_level_migration_plan.path }}
+(Read this file if you need context about how this module relates to other modules in the migration)
 
 MODULE MIGRATION PLAN:
 {{module_migration_plan}}
 
-CHEF SOURCE PATH: `{{ path }}`
+SOURCE PATH: `{{ path }}`
 ANSIBLE OUTPUT PATH: `./ansible/roles/{{ module }}`
 
 {% if aap_discovery and aap_discovery.enabled and aap_discovery.content %}
@@ -42,9 +42,9 @@ THEN: USE add_checklist_task TOOL to add ONLY missing migration tasks:
 TOOL: add_checklist_task(category, source_path, target_path, description)
 
 Categories:
-- "templates": ERB templates → Jinja2 templates
-- "recipes": Chef recipes → Ansible tasks
-- "attributes": Chef attributes → Ansible variables
+- "templates": ERB/EPP templates → Jinja2 templates
+- "recipes": Chef recipes (.rb) or Puppet manifests (.pp) → Ansible tasks
+- "attributes": Chef attributes or Puppet Hiera data → Ansible variables
 - "files": Static files (configs, scripts, etc.)
 - "structure": Generated Ansible role structure files (meta/main.yml, handlers/main.yml, etc.)
 - "dependencies": Collection dependencies for requirements.yml
@@ -68,12 +68,14 @@ For target_path, combine ANSIBLE OUTPUT PATH with the relative Ansible role path
 
 Examples:
 - If the File Structure shows "cookbooks/myapp/templates/default/config.erb", use that EXACT path as source_path
+- If the File Structure shows "modules/myapp/templates/config.epp", use that EXACT path as source_path
 - For target_path, use the ANSIBLE OUTPUT PATH + relative role path (e.g., "ansible/roles/myapp/templates/config.j2")
 - For generated Ansible structure files, use source_path="N/A"
 
 Sample calls (replace {{module}} with actual module name from ANSIBLE OUTPUT PATH):
 - add_checklist_task(category="templates", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/templates/config.j2", description="Configuration template")
-- add_checklist_task(category="recipes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/tasks/main.yml", description="Main recipe tasks")
+- add_checklist_task(category="recipes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/tasks/main.yml", description="Main tasks")
+- add_checklist_task(category="attributes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/defaults/main.yml", description="Default variables")
 - add_checklist_task(category="structure", source_path="N/A", target_path="ansible/roles/{{module}}/meta/main.yml", description="Role metadata")
 - add_checklist_task(category="dependencies", source_path="collection:namespace.collection_name", target_path="ansible/roles/{{module}}/requirements.yml", description="External collection dependency")
 

--- a/prompts/export_ansible_planning_task.j2
+++ b/prompts/export_ansible_planning_task.j2
@@ -42,9 +42,9 @@ THEN: USE add_checklist_task TOOL to add ONLY missing migration tasks:
 TOOL: add_checklist_task(category, source_path, target_path, description)
 
 Categories:
-- "templates": ERB/EPP templates → Jinja2 templates
-- "recipes": Chef recipes (.rb) or Puppet manifests (.pp) → Ansible tasks
-- "attributes": Chef attributes or Puppet Hiera data → Ansible variables
+- "templates": ERB templates → Jinja2 templates
+- "recipes": Chef recipes → Ansible tasks
+- "attributes": Chef attributes → Ansible variables
 - "files": Static files (configs, scripts, etc.)
 - "structure": Generated Ansible role structure files (meta/main.yml, handlers/main.yml, etc.)
 - "dependencies": Collection dependencies for requirements.yml
@@ -68,14 +68,12 @@ For target_path, combine ANSIBLE OUTPUT PATH with the relative Ansible role path
 
 Examples:
 - If the File Structure shows "cookbooks/myapp/templates/default/config.erb", use that EXACT path as source_path
-- If the File Structure shows "modules/myapp/templates/config.epp", use that EXACT path as source_path
 - For target_path, use the ANSIBLE OUTPUT PATH + relative role path (e.g., "ansible/roles/myapp/templates/config.j2")
 - For generated Ansible structure files, use source_path="N/A"
 
 Sample calls (replace {{module}} with actual module name from ANSIBLE OUTPUT PATH):
 - add_checklist_task(category="templates", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/templates/config.j2", description="Configuration template")
-- add_checklist_task(category="recipes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/tasks/main.yml", description="Main tasks")
-- add_checklist_task(category="attributes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/defaults/main.yml", description="Default variables")
+- add_checklist_task(category="recipes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/tasks/main.yml", description="Main recipe tasks")
 - add_checklist_task(category="structure", source_path="N/A", target_path="ansible/roles/{{module}}/meta/main.yml", description="Role metadata")
 - add_checklist_task(category="dependencies", source_path="collection:namespace.collection_name", target_path="ansible/roles/{{module}}/requirements.yml", description="External collection dependency")
 

--- a/prompts/export_ansible_validation_task.j2
+++ b/prompts/export_ansible_validation_task.j2
@@ -50,7 +50,7 @@ Using the wrong tool will break files! Always check the file extension before wr
 ## Context
 
 Module: {{ module }}
-Chef Source: {{ chef_path }}
+Source: {{ chef_path }}
 Ansible Output: {{ ansible_path }}
 
 ## Error Report

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -20,46 +20,20 @@ OPTIONAL: After writing files, you can run ansible_lint on the output directory 
 Key conversion rules:
 
 TEMPLATES (.erb / .epp → .j2):
-CRITICAL: You MUST read the source template file and convert its actual content to Jinja2 format.
+CRITICAL: You MUST read the source .erb file and convert its actual content to Jinja2 format.
 NEVER write placeholder variables like {% raw %}{{ template_name_content }}{% endraw %} - this is wrong!
 
 Step-by-step process for EVERY template:
-1. Use read_file to read the source template file (.erb or .epp)
-2. Convert the syntax to Jinja2:
-
-Chef/Puppet ERB syntax:{% raw %}
+1. Use read_file to read the Chef ERB source file
+2. Convert the ERB syntax to Jinja2:{% raw %}
    - <%= @variable %> → {{ variable }} (remove @ prefix)
    - <%= variable %> → {{ variable }}
    - <% if @condition %> → {% if condition %}
    - <% @items.each do |item| %> → {% for item in items %}
    - <% end %> → {% endfor %} or {% endif %}{% endraw %}
-
-Puppet EPP syntax:{% raw %}
-   - <%= $variable %> → {{ variable }} (remove $ prefix)
-   - <% if $condition { %> → {% if condition %}
-   - <% unless $condition { %> → {% if not condition %}
-   - <% $items.each |$item| { %> → {% for item in items %}
-   - <% } %> → {% endfor %} or {% endif %}
-   - <%- (trim left) and -%> (trim right) work like {%- and -%} in Jinja2{% endraw %}
-
 3. Write the CONVERTED CONTENT using write_file (NOT ansible_write)
 
-PUPPET VARIABLE NAMING IN TEMPLATES — CRITICAL:
-The migration plan maps Puppet namespaced parameters to Ansible variable names
-(e.g., `profile_haproxy::stats_user` → `haproxy_stats_user`).
-When converting templates, ALWAYS use the Ansible variable name from the migration plan.
-
-WRONG — bare Puppet variable name:{% raw %}
-```
-stats auth {{ stats_user }}:{{ stats_password }}
-```{% endraw %}
-
-CORRECT — Ansible role variable name:{% raw %}
-```
-stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
-```{% endraw %}
-
-Example ERB conversion (Chef/Puppet):
+Example conversion:
 Source ERB (site.conf.erb):
 ```
 server_name <%= @server_name %>;
@@ -82,32 +56,12 @@ root {{ document_root }};
 {% endif %}{% endraw %}
 ```
 
-Example EPP conversion (Puppet):
-Source EPP (backend.conf.epp):
-```
-<%- | String $backend_name, Integer $port, Array $servers | -%>
-backend <%= $backend_name %>
-  balance roundrobin
-<% $servers.each |$server| { -%>
-  server <%= $server %> <%= $server %>:<%= $port %>
-<% } -%>
-```
-
-Correct Jinja2 output (backend.conf.j2):
-```{% raw %}
-backend {{ backend_name }}
-  balance roundrobin
-{% for server in servers %}
-  server {{ server }} {{ server }}:{{ port }}
-{% endfor %}{% endraw %}
-```
-
 WRONG output (do NOT do this):
 ```{% raw %}
 {{ site_conf_content }}{% endraw %}
 ```
 
-If a template has NO template variables (static content), copy it as-is.
+If a template has NO ERB variables (static content), copy it as-is.
 
 TEMPLATE VARIABLE PASSING:
 When a task uses ansible.builtin.template and needs to pass variables into the template, use
@@ -145,23 +99,11 @@ Migrated roles should be portable across OS families unless the source explicitl
   `ansible_os_family` conditionals in defaults/main.yml rather than hardcoding values
 - Put OS-dependent values in defaults/main.yml as variables, not hardcoded in templates or tasks
 
-SOURCE FILES → ANSIBLE TASKS:
-- Convert Chef recipes (.rb) or Puppet manifests (.pp) to Ansible task files (.yml)
-- Use FQCN (Fully Qualified Collection Names): ansible.builtin.package, NOT package
+RECIPES (.rb → .yml tasks):
+- Convert Chef resources to Ansible modules using FQCN (Fully Qualified Collection Names)
+- Example: ansible.builtin.package, NOT package
 - Task files must be a flat list of tasks WITHOUT playbook wrappers (no hosts:, no tasks: wrapper)
 - Use ansible_write tool for task files
-
-Puppet manifest conversion:
-- `package` → `ansible.builtin.package`
-- `service` → `ansible.builtin.service` or `ansible.builtin.systemd`
-- `file` with `content => template(...)` → `ansible.builtin.template`
-- `file` with `source => puppet:///...` → `ansible.builtin.copy`
-- `file` with `ensure => directory` → `ansible.builtin.file` with `state: directory`
-- `exec` → `ansible.builtin.command` with `changed_when`/`creates`/`unless`
-- `cron` → `ansible.builtin.cron`
-- `each` loops → `loop:` with `dict2items` for hashes
-- `if`/`unless`/`case` → `when:` conditions
-- Firewall: prefer `community.general.ufw` module over raw `ansible.builtin.command: ufw`
 
 COMMAND vs SHELL MODULE SELECTION:
 - Use ansible.builtin.command for simple, single commands with no shell operators
@@ -348,63 +290,9 @@ CORRECT task file format:
     state: started
 ```
 
-VARIABLES AND DEFAULTS:
-Chef attributes (attributes/*.rb → defaults/main.yml):
+ATTRIBUTES (attributes/*.rb → defaults/main.yml):
 - Convert Ruby hash syntax to YAML
 - default['key'] = 'value' becomes key: 'value'
-
-Puppet Hiera data (data/*.yaml → defaults/main.yml + vars/):
-- Hiera `common.yaml` → `defaults/main.yml`
-- Strip Puppet namespace: `profile_haproxy::stats_user` → `haproxy_stats_user`
-- Per-OS Hiera data (`os/Debian.yaml`) → `vars/Debian.yml` loaded via `include_vars` based on `ansible_os_family`
-- Per-environment/datacenter/cluster data → `vars/` files loaded via `include_vars`
-- Puppet facts → Ansible facts: `$facts['os']['family']` → `ansible_os_family`, `$facts['networking']['ip']` → `ansible_default_ipv4.address`
-
-DEFAULTS/MAIN.YML — CRITICAL:
-- Values in defaults/main.yml MUST be plain values, NOT Jinja2 references to other variables
-- WRONG: `haproxy_stats_user: "{% raw %}{{ stats_user | default('admin') }}{% endraw %}"`
-- CORRECT: `haproxy_stats_user: admin`
-
-DEEP MERGE for Puppet Hiera variables:
-When the migration plan marks a variable as "deep merged" (e.g., `backends: (type: hash, deep merged)`),
-the variable is defined at multiple Hiera levels and values must be merged recursively, not replaced.
-
-Pattern:
-- Define the base value in `defaults/main.yml` (e.g., `haproxy_backends`)
-- In each vars/ override file, use the `_override` suffix (e.g., `haproxy_backends_override`)
-- In `load_vars.yml`, AFTER each `include_vars`, add a `set_fact` that merges the override into the base
-
-Complete `load_vars.yml` example:
-```yaml{% raw %}
----
-- name: Load OS-specific variables
-  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
-  failed_when: false
-
-- name: Load datacenter-specific variables
-  ansible.builtin.include_vars: "{{ haproxy_datacenter }}.yml"
-  when: haproxy_datacenter is defined
-  failed_when: false
-
-- name: Deep merge datacenter backend overrides
-  ansible.builtin.set_fact:
-    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
-  when: haproxy_backends_override is defined
-
-- name: Load cluster-specific variables
-  ansible.builtin.include_vars: "{{ haproxy_cluster }}.yml"
-  when: haproxy_cluster is defined
-  failed_when: false
-
-- name: Deep merge cluster backend overrides
-  ansible.builtin.set_fact:
-    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
-  when: haproxy_backends_override is defined{% endraw %}
-```
-
-The `_override` variable is loaded by `include_vars` from each level's vars file, then merged into the
-base variable. Each level's merge builds on the previous result, so cluster overrides datacenter
-overrides common — matching Puppet's Hiera precedence.
 
 STATIC FILES:
 - Copy directly from files/default/* to files/* using copy_file tool
@@ -459,6 +347,10 @@ IMPORTANT: Use Ubuntu release names (bionic, focal) NOT version numbers ("18.04"
 
 {% if source_technology == 'Ansible' %}
 {% include 'write_from_ansible.md' %}
+{% endif %}
+
+{% if source_technology == 'Puppet' %}
+{% include 'write_from_puppet.md' %}
 {% endif %}
 
 Do NOT generate molecule files (molecule/default/*) — they are handled by a separate MoleculeAgent.

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -1,5 +1,5 @@
 You are an infrastructure-to-Ansible migration expert. Your job is to write all files from the migration checklist.
-The source may be Chef cookbooks, PowerShell scripts, or legacy Ansible roles — adapt your approach accordingly.
+The source may be Chef cookbooks, Puppet modules, PowerShell scripts, or legacy Ansible roles — adapt your approach accordingly.
 
 You have these tools available:
 - read_file: Read source files to understand what needs to be converted
@@ -19,21 +19,47 @@ OPTIONAL: After writing files, you can run ansible_lint on the output directory 
 
 Key conversion rules:
 
-TEMPLATES (.erb → .j2):
-CRITICAL: You MUST read the source .erb file and convert its actual content to Jinja2 format.
+TEMPLATES (.erb / .epp → .j2):
+CRITICAL: You MUST read the source template file and convert its actual content to Jinja2 format.
 NEVER write placeholder variables like {% raw %}{{ template_name_content }}{% endraw %} - this is wrong!
 
 Step-by-step process for EVERY template:
-1. Use read_file to read the Chef ERB source file
-2. Convert the ERB syntax to Jinja2:{% raw %}
+1. Use read_file to read the source template file (.erb or .epp)
+2. Convert the syntax to Jinja2:
+
+Chef/Puppet ERB syntax:{% raw %}
    - <%= @variable %> → {{ variable }} (remove @ prefix)
    - <%= variable %> → {{ variable }}
    - <% if @condition %> → {% if condition %}
    - <% @items.each do |item| %> → {% for item in items %}
    - <% end %> → {% endfor %} or {% endif %}{% endraw %}
+
+Puppet EPP syntax:{% raw %}
+   - <%= $variable %> → {{ variable }} (remove $ prefix)
+   - <% if $condition { %> → {% if condition %}
+   - <% unless $condition { %> → {% if not condition %}
+   - <% $items.each |$item| { %> → {% for item in items %}
+   - <% } %> → {% endfor %} or {% endif %}
+   - <%- (trim left) and -%> (trim right) work like {%- and -%} in Jinja2{% endraw %}
+
 3. Write the CONVERTED CONTENT using write_file (NOT ansible_write)
 
-Example conversion:
+PUPPET VARIABLE NAMING IN TEMPLATES — CRITICAL:
+The migration plan maps Puppet namespaced parameters to Ansible variable names
+(e.g., `profile_haproxy::stats_user` → `haproxy_stats_user`).
+When converting templates, ALWAYS use the Ansible variable name from the migration plan.
+
+WRONG — bare Puppet variable name:{% raw %}
+```
+stats auth {{ stats_user }}:{{ stats_password }}
+```{% endraw %}
+
+CORRECT — Ansible role variable name:{% raw %}
+```
+stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
+```{% endraw %}
+
+Example ERB conversion (Chef/Puppet):
 Source ERB (site.conf.erb):
 ```
 server_name <%= @server_name %>;
@@ -56,12 +82,32 @@ root {{ document_root }};
 {% endif %}{% endraw %}
 ```
 
+Example EPP conversion (Puppet):
+Source EPP (backend.conf.epp):
+```
+<%- | String $backend_name, Integer $port, Array $servers | -%>
+backend <%= $backend_name %>
+  balance roundrobin
+<% $servers.each |$server| { -%>
+  server <%= $server %> <%= $server %>:<%= $port %>
+<% } -%>
+```
+
+Correct Jinja2 output (backend.conf.j2):
+```{% raw %}
+backend {{ backend_name }}
+  balance roundrobin
+{% for server in servers %}
+  server {{ server }} {{ server }}:{{ port }}
+{% endfor %}{% endraw %}
+```
+
 WRONG output (do NOT do this):
 ```{% raw %}
 {{ site_conf_content }}{% endraw %}
 ```
 
-If a template has NO ERB variables (static content), copy it as-is.
+If a template has NO template variables (static content), copy it as-is.
 
 TEMPLATE VARIABLE PASSING:
 When a task uses ansible.builtin.template and needs to pass variables into the template, use
@@ -99,11 +145,23 @@ Migrated roles should be portable across OS families unless the source explicitl
   `ansible_os_family` conditionals in defaults/main.yml rather than hardcoding values
 - Put OS-dependent values in defaults/main.yml as variables, not hardcoded in templates or tasks
 
-RECIPES (.rb → .yml tasks):
-- Convert Chef resources to Ansible modules using FQCN (Fully Qualified Collection Names)
-- Example: ansible.builtin.package, NOT package
+SOURCE FILES → ANSIBLE TASKS:
+- Convert Chef recipes (.rb) or Puppet manifests (.pp) to Ansible task files (.yml)
+- Use FQCN (Fully Qualified Collection Names): ansible.builtin.package, NOT package
 - Task files must be a flat list of tasks WITHOUT playbook wrappers (no hosts:, no tasks: wrapper)
 - Use ansible_write tool for task files
+
+Puppet manifest conversion:
+- `package` → `ansible.builtin.package`
+- `service` → `ansible.builtin.service` or `ansible.builtin.systemd`
+- `file` with `content => template(...)` → `ansible.builtin.template`
+- `file` with `source => puppet:///...` → `ansible.builtin.copy`
+- `file` with `ensure => directory` → `ansible.builtin.file` with `state: directory`
+- `exec` → `ansible.builtin.command` with `changed_when`/`creates`/`unless`
+- `cron` → `ansible.builtin.cron`
+- `each` loops → `loop:` with `dict2items` for hashes
+- `if`/`unless`/`case` → `when:` conditions
+- Firewall: prefer `community.general.ufw` module over raw `ansible.builtin.command: ufw`
 
 COMMAND vs SHELL MODULE SELECTION:
 - Use ansible.builtin.command for simple, single commands with no shell operators
@@ -290,9 +348,63 @@ CORRECT task file format:
     state: started
 ```
 
-ATTRIBUTES (attributes/*.rb → defaults/main.yml):
+VARIABLES AND DEFAULTS:
+Chef attributes (attributes/*.rb → defaults/main.yml):
 - Convert Ruby hash syntax to YAML
 - default['key'] = 'value' becomes key: 'value'
+
+Puppet Hiera data (data/*.yaml → defaults/main.yml + vars/):
+- Hiera `common.yaml` → `defaults/main.yml`
+- Strip Puppet namespace: `profile_haproxy::stats_user` → `haproxy_stats_user`
+- Per-OS Hiera data (`os/Debian.yaml`) → `vars/Debian.yml` loaded via `include_vars` based on `ansible_os_family`
+- Per-environment/datacenter/cluster data → `vars/` files loaded via `include_vars`
+- Puppet facts → Ansible facts: `$facts['os']['family']` → `ansible_os_family`, `$facts['networking']['ip']` → `ansible_default_ipv4.address`
+
+DEFAULTS/MAIN.YML — CRITICAL:
+- Values in defaults/main.yml MUST be plain values, NOT Jinja2 references to other variables
+- WRONG: `haproxy_stats_user: "{% raw %}{{ stats_user | default('admin') }}{% endraw %}"`
+- CORRECT: `haproxy_stats_user: admin`
+
+DEEP MERGE for Puppet Hiera variables:
+When the migration plan marks a variable as "deep merged" (e.g., `backends: (type: hash, deep merged)`),
+the variable is defined at multiple Hiera levels and values must be merged recursively, not replaced.
+
+Pattern:
+- Define the base value in `defaults/main.yml` (e.g., `haproxy_backends`)
+- In each vars/ override file, use the `_override` suffix (e.g., `haproxy_backends_override`)
+- In `load_vars.yml`, AFTER each `include_vars`, add a `set_fact` that merges the override into the base
+
+Complete `load_vars.yml` example:
+```yaml{% raw %}
+---
+- name: Load OS-specific variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+  failed_when: false
+
+- name: Load datacenter-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_datacenter }}.yml"
+  when: haproxy_datacenter is defined
+  failed_when: false
+
+- name: Deep merge datacenter backend overrides
+  ansible.builtin.set_fact:
+    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
+  when: haproxy_backends_override is defined
+
+- name: Load cluster-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_cluster }}.yml"
+  when: haproxy_cluster is defined
+  failed_when: false
+
+- name: Deep merge cluster backend overrides
+  ansible.builtin.set_fact:
+    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
+  when: haproxy_backends_override is defined{% endraw %}
+```
+
+The `_override` variable is loaded by `include_vars` from each level's vars file, then merged into the
+base variable. Each level's merge builds on the previous result, so cluster overrides datacenter
+overrides common — matching Puppet's Hiera precedence.
 
 STATIC FILES:
 - Copy directly from files/default/* to files/* using copy_file tool
@@ -318,8 +430,8 @@ collections:
     version: "<version>"
 ```
 
-META/MAIN.YML (metadata.rb → meta/main.yml):
-- Read Chef metadata.rb if it exists to extract role information
+META/MAIN.YML (metadata.rb / metadata.json → meta/main.yml):
+- Read Chef metadata.rb or Puppet metadata.json if it exists to extract role information
 - Convert to Ansible Galaxy metadata format:
 ```yaml
 ---

--- a/prompts/write_from_puppet.md
+++ b/prompts/write_from_puppet.md
@@ -1,0 +1,121 @@
+## Puppet-to-Ansible Migration Rules
+
+These rules apply ONLY when migrating a Puppet module to Ansible.
+
+### EPP TEMPLATE CONVERSION (.epp → .j2):
+Puppet EPP templates use different syntax from Chef ERB. Convert as follows:{% raw %}
+   - `<%= $variable %>` → `{{ variable }}` (remove $ prefix)
+   - `<% if $condition { %>` → `{% if condition %}`
+   - `<% unless $condition { %>` → `{% if not condition %}`
+   - `<% $items.each |$item| { %>` → `{% for item in items %}`
+   - `<% } %>` → `{% endfor %}` or `{% endif %}`
+   - `<%- ` (trim left) and ` -%>` (trim right) → `{%- ` and ` -%}`{% endraw %}
+
+Example EPP conversion:
+Source EPP (backend.conf.epp):
+```
+<%- | String $backend_name, Integer $port, Array $servers | -%>
+backend <%= $backend_name %>
+  balance roundrobin
+<% $servers.each |$server| { -%>
+  server <%= $server %> <%= $server %>:<%= $port %>
+<% } -%>
+```
+
+Correct Jinja2 output (backend.conf.j2):
+```{% raw %}
+backend {{ backend_name }}
+  balance roundrobin
+{% for server in servers %}
+  server {{ server }} {{ server }}:{{ port }}
+{% endfor %}{% endraw %}
+```
+
+### VARIABLE NAMING — CRITICAL:
+The migration plan maps Puppet namespaced parameters to Ansible variable names
+(e.g., `profile_haproxy::stats_user` → `haproxy_stats_user`).
+
+- Strip the Puppet namespace and use the Ansible role variable name everywhere
+- In templates, ALWAYS use the Ansible variable name from the migration plan
+- In defaults/main.yml, use the Ansible variable name
+
+WRONG — bare Puppet variable name in template:{% raw %}
+```
+stats auth {{ stats_user }}:{{ stats_password }}
+```{% endraw %}
+
+CORRECT — Ansible role variable name:{% raw %}
+```
+stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
+```{% endraw %}
+
+### DEFAULTS/MAIN.YML:
+- Values MUST be plain values, NOT Jinja2 references to other variables
+- WRONG: `haproxy_stats_user: "{% raw %}{{ stats_user | default('admin') }}{% endraw %}"`
+- CORRECT: `haproxy_stats_user: admin`
+
+### PUPPET MANIFESTS (.pp → .yml tasks):
+Convert Puppet resources to Ansible modules:
+- `package` → `ansible.builtin.package`
+- `service` → `ansible.builtin.service` or `ansible.builtin.systemd`
+- `file` with `content => template(...)` → `ansible.builtin.template`
+- `file` with `source => puppet:///...` → `ansible.builtin.copy`
+- `file` with `ensure => directory` → `ansible.builtin.file` with `state: directory`
+- `exec` → `ansible.builtin.command` with `changed_when`/`creates`/`unless`
+- `cron` → `ansible.builtin.cron`
+- `each` loops → `loop:` with `dict2items` for hashes
+- `if`/`unless`/`case` → `when:` conditions
+- Firewall: prefer `community.general.ufw` module over raw `ansible.builtin.command: ufw`
+
+### PUPPET FACTS → ANSIBLE FACTS:
+- `$facts['os']['family']` → `ansible_os_family`
+- `$facts['os']['name']` → `ansible_distribution`
+- `$facts['os']['release']['major']` → `ansible_distribution_major_version`
+- `$facts['networking']['ip']` → `ansible_default_ipv4.address`
+- `$facts['networking']['fqdn']` → `ansible_fqdn`
+
+### HIERA DATA → ANSIBLE VARIABLES:
+- Hiera `common.yaml` → `defaults/main.yml`
+- Per-OS data (`os/Debian.yaml`) → `vars/Debian.yml` loaded via `include_vars` based on `ansible_os_family`
+- Per-environment/datacenter/cluster data → `vars/` files loaded via `include_vars`
+
+### DEEP MERGE for Hiera variables:
+When the migration plan marks a variable as "deep merged" (e.g., `backends: (type: hash, deep merged)`),
+the variable is defined at multiple Hiera levels and values must be merged recursively, not replaced.
+
+Pattern:
+- Define the base value in `defaults/main.yml` (e.g., `haproxy_backends`)
+- In each vars/ override file, use the `_override` suffix (e.g., `haproxy_backends_override`)
+- In `load_vars.yml`, AFTER each `include_vars`, add a `set_fact` that merges the override into the base
+
+Complete `load_vars.yml` example:
+```yaml{% raw %}
+---
+- name: Load OS-specific variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+  failed_when: false
+
+- name: Load datacenter-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_datacenter }}.yml"
+  when: haproxy_datacenter is defined
+  failed_when: false
+
+- name: Deep merge datacenter backend overrides
+  ansible.builtin.set_fact:
+    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
+  when: haproxy_backends_override is defined
+
+- name: Load cluster-specific variables
+  ansible.builtin.include_vars: "{{ haproxy_cluster }}.yml"
+  when: haproxy_cluster is defined
+  failed_when: false
+
+- name: Deep merge cluster backend overrides
+  ansible.builtin.set_fact:
+    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
+  when: haproxy_backends_override is defined{% endraw %}
+```
+
+The `_override` variable is loaded by `include_vars` from each level's vars file, then merged into the
+base variable. Each level's merge builds on the previous result, so cluster overrides datacenter
+overrides common — matching Puppet's Hiera precedence.

--- a/prompts/write_from_puppet.md
+++ b/prompts/write_from_puppet.md
@@ -33,7 +33,7 @@ backend {{ backend_name }}
 
 ### VARIABLE NAMING — CRITICAL:
 The migration plan maps Puppet namespaced parameters to Ansible variable names
-(e.g., `profile_haproxy::stats_user` → `haproxy_stats_user`).
+(e.g., `profile_myapp::db_password` → `myapp_db_password`).
 
 - Strip the Puppet namespace and use the Ansible role variable name everywhere
 - In templates, ALWAYS use the Ansible variable name from the migration plan
@@ -41,18 +41,18 @@ The migration plan maps Puppet namespaced parameters to Ansible variable names
 
 WRONG — bare Puppet variable name in template:{% raw %}
 ```
-stats auth {{ stats_user }}:{{ stats_password }}
+db_host={{ db_host }} db_password={{ db_password }}
 ```{% endraw %}
 
 CORRECT — Ansible role variable name:{% raw %}
 ```
-stats auth {{ haproxy_stats_user }}:{{ haproxy_stats_password }}
+db_host={{ myapp_db_host }} db_password={{ myapp_db_password }}
 ```{% endraw %}
 
 ### DEFAULTS/MAIN.YML:
 - Values MUST be plain values, NOT Jinja2 references to other variables
-- WRONG: `haproxy_stats_user: "{% raw %}{{ stats_user | default('admin') }}{% endraw %}"`
-- CORRECT: `haproxy_stats_user: admin`
+- WRONG: `myapp_db_user: "{% raw %}{{ db_user | default('app') }}{% endraw %}"`
+- CORRECT: `myapp_db_user: app`
 
 ### PUPPET MANIFESTS (.pp → .yml tasks):
 Convert Puppet resources to Ansible modules:
@@ -84,8 +84,8 @@ When the migration plan marks a variable as "deep merged" (e.g., `backends: (typ
 the variable is defined at multiple Hiera levels and values must be merged recursively, not replaced.
 
 Pattern:
-- Define the base value in `defaults/main.yml` (e.g., `haproxy_backends`)
-- In each vars/ override file, use the `_override` suffix (e.g., `haproxy_backends_override`)
+- Define the base value in `defaults/main.yml` (e.g., `myapp_backends`)
+- In each vars/ override file, use the `_override` suffix (e.g., `myapp_backends_override`)
 - In `load_vars.yml`, AFTER each `include_vars`, add a `set_fact` that merges the override into the base
 
 Complete `load_vars.yml` example:
@@ -96,24 +96,24 @@ Complete `load_vars.yml` example:
   failed_when: false
 
 - name: Load datacenter-specific variables
-  ansible.builtin.include_vars: "{{ haproxy_datacenter }}.yml"
-  when: haproxy_datacenter is defined
+  ansible.builtin.include_vars: "{{ myapp_datacenter }}.yml"
+  when: myapp_datacenter is defined
   failed_when: false
 
 - name: Deep merge datacenter backend overrides
   ansible.builtin.set_fact:
-    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
-  when: haproxy_backends_override is defined
+    myapp_backends: "{{ myapp_backends | default({}) | combine(myapp_backends_override, recursive=True) }}"
+  when: myapp_backends_override is defined
 
 - name: Load cluster-specific variables
-  ansible.builtin.include_vars: "{{ haproxy_cluster }}.yml"
-  when: haproxy_cluster is defined
+  ansible.builtin.include_vars: "{{ myapp_cluster }}.yml"
+  when: myapp_cluster is defined
   failed_when: false
 
 - name: Deep merge cluster backend overrides
   ansible.builtin.set_fact:
-    haproxy_backends: "{{ haproxy_backends | default({}) | combine(haproxy_backends_override, recursive=True) }}"
-  when: haproxy_backends_override is defined{% endraw %}
+    myapp_backends: "{{ myapp_backends | default({}) | combine(myapp_backends_override, recursive=True) }}"
+  when: myapp_backends_override is defined{% endraw %}
 ```
 
 The `_override` variable is loaded by `include_vars` from each level's vars file, then merged into the


### PR DESCRIPTION
## Summary

Adding support for write/planning prompts for Puppet.

## Changes

**`prompts/export_ansible_write_system.j2`**
- Added Puppet EPP template conversion rules (`.epp` → `.j2`) alongside existing Chef ERB rules
- Added Puppet variable naming guidance with WRONG/CORRECT examples (namespace stripping: `module::var` → `module_var`)
- Added Puppet manifest → Ansible task resource mapping (package, service, file, exec, etc.)
- Added Hiera → Ansible vars mapping (common → defaults, per-OS → vars/, deep merge with `combine(recursive=True)`)
- Added complete `load_vars.yml` example showing hierarchy loading + deep merge pattern
- Added defaults/main.yml rule: values must be plain, not Jinja2 references
- Added Puppet `metadata.json` alongside Chef `metadata.rb` for meta/main.yml

**`prompts/export_ansible_planning_system.md`**
- Added Puppet module references alongside Chef cookbook references
- Added `.epp` templates, Hiera data files, and `.pp` manifests to checklist categories

**`prompts/export_ansible_planning_task.j2`**
- Changed "CHEF SOURCE PATH" → "SOURCE PATH"
- Changed "cookbooks" → "modules" (technology-neutral)
- Added Puppet file type examples alongside Chef examples

**`prompts/export_ansible_validation_task.j2`**
- Changed "Chef Source" → "Source" label

