### PR TITLE
fix: Ansible write issues with .yaml files

### DIFF
--- a/tests/tools/test_ansible_write.py
+++ b/tests/tools/test_ansible_write.py
@@ -687,3 +687,61 @@ app_log_level: "{{ log_level | default('INFO') | upper }}"
         assert "main.yml:" in result
         # Should have a line number
         assert any(char.isdigit() for char in result)
+
+    def test_ari_validation_no_false_positive_import_tasks(self) -> None:
+        """Test that import_tasks with FQCN does not trigger R301 false positive.
+
+        ARI misidentifies the filename argument (e.g. 'install.yml') as the
+        module name and returns an empty FQCN, which previously caused a
+        spurious R301 warning.
+        """
+        yaml_content = """---
+- name: Set redis configuration variables
+  ansible.builtin.set_fact:
+    redis_port: "{{ redis_port | default(6379) }}"
+
+- name: Include install tasks
+  ansible.builtin.import_tasks: install.yml
+"""
+        file_path = Path(self.temp_dir) / "tasks" / "main.yml"
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+
+        result = self.tool._run(file_path=str(file_path), yaml_content=yaml_content)
+
+        assert "Successfully wrote" in result
+        assert "WARNING" not in result
+        assert "R301" not in result
+        assert Path(file_path).exists()
+
+    def test_ari_validation_no_false_positive_include_tasks(self) -> None:
+        """Test that include_tasks with FQCN does not trigger R301 false positive."""
+        yaml_content = """---
+- name: Include platform-specific tasks
+  ansible.builtin.include_tasks: "{{ ansible_os_family }}.yml"
+"""
+        file_path = Path(self.temp_dir) / "tasks" / "main.yml"
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+
+        result = self.tool._run(file_path=str(file_path), yaml_content=yaml_content)
+
+        assert "Successfully wrote" in result
+        assert "WARNING" not in result
+        assert "R301" not in result
+        assert Path(file_path).exists()
+
+    def test_ari_validation_still_catches_short_module_names(self) -> None:
+        """Test that R301 still catches actual non-FQCN module usage."""
+        yaml_content = """---
+- name: Install package
+  apt:
+    name: nginx
+    state: present
+"""
+        file_path = Path(self.temp_dir) / "tasks" / "main.yml"
+        Path(file_path).parent.mkdir(parents=True, exist_ok=True)
+
+        result = self.tool._run(file_path=str(file_path), yaml_content=yaml_content)
+
+        assert "WARNING" in result
+        assert "R301" in result
+        assert "apt" in result

--- a/tools/ansible_write.py
+++ b/tools/ansible_write.py
@@ -451,13 +451,17 @@ class TaskfileValidator:
         rule = rule_result.rule
         detail = rule_result.detail or {}
 
-        # For R301 (FQCN), only flag if module name differs from FQCN
+        # For R301 (FQCN), only flag if module name differs from FQCN.
+        # Skip when fqcn is empty — ARI can't resolve import_tasks/include_tasks
+        # values and misreports the filename as the module name.
         if (
             rule.rule_id == "R301"
             and detail
             and "module" in detail
             and "fqcn" in detail
         ):
+            if not detail["fqcn"]:
+                return False
             return detail["module"] != detail["fqcn"]
 
         # verdict=True usually means issue found for error-detection rules


### PR DESCRIPTION
When debugging execution I found this common pattern:

```
Ansible write:
 ansible/roles/profile_redis_cluster/tasks/main.yml
content:
 ---
- name: Set redis configuration variables
  ansible.builtin.set_fact:
    redis_port: "{{ redis_port | default(6379) }}"
    redis_password: "{{ redis_password | default('CHANGEME') }}"
    maxmemory_mb: "{{ maxmemory_mb | default(2048) }}"
    maxmemory_policy: "{{ maxmemory_policy | default('allkeys-lru') }}"

- name: Include install tasks
  ansible.builtin.import_tasks: install.yml

```

And it reported incorrectly:

```
WARNING: File written but found 1 validation issues:

<ansible_lint_errors>
<file_path>ansible/roles/profile_redis_cluster/tasks/main.yml</file_path>

<validation_errors>
Found 1 issue(s):
main.yml:2 [R301] Task 'Include install tasks' has the following issue: 'A task with a short module name is found' - install.yml →
</validation_errors>

<fix_workflow>
1. Review each error with its line number and rule ID above
2. Apply fixes for the specific issues found:
   - [R301] Non-FQCN: Replace short module names with FQCN (e.g., 'apt' → 'ansible.builtin.apt')
3. Fix ALL the issues listed above in your yaml_content
4. Call ansible_write AGAIN with the corrected yaml_content
5. DO NOT RE-READ FILES - just fix and retry with ansible_write
</fix_workflow>
</ansible_lint_errors>
```

It's a bug on Asterisk Risk insights, pushed here a fix (It's not longer maintained)