### PR TITLE
feat: add goals iterations

### DIFF
--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -22,6 +22,7 @@ from langchain_core.tools import BaseTool
 
 from src.config import get_settings
 from src.middleware.agent_dump import AgentDumpMiddleware
+from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
 from src.model import get_model, get_runnable_config, report_tool_calls
 from src.types.base_state import BaseState
@@ -43,6 +44,7 @@ class BaseAgent[S: BaseState](ABC):
     BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = []
     _NAME: ClassVar[str | None] = None
     RULES_FILE: ClassVar[str | None] = None
+    GOAL: ClassVar[str | None] = None
 
     def __init__(self, model: BaseChatModel | None = None):
         self.model = model or get_model()
@@ -50,6 +52,8 @@ class BaseAgent[S: BaseState](ABC):
         self._log = get_logger(self.__class__.__module__).bind(
             agent=self.agent_name, agent_id=self.agent_id
         )
+        # Cache middleware instances to preserve state (e.g., retry_count)
+        self._middleware_cache: list[AgentMiddleware] | None = None
 
     @property
     def agent_name(self) -> str:
@@ -67,12 +71,24 @@ class BaseAgent[S: BaseState](ABC):
     def middleware(self) -> list:
         """Return middleware list for conversation compaction.
 
+        When GOAL is set, GoalValidationMiddleware is added first
+        to validate goal achievement and retry if necessary.
         When RULES_FILE is set, RulesMiddleware is included
         to inject rules as a message at agent startup.
         When JSON_LINES is configured, AgentDumpMiddleware is included
         to dump messages for debugging.
+
+        Middleware instances are cached to preserve state across invocations
+        (e.g., retry_count in GoalValidationMiddleware).
         """
+        # Return cached middleware if available
+        if self._middleware_cache is not None:
+            return self._middleware_cache
+
+        # Build middleware stack once
         stack: list[AgentMiddleware] = []
+        if self.GOAL:
+            stack.append(GoalValidationMiddleware(self.GOAL, agent=self))
         if self.RULES_FILE:
             stack.append(RulesMiddleware(self.RULES_FILE))
         stack.append(
@@ -85,6 +101,9 @@ class BaseAgent[S: BaseState](ABC):
         settings = get_settings()
         if settings.logging.json_lines:
             stack.append(AgentDumpMiddleware(self.agent_name, self.agent_id))
+
+        # Cache for reuse
+        self._middleware_cache = stack
         return stack
 
     def __call__(self, state: S) -> S:
@@ -167,17 +186,26 @@ class BaseAgent[S: BaseState](ABC):
         schema: type,
         messages: Any,
         metrics: AgentMetrics | None = None,
+        **kwargs,
     ) -> Any:
         """Invoke model with structured output schema.
 
         Returns the parsed schema instance, or None if validation fails.
 
         The reason why it's an agent it to be able to iterate if the model cannot do it in the first run.
+
+        Args:
+            schema: Pydantic model schema for structured output
+            messages: Messages to send to the model
+            metrics: Optional metrics collector
+            middleware: Middleware stack to use. If None, uses self.middleware().
+                        Pass [] to bypass middleware (e.g., for validation to avoid recursion)
+            **kwargs: Additional arguments (e.g., tools=[...])
         """
         agent = create_agent(
             model=self.model,
-            middleware=self.middleware(),
             response_format=schema,
+            tools=kwargs.get("tools", []),
         )
 
         try:

--- a/src/init/initialize_subagent.py
+++ b/src/init/initialize_subagent.py
@@ -37,6 +37,8 @@ class InitializeSubAgent(BaseAgent[InitState]):
         lambda: WriteFileTool(),
     ]
 
+    GOAL = f"Verify that the file '{MIGRATION_PLAN_FILE}' exists and contains valid migration plan content"
+
     SYSTEM_PROMPT_NAME = "init_migration_instructions"
     USER_PROMPT_NAME = "init_migration_plan_request"
 

--- a/src/middleware/goal_validation.py
+++ b/src/middleware/goal_validation.py
@@ -1,0 +1,162 @@
+"""Goal validation middleware with retry logic."""
+
+from collections.abc import Callable
+from copy import deepcopy
+from typing import Any, ClassVar
+
+from langchain.agents.middleware.types import AgentMiddleware, hook_config
+from langchain_community.tools.file_management.file_search import FileSearchTool
+from langchain_community.tools.file_management.list_dir import ListDirectoryTool
+from langchain_community.tools.file_management.read import ReadFileTool
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from src.utils.logging import get_logger
+
+VALIDATION_PROMPT_TEMPLATE = """You are a read-only goal validation agent. Your ONLY job is to CHECK whether the following goal was achieved. You must NEVER create, write, or modify any files.
+
+GOAL: {goal}
+
+CONVERSATION CONTEXT:
+{context}
+
+Use ONLY the read-only tools (read_file, list_directory, file_search) to inspect existing files and verify the goal was met. Do NOT attempt to fix, create, or write anything.
+
+Provide:
+- achieved: true if the goal is fully met, false otherwise
+- feedback: Specific details about what was verified or what is missing/incorrect
+"""
+
+RETRY_MESSAGE_TEMPLATE = """The goal was not achieved. Please address the following issues:
+
+{feedback}
+
+Remember the goal: {goal}
+
+Please try again."""
+
+
+class GoalValidationResult(BaseModel):
+    achieved: bool = Field(
+        description="Whether the goal was achieved (true) or not (false)"
+    )
+    feedback: str = Field(
+        description="Specific feedback about what was verified or what is missing/incorrect"
+    )
+
+
+class GoalValidationMiddleware(AgentMiddleware):
+    """Validates goal achievement after agent execution, retrying up to MAX_RETRIES times."""
+
+    name = "GoalValidation"
+    MAX_RETRIES = 3
+    CONTEXT_HEAD = 3
+    CONTEXT_TAIL = 2
+
+    BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
+        lambda: FileSearchTool(),
+        lambda: ListDirectoryTool(),
+        lambda: ReadFileTool(),
+    ]
+
+    def __init__(self, goal_description: str, agent: Any):
+        self._log = get_logger(__name__)
+        self.goal_description = goal_description
+        self.agent = agent
+        self.retry_count = 0
+
+    def _extract_context_messages(self, messages: list) -> list:
+        max_passthrough = self.CONTEXT_HEAD + self.CONTEXT_TAIL
+        if len(messages) <= max_passthrough:
+            return messages
+        return messages[: self.CONTEXT_HEAD] + messages[-self.CONTEXT_TAIL :]
+
+    def _build_validation_prompt(self, context_messages: list) -> str:
+        context_text = "\n\n".join(
+            f"[{msg.__class__.__name__}] {msg.content}"
+            for msg in context_messages
+            if hasattr(msg, "content")
+        )
+        return VALIDATION_PROMPT_TEMPLATE.format(
+            goal=self.goal_description, context=context_text
+        )
+
+    def _run_validation(self, state: dict) -> tuple[bool, str]:
+        self._log.info("Running goal validation", retry_count=self.retry_count)
+
+        messages = state.get("messages", [])
+        context_messages = self._extract_context_messages(messages)
+        validation_prompt = self._build_validation_prompt(context_messages)
+
+        try:
+            validation_tools = [factory() for factory in self.BASE_TOOLS]
+            validation_result = self.agent.invoke_structured(
+                schema=GoalValidationResult,
+                messages=[{"role": "user", "content": validation_prompt}],
+                metrics=None,
+                tools=validation_tools,
+            )
+
+            if not validation_result:
+                self._log.warning("No response from validation")
+                return False, "Validation did not respond"
+
+            self._log.debug(
+                "Validation result",
+                achieved=validation_result.achieved,
+                feedback=validation_result.feedback,
+            )
+            return validation_result.achieved, validation_result.feedback
+
+        except Exception as e:
+            self._log.error("Validation failed", error=str(e))
+            return False, f"Validation error: {e!s}"
+
+    @hook_config(can_jump_to=["model"])
+    def after_agent(self, state, runtime):
+        original_state = deepcopy(state)
+
+        self._log.info(
+            "Goal validation after_agent",
+            retry_count=self.retry_count,
+            max_retries=self.MAX_RETRIES,
+            messages_count=len(state.get("messages", [])),
+        )
+
+        goal_achieved, feedback = self._run_validation(state)
+
+        if goal_achieved:
+            self._log.info("Goal achieved", feedback=feedback)
+            return original_state
+
+        self._log.warning(
+            "Goal not achieved",
+            retry_count=self.retry_count,
+            feedback=feedback,
+        )
+
+        if self.retry_count >= self.MAX_RETRIES:
+            self._log.error("Max retries reached", feedback=feedback)
+            return state
+
+        self.retry_count += 1
+        messages = list(original_state.get("messages", []))
+        messages.append(
+            HumanMessage(
+                content=RETRY_MESSAGE_TEMPLATE.format(
+                    feedback=feedback, goal=self.goal_description
+                )
+            )
+        )
+
+        self._log.info(
+            "Retrying with feedback",
+            retry_count=self.retry_count,
+            feedback=feedback[:100],
+        )
+
+        return {
+            "messages": messages,
+            "jump_to": "model",
+        }

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -8,6 +8,7 @@ from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.messages.ai import UsageMetadata
 
 from src.base_agent import BaseAgent
+from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
 from src.types.base_state import BaseState
 
@@ -34,6 +35,16 @@ class RuledAgent(BaseAgent[BaseState]):
     """Agent with RULES_FILE set for testing."""
 
     RULES_FILE = "INPUT-AGENTS.md"
+
+    def execute(self, state: BaseState, metrics):
+        """Minimal execute implementation."""
+        return state
+
+
+class GoalAgent(BaseAgent[BaseState]):
+    """Agent with GOAL set for testing."""
+
+    GOAL = "Verify output file exists"
 
     def execute(self, state: BaseState, metrics):
         """Minimal execute implementation."""
@@ -437,10 +448,9 @@ class TestBaseAgentInvokeStructured:
 
 
 class TestBaseAgentMiddleware:
-    """Tests for BaseAgent.middleware() with RULES_FILE."""
+    """Tests for BaseAgent.middleware() configuration."""
 
-    def test_middleware_without_rules_file(self):
-        """Agent without RULES_FILE returns only SummarizationMiddleware."""
+    def test_middleware_without_rules_or_goal(self):
         agent = ConcreteAgent()
         stack = agent.middleware()
 
@@ -448,7 +458,6 @@ class TestBaseAgentMiddleware:
         assert isinstance(stack[0], SummarizationMiddleware)
 
     def test_middleware_with_rules_file(self):
-        """Agent with RULES_FILE prepends RulesMiddleware."""
         agent = RuledAgent()
         stack = agent.middleware()
 
@@ -456,12 +465,41 @@ class TestBaseAgentMiddleware:
         assert isinstance(stack[0], RulesMiddleware)
         assert isinstance(stack[1], SummarizationMiddleware)
 
+    def test_middleware_with_goal(self):
+        agent = GoalAgent()
+        stack = agent.middleware()
+
+        assert len(stack) == 2
+        assert isinstance(stack[0], GoalValidationMiddleware)
+        assert isinstance(stack[1], SummarizationMiddleware)
+
+    def test_middleware_with_goal_passes_agent_reference(self):
+        agent = GoalAgent()
+        stack = agent.middleware()
+        goal_mw = stack[0]
+
+        assert goal_mw.agent is agent
+        assert goal_mw.goal_description == "Verify output file exists"
+
+    def test_middleware_is_cached(self):
+        agent = GoalAgent()
+        first = agent.middleware()
+        second = agent.middleware()
+
+        assert first is second
+
     def test_rules_file_classvar_defaults_to_none(self):
-        """RULES_FILE defaults to None on BaseAgent subclasses."""
         agent = ConcreteAgent()
         assert agent.RULES_FILE is None
 
+    def test_goal_classvar_defaults_to_none(self):
+        agent = ConcreteAgent()
+        assert agent.GOAL is None
+
     def test_rules_file_classvar_set_on_subclass(self):
-        """RULES_FILE is accessible on subclasses that set it."""
         agent = RuledAgent()
         assert agent.RULES_FILE == "INPUT-AGENTS.md"
+
+    def test_goal_classvar_set_on_subclass(self):
+        agent = GoalAgent()
+        assert agent.GOAL == "Verify output file exists"

--- a/tests/test_goal_validation.py
+++ b/tests/test_goal_validation.py
@@ -1,0 +1,242 @@
+"""Tests for GoalValidationMiddleware."""
+
+from copy import deepcopy
+from typing import ClassVar
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from src.middleware.goal_validation import (
+    GoalValidationMiddleware,
+    GoalValidationResult,
+)
+
+
+class FakeAgent:
+    BASE_TOOLS: ClassVar[list] = [lambda: MagicMock()]
+
+    def __init__(self, structured_result=None):
+        self._structured_result = structured_result
+
+    def invoke_structured(self, **kwargs):
+        return self._structured_result
+
+
+@pytest.fixture
+def make_middleware():
+    def _factory(goal="Test goal", structured_result=None):
+        agent = FakeAgent(structured_result=structured_result)
+        return GoalValidationMiddleware(goal, agent=agent)
+
+    return _factory
+
+
+class TestGoalValidationResult:
+    def test_schema_fields(self):
+        result = GoalValidationResult(achieved=True, feedback="All good")
+        assert result.achieved is True
+        assert result.feedback == "All good"
+
+    def test_schema_requires_fields(self):
+        with pytest.raises(ValueError):
+            GoalValidationResult.model_validate({})
+
+
+class TestExtractContextMessages:
+    def test_short_list_returned_unchanged(self, make_middleware):
+        mw = make_middleware()
+        messages = [HumanMessage(content=f"msg{i}") for i in range(4)]
+        assert mw._extract_context_messages(messages) == messages
+
+    def test_exact_boundary_returned_unchanged(self, make_middleware):
+        mw = make_middleware()
+        messages = [HumanMessage(content=f"msg{i}") for i in range(5)]
+        assert mw._extract_context_messages(messages) == messages
+
+    def test_long_list_keeps_head_and_tail(self, make_middleware):
+        mw = make_middleware()
+        messages = [HumanMessage(content=f"msg{i}") for i in range(10)]
+
+        result = mw._extract_context_messages(messages)
+
+        assert len(result) == 5
+        assert result[:3] == messages[:3]
+        assert result[3:] == messages[-2:]
+
+    def test_empty_list(self, make_middleware):
+        mw = make_middleware()
+        assert mw._extract_context_messages([]) == []
+
+
+class TestBuildValidationPrompt:
+    def test_includes_goal_and_context(self, make_middleware):
+        mw = make_middleware(goal="Create output.txt")
+        messages = [HumanMessage(content="Hello"), AIMessage(content="Done")]
+
+        prompt = mw._build_validation_prompt(messages)
+
+        assert "Create output.txt" in prompt
+        assert "[HumanMessage] Hello" in prompt
+        assert "[AIMessage] Done" in prompt
+
+    def test_skips_messages_without_content(self, make_middleware):
+        mw = make_middleware()
+        msg_with_content = HumanMessage(content="visible")
+        msg_without_content = MagicMock(spec=[])
+
+        prompt = mw._build_validation_prompt([msg_with_content, msg_without_content])
+
+        assert "visible" in prompt
+
+
+class TestRunValidation:
+    def test_goal_achieved(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(
+                achieved=True, feedback="File exists"
+            )
+        )
+        state = {"messages": [HumanMessage(content="create file")]}
+
+        achieved, feedback = mw._run_validation(state)
+
+        assert achieved is True
+        assert feedback == "File exists"
+
+    def test_goal_not_achieved(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(
+                achieved=False, feedback="File missing"
+            )
+        )
+        state = {"messages": [HumanMessage(content="create file")]}
+
+        achieved, feedback = mw._run_validation(state)
+
+        assert achieved is False
+        assert feedback == "File missing"
+
+    def test_none_result_returns_false(self, make_middleware):
+        mw = make_middleware(structured_result=None)
+        state = {"messages": []}
+
+        achieved, feedback = mw._run_validation(state)
+
+        assert achieved is False
+        assert "did not respond" in feedback
+
+    def test_exception_returns_false(self, make_middleware):
+        mw = make_middleware()
+        mw.agent.invoke_structured = MagicMock(
+            side_effect=RuntimeError("LLM unavailable")
+        )
+        state = {"messages": []}
+
+        achieved, feedback = mw._run_validation(state)
+
+        assert achieved is False
+        assert "LLM unavailable" in feedback
+
+    def test_passes_middleware_tools_not_agent_tools(self):
+        agent = MagicMock()
+        agent.invoke_structured.return_value = GoalValidationResult(
+            achieved=True, feedback="ok"
+        )
+        mw = GoalValidationMiddleware("goal", agent=agent)
+
+        mw._run_validation({"messages": []})
+
+        call_kwargs = agent.invoke_structured.call_args[1]
+        tool_types = {type(t).__name__ for t in call_kwargs["tools"]}
+        assert "FileSearchTool" in tool_types
+        assert "ListDirectoryTool" in tool_types
+        assert "ReadFileTool" in tool_types
+        assert "WriteFileTool" not in tool_types
+
+
+class TestAfterAgent:
+    def test_goal_achieved_returns_original_state(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(achieved=True, feedback="All good")
+        )
+        state = {"messages": [HumanMessage(content="do thing")]}
+        original_messages = deepcopy(state["messages"])
+
+        result = mw.after_agent(state, runtime=None)
+
+        assert len(result["messages"]) == len(original_messages)
+        assert mw.retry_count == 0
+
+    def test_goal_not_achieved_adds_feedback_and_jumps(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(
+                achieved=False, feedback="Missing file"
+            )
+        )
+        state = {"messages": [HumanMessage(content="do thing")]}
+
+        result = mw.after_agent(state, runtime=None)
+
+        assert result["jump_to"] == "model"
+        assert mw.retry_count == 1
+        last_msg = result["messages"][-1]
+        assert "Missing file" in last_msg.content
+        assert isinstance(last_msg, HumanMessage)
+
+    def test_max_retries_returns_state_without_jump(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(
+                achieved=False, feedback="Still failing"
+            )
+        )
+        mw.retry_count = 3
+        state = {"messages": [HumanMessage(content="do thing")]}
+
+        result = mw.after_agent(state, runtime=None)
+
+        assert "jump_to" not in result
+        assert mw.retry_count == 3
+
+    def test_retry_increments_count(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(achieved=False, feedback="nope")
+        )
+
+        mw.after_agent({"messages": []}, runtime=None)
+        assert mw.retry_count == 1
+
+        mw.after_agent({"messages": []}, runtime=None)
+        assert mw.retry_count == 2
+
+        mw.after_agent({"messages": []}, runtime=None)
+        assert mw.retry_count == 3
+
+        result = mw.after_agent({"messages": []}, runtime=None)
+        assert mw.retry_count == 3
+        assert "jump_to" not in result
+
+    def test_feedback_message_contains_goal(self, make_middleware):
+        mw = make_middleware(
+            goal="Create output.txt",
+            structured_result=GoalValidationResult(
+                achieved=False, feedback="file not found"
+            ),
+        )
+        result = mw.after_agent({"messages": []}, runtime=None)
+
+        feedback_msg = result["messages"][-1]
+        assert "Create output.txt" in feedback_msg.content
+
+    def test_preserves_original_messages_on_retry(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(achieved=False, feedback="retry")
+        )
+        original_msg = HumanMessage(content="original")
+        state = {"messages": [original_msg]}
+
+        result = mw.after_agent(state, runtime=None)
+
+        assert result["messages"][0].content == "original"
+        assert len(result["messages"]) == 2
+        assert len(state["messages"]) == 1


### PR DESCRIPTION
There is a problem that when the `BaseAgent.invoke_react()` is in there, there is no "judge" if something goes wrong. This is a small middleware which judge the output and tell the agent to continue.

Some example is where we use gpt-oss-120, the migration file was not created correctly, and the thing failed in some many dumb ways.