### PR TITLE
With structured output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ ignore = [
     "E501",    # Line too long (handled by formatter)
     "TRY003",  # Avoid specifying long messages outside exception class
     "TRY300",  # Consider else block
+    "TRY301",  # Abstract `raise` to an inner function
     "TRY400",  # Use logging.exception instead of logging.error
 
 ]

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -86,6 +86,15 @@ Please provide a complete response that:
 
 Retry your response now, ensuring it matches the schema structure exactly."""
 
+    TOOL_CALL_CORRECTION = """ERROR: You provided a text response instead of calling the structured output tool.
+
+This is NOT acceptable. You MUST call the '{schema_name}' tool with your analysis.
+
+DO NOT write explanations. DO NOT write conversational text.
+ONLY call the tool with the required data.
+
+Try again now, and this time CALL THE TOOL."""
+
     def __init__(self, model: BaseChatModel | None = None):
         self.model = model or get_model()
         self.agent_id = str(uuid.uuid4())
@@ -161,58 +170,6 @@ Retry your response now, ensuring it matches the schema structure exactly."""
 
     # --- Invocation Helpers ---
 
-    def _inject_structured_output_instruction(
-        self, messages: Any
-    ) -> list[dict[str, str]]:
-        """Inject structured output instruction into messages.
-
-        This helps GPT-OSS understand it MUST use the structured output tool
-        rather than outputting conversational text.
-
-        Args:
-            messages: Original messages (list of dicts or other format)
-
-        Returns:
-            List of message dicts with instruction injected
-        """
-        # Convert to list of dicts if needed
-        if not isinstance(messages, list):
-            messages = [messages]
-
-        message_list = []
-        for msg in messages:
-            if isinstance(msg, dict):
-                message_list.append(msg)
-            elif hasattr(msg, "role") and hasattr(msg, "content"):
-                message_list.append({"role": msg.role, "content": msg.content})
-            else:
-                # Fallback: convert to string content
-                message_list.append({"role": "user", "content": str(msg)})
-
-        # Find the last system message or insert at the beginning
-        last_system_idx = -1
-        for i, msg in enumerate(message_list):
-            if msg.get("role") == "system":
-                last_system_idx = i
-
-        if last_system_idx >= 0:
-            # Append instruction to existing system message
-            existing_content = message_list[last_system_idx].get("content", "")
-            message_list[last_system_idx]["content"] = (
-                f"{existing_content}\n\n{self.STRUCTURED_OUTPUT_INSTRUCTION}"
-            )
-        else:
-            # Insert new system message at the beginning
-            message_list.insert(
-                0,
-                {
-                    "role": "system",
-                    "content": self.STRUCTURED_OUTPUT_INSTRUCTION,
-                },
-            )
-
-        return message_list
-
     def _get_tools(self, state: S) -> list[BaseTool]:
         """Build tools from BASE_TOOLS and state, binding agent name on X2ATool instances."""
         tools = [factory() for factory in self.BASE_TOOLS]
@@ -222,8 +179,22 @@ Retry your response now, ensuring it matches the schema structure exactly."""
             for tool in tools
         ]
 
+    @staticmethod
+    def _extract_message_tokens(message: AIMessage) -> tuple[int, int]:
+        """Extract tokens from a single AIMessage.
+
+        Returns:
+            Tuple of (input_tokens, output_tokens)
+        """
+        if not hasattr(message, "usage_metadata") or not message.usage_metadata:
+            return 0, 0
+
+        input_tokens = message.usage_metadata.get("input_tokens", 0)
+        output_tokens = message.usage_metadata.get("output_tokens", 0)
+        return input_tokens, output_tokens
+
     def _extract_token_usage(self, result: dict) -> tuple[int, int]:
-        """Extract total input and output tokens from AIMessage objects.
+        """Extract total input and output tokens from AIMessage objects in result dict.
 
         Returns:
             Tuple of (input_tokens, output_tokens)
@@ -232,13 +203,10 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         output_tokens = 0
 
         for msg in result.get("messages", []):
-            if not isinstance(msg, AIMessage):
-                continue
-            if not hasattr(msg, "usage_metadata") or not msg.usage_metadata:
-                continue
-
-            input_tokens += msg.usage_metadata.get("input_tokens", 0)
-            output_tokens += msg.usage_metadata.get("output_tokens", 0)
+            if isinstance(msg, AIMessage):
+                msg_in, msg_out = self._extract_message_tokens(msg)
+                input_tokens += msg_in
+                output_tokens += msg_out
 
         return input_tokens, output_tokens
 
@@ -268,8 +236,7 @@ Retry your response now, ensuring it matches the schema structure exactly."""
 
         if metrics:
             metrics.record_tool_calls(tool_calls)
-            input_tokens, output_tokens = self._extract_token_usage(result)
-            metrics.record_tokens(input_tokens, output_tokens)
+            metrics.record_tokens(*self._extract_token_usage(result))
 
         return result
 
@@ -298,42 +265,25 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         if max_retries <= 0:
             max_retries = 1
 
-        # Inject structured output instruction to help GPT-OSS understand it MUST use the tool
-        # This addresses Issue 2: non-deterministic tool calling behavior
-        current_messages = self._inject_structured_output_instruction(messages)
+        current_messages = [
+            {"role": "system", "content": self.STRUCTURED_OUTPUT_INSTRUCTION},
+            *messages,
+        ]
 
-        # Use with_structured_output directly on the model
-        # This gives us more control over the structured output behavior
-        # method="function_calling" converts schema to a tool call
         structured_model = self.model.with_structured_output(
             schema, method="function_calling"
         )
         for attempt in range(max_retries):
             try:
-                # Invoke structured model directly - it returns the parsed object or raises
                 result = structured_model.invoke(
                     current_messages,
                     get_runnable_config(),
                 )
 
-                # Record tokens if we got an AIMessage with metadata
-                # (with_structured_output might not return AIMessage, just the parsed object)
-                if (
-                    metrics
-                    and isinstance(result, AIMessage)
-                    and hasattr(result, "usage_metadata")
-                    and result.usage_metadata
-                ):
-                    input_tokens = result.usage_metadata.get("input_tokens", 0)
-                    output_tokens = result.usage_metadata.get("output_tokens", 0)
-                    metrics.record_tokens(input_tokens, output_tokens)
+                if metrics and isinstance(result, AIMessage):
+                    metrics.record_tokens(*self._extract_message_tokens(result))
 
-                # with_structured_output returns the structured object directly
-                structured_response = result
-
-                # Issue 2: GPT-OSS sometimes returns None instead of calling the tool
-                # In this case, structured_response will be None
-                if structured_response is None:
+                if result is None:
                     is_last_attempt = attempt == max_retries - 1
                     schema_name = getattr(schema, "__name__", str(schema))
 
@@ -345,75 +295,41 @@ Retry your response now, ensuring it matches the schema structure exactly."""
                     if is_last_attempt:
                         return None
 
-                    # Add a strong correction message
-                    correction_message = f"""ERROR: You provided a text response instead of calling the structured output tool.
-
-This is NOT acceptable. You MUST call the '{schema_name}' tool with your analysis.
-
-DO NOT write explanations. DO NOT write conversational text.
-ONLY call the tool with the required data.
-
-Try again now, and this time CALL THE TOOL."""
-
+                    correction_message = self.TOOL_CALL_CORRECTION.format(
+                        schema_name=schema_name
+                    )
                     current_messages.append(
                         {"role": "user", "content": correction_message}
                     )
                     continue
 
-                return structured_response
+                return result
 
             except StructuredOutputValidationError as e:
                 is_last_attempt = attempt == max_retries - 1
                 schema_name = getattr(schema, "__name__", str(schema))
+                ai_content = (
+                    str(e.ai_message.content)
+                    if hasattr(e, "ai_message") and e.ai_message
+                    else "No content"
+                )
 
                 self._log.error(
                     f"Structured output validation failed for schema '{schema_name}' "
                     f"(attempt {attempt + 1}/{max_retries}): {e.source}",
                     tool_name=getattr(e, "tool_name", None),
-                    ai_message_content=str(e.ai_message.content)
-                    if hasattr(e, "ai_message") and e.ai_message
-                    else "No content",
+                    ai_message_content=ai_content,
                 )
 
                 if is_last_attempt:
                     return None
-
-                # Extract AI message content for the error message
-                ai_content = (
-                    str(e.ai_message.content)
-                    if hasattr(e, "ai_message") and e.ai_message
-                    else "No response content"
-                )
 
                 error_message = self.STRUCTURED_ERROR.format(
                     validation_error=str(e.args[0]) if e.args else str(e),
                     schema_name=schema_name,
                     ai_message_content=ai_content,
                 )
-
-                # Add the error message to retry
                 current_messages.append({"role": "user", "content": error_message})
-                continue
-
-            except Exception as e:
-                # Catch any other exceptions (like empty content errors from Bedrock)
-                is_last_attempt = attempt == max_retries - 1
-                schema_name = getattr(schema, "__name__", str(schema))
-
-                self._log.error(
-                    f"Unexpected error during structured output invocation "
-                    f"for schema '{schema_name}' (attempt {attempt + 1}/{max_retries}): {e}"
-                )
-
-                if is_last_attempt:
-                    return None
-
-                # Add a generic retry message
-                retry_message = f"""ERROR: An error occurred while processing your response.
-
-Please try again and ensure you call the '{schema_name}' tool correctly with all required fields."""
-
-                current_messages.append({"role": "user", "content": retry_message})
                 continue
 
         return None
@@ -423,23 +339,12 @@ Please try again and ensure you call the '{schema_name}' tool correctly with all
         messages: list[dict[str, str]],
         metrics: AgentMetrics | None = None,
     ) -> str:
-        """Direct model invocation, returns content string.
-
-        Uses .text property to handle GPT-OSS Issue 4 & 5: reasoning_content blocks.
-        """
+        """Direct model invocation, returns content string."""
         result = self.model.invoke(messages, config=get_runnable_config())
-        if (
-            metrics
-            and isinstance(result, AIMessage)
-            and hasattr(result, "usage_metadata")
-            and result.usage_metadata
-        ):
-            input_tokens = result.usage_metadata.get("input_tokens", 0)
-            output_tokens = result.usage_metadata.get("output_tokens", 0)
-            metrics.record_tokens(input_tokens, output_tokens)
 
-        # Use .text property to extract text from potentially complex content
-        # (handles reasoning_content blocks from GPT-OSS)
+        if metrics and isinstance(result, AIMessage):
+            metrics.record_tokens(*self._extract_message_tokens(result))
+
         if isinstance(result, AIMessage) and hasattr(result, "text"):
             return result.text
         if isinstance(result.content, str):

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -17,7 +17,7 @@ from langchain.agents.middleware import SummarizationMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import StructuredOutputValidationError
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage
 from langchain_core.tools import BaseTool
 
 from src.config import get_settings
@@ -45,6 +45,23 @@ class BaseAgent[S: BaseState](ABC):
     _NAME: ClassVar[str | None] = None
     RULES_FILE: ClassVar[str | None] = None
     GOAL: ClassVar[str | None] = None
+
+    STRUCTURED_OUTPUT_INSTRUCTION = """CRITICAL INSTRUCTION - STRUCTURED OUTPUT REQUIRED:
+
+You MUST use the structured output tool that has been provided to you. This is NOT optional.
+
+DO NOT write a text response. DO NOT write explanatory text. DO NOT write conversational output.
+
+REQUIRED ACTION:
+1. Analyze the input according to the instructions
+2. IMMEDIATELY call the structured output tool with your analysis
+3. Ensure the tool call includes ALL required fields from the schema
+
+The structured output tool is the ONLY way to respond. Any text response will be rejected.
+
+If you are uncertain about any field, make your best analysis and include it in the tool call.
+If a field is optional and you have no data, you may omit it or use null.
+But you MUST call the tool - there is no alternative response format."""
 
     STRUCTURED_ERROR = """You failed to generate a valid structured output. The validation error was:
 
@@ -144,6 +161,58 @@ Retry your response now, ensuring it matches the schema structure exactly."""
 
     # --- Invocation Helpers ---
 
+    def _inject_structured_output_instruction(
+        self, messages: Any
+    ) -> list[dict[str, str]]:
+        """Inject structured output instruction into messages.
+
+        This helps GPT-OSS understand it MUST use the structured output tool
+        rather than outputting conversational text.
+
+        Args:
+            messages: Original messages (list of dicts or other format)
+
+        Returns:
+            List of message dicts with instruction injected
+        """
+        # Convert to list of dicts if needed
+        if not isinstance(messages, list):
+            messages = [messages]
+
+        message_list = []
+        for msg in messages:
+            if isinstance(msg, dict):
+                message_list.append(msg)
+            elif hasattr(msg, "role") and hasattr(msg, "content"):
+                message_list.append({"role": msg.role, "content": msg.content})
+            else:
+                # Fallback: convert to string content
+                message_list.append({"role": "user", "content": str(msg)})
+
+        # Find the last system message or insert at the beginning
+        last_system_idx = -1
+        for i, msg in enumerate(message_list):
+            if msg.get("role") == "system":
+                last_system_idx = i
+
+        if last_system_idx >= 0:
+            # Append instruction to existing system message
+            existing_content = message_list[last_system_idx].get("content", "")
+            message_list[last_system_idx]["content"] = (
+                f"{existing_content}\n\n{self.STRUCTURED_OUTPUT_INSTRUCTION}"
+            )
+        else:
+            # Insert new system message at the beginning
+            message_list.insert(
+                0,
+                {
+                    "role": "system",
+                    "content": self.STRUCTURED_OUTPUT_INSTRUCTION,
+                },
+            )
+
+        return message_list
+
     def _get_tools(self, state: S) -> list[BaseTool]:
         """Build tools from BASE_TOOLS and state, binding agent name on X2ATool instances."""
         tools = [factory() for factory in self.BASE_TOOLS]
@@ -229,25 +298,69 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         if max_retries <= 0:
             max_retries = 1
 
-        agent = create_agent(
-            model=self.model,
-            response_format=schema,
-            tools=kwargs.get("tools", []),
-        )
+        # Inject structured output instruction to help GPT-OSS understand it MUST use the tool
+        # This addresses Issue 2: non-deterministic tool calling behavior
+        current_messages = self._inject_structured_output_instruction(messages)
 
-        current_messages = messages
+        # Use with_structured_output directly on the model
+        # This gives us more control over the structured output behavior
+        # method="function_calling" converts schema to a tool call
+        structured_model = self.model.with_structured_output(
+            schema, method="function_calling"
+        )
         for attempt in range(max_retries):
             try:
-                result = agent.invoke(
-                    {"messages": current_messages},
+                # Invoke structured model directly - it returns the parsed object or raises
+                result = structured_model.invoke(
+                    current_messages,
                     get_runnable_config(),
                 )
 
-                if metrics:
-                    input_tokens, output_tokens = self._extract_token_usage(result)
+                # Record tokens if we got an AIMessage with metadata
+                # (with_structured_output might not return AIMessage, just the parsed object)
+                if (
+                    metrics
+                    and isinstance(result, AIMessage)
+                    and hasattr(result, "usage_metadata")
+                    and result.usage_metadata
+                ):
+                    input_tokens = result.usage_metadata.get("input_tokens", 0)
+                    output_tokens = result.usage_metadata.get("output_tokens", 0)
                     metrics.record_tokens(input_tokens, output_tokens)
 
-                return result.get("structured_response")
+                # with_structured_output returns the structured object directly
+                structured_response = result
+
+                # Issue 2: GPT-OSS sometimes returns None instead of calling the tool
+                # In this case, structured_response will be None
+                if structured_response is None:
+                    is_last_attempt = attempt == max_retries - 1
+                    schema_name = getattr(schema, "__name__", str(schema))
+
+                    self._log.warning(
+                        f"Model returned None for structured output "
+                        f"for schema '{schema_name}' (attempt {attempt + 1}/{max_retries})"
+                    )
+
+                    if is_last_attempt:
+                        return None
+
+                    # Add a strong correction message
+                    correction_message = f"""ERROR: You provided a text response instead of calling the structured output tool.
+
+This is NOT acceptable. You MUST call the '{schema_name}' tool with your analysis.
+
+DO NOT write explanations. DO NOT write conversational text.
+ONLY call the tool with the required data.
+
+Try again now, and this time CALL THE TOOL."""
+
+                    current_messages.append(
+                        {"role": "user", "content": correction_message}
+                    )
+                    continue
+
+                return structured_response
 
             except StructuredOutputValidationError as e:
                 is_last_attempt = attempt == max_retries - 1
@@ -256,27 +369,51 @@ Retry your response now, ensuring it matches the schema structure exactly."""
                 self._log.error(
                     f"Structured output validation failed for schema '{schema_name}' "
                     f"(attempt {attempt + 1}/{max_retries}): {e.source}",
-                    tool_name=e.tool_name,
-                    ai_message_content=str(e.ai_message.content),
+                    tool_name=getattr(e, "tool_name", None),
+                    ai_message_content=str(e.ai_message.content)
+                    if hasattr(e, "ai_message") and e.ai_message
+                    else "No content",
                 )
-
-                # These shouldn't be an issue, but just in case.
-                if not self.STRUCTURED_ERROR:
-                    return None
-
-                if not e.ai_message:
-                    return None
 
                 if is_last_attempt:
                     return None
 
-                error_message = self.STRUCTURED_ERROR.format(
-                    validation_error=str(e.args[0]),
-                    schema_name=schema_name,
-                    ai_message_content=str(e.ai_message.content),
+                # Extract AI message content for the error message
+                ai_content = (
+                    str(e.ai_message.content)
+                    if hasattr(e, "ai_message") and e.ai_message
+                    else "No response content"
                 )
-                current_messages.append(e.ai_message)
-                current_messages.append(HumanMessage(content=error_message))
+
+                error_message = self.STRUCTURED_ERROR.format(
+                    validation_error=str(e.args[0]) if e.args else str(e),
+                    schema_name=schema_name,
+                    ai_message_content=ai_content,
+                )
+
+                # Add the error message to retry
+                current_messages.append({"role": "user", "content": error_message})
+                continue
+
+            except Exception as e:
+                # Catch any other exceptions (like empty content errors from Bedrock)
+                is_last_attempt = attempt == max_retries - 1
+                schema_name = getattr(schema, "__name__", str(schema))
+
+                self._log.error(
+                    f"Unexpected error during structured output invocation "
+                    f"for schema '{schema_name}' (attempt {attempt + 1}/{max_retries}): {e}"
+                )
+
+                if is_last_attempt:
+                    return None
+
+                # Add a generic retry message
+                retry_message = f"""ERROR: An error occurred while processing your response.
+
+Please try again and ensure you call the '{schema_name}' tool correctly with all required fields."""
+
+                current_messages.append({"role": "user", "content": retry_message})
                 continue
 
         return None
@@ -286,7 +423,10 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         messages: list[dict[str, str]],
         metrics: AgentMetrics | None = None,
     ) -> str:
-        """Direct model invocation, returns content string."""
+        """Direct model invocation, returns content string.
+
+        Uses .text property to handle GPT-OSS Issue 4 & 5: reasoning_content blocks.
+        """
         result = self.model.invoke(messages, config=get_runnable_config())
         if (
             metrics
@@ -298,6 +438,10 @@ Retry your response now, ensuring it matches the schema structure exactly."""
             output_tokens = result.usage_metadata.get("output_tokens", 0)
             metrics.record_tokens(input_tokens, output_tokens)
 
+        # Use .text property to extract text from potentially complex content
+        # (handles reasoning_content blocks from GPT-OSS)
+        if isinstance(result, AIMessage) and hasattr(result, "text"):
+            return result.text
         if isinstance(result.content, str):
             return result.content
         return str(result.content)

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -170,48 +170,25 @@ Retry your response now, ensuring it matches the schema structure exactly."""
             for tool in tools
         ]
 
-    @staticmethod
-    def _extract_message_tokens(message: AIMessage) -> tuple[int, int]:
-        """Extract tokens from a single AIMessage.
-
-        Returns:
-            Tuple of (input_tokens, output_tokens)
-        """
-        if not hasattr(message, "usage_metadata") or not message.usage_metadata:
-            return 0, 0
-
-        input_tokens = message.usage_metadata.get("input_tokens", 0)
-        output_tokens = message.usage_metadata.get("output_tokens", 0)
-        return input_tokens, output_tokens
-
     def _extract_token_usage(self, result: dict) -> tuple[int, int]:
-        """Extract total input and output tokens from AIMessage objects in result dict.
+        """Extract total input and output tokens from AIMessage objects.
 
         Returns:
-            Tuple of (input_tokens, output_tokens)
+        Tuple of (input_tokens, output_tokens)
         """
         input_tokens = 0
         output_tokens = 0
 
         for msg in result.get("messages", []):
-            if isinstance(msg, AIMessage):
-                msg_in, msg_out = self._extract_message_tokens(msg)
-                input_tokens += msg_in
-                output_tokens += msg_out
+            if not isinstance(msg, AIMessage):
+                continue
+            if not hasattr(msg, "usage_metadata") or not msg.usage_metadata:
+                continue
+
+            input_tokens += msg.usage_metadata.get("input_tokens", 0)
+            output_tokens += msg.usage_metadata.get("output_tokens", 0)
 
         return input_tokens, output_tokens
-
-    @staticmethod
-    def _raise_missing_structured_output(schema: type) -> None:
-        """Raise error when model returns None instead of calling the structured output tool."""
-        schema_name = getattr(schema, "__name__", str(schema))
-        raise StructuredOutputValidationError(
-            tool_name=schema_name,
-            source=ValueError(
-                f"Model returned None instead of calling {schema_name} tool"
-            ),
-            ai_message=AIMessage(content="No tool call made"),
-        )
 
     def invoke_react(
         self,
@@ -239,7 +216,8 @@ Retry your response now, ensuring it matches the schema structure exactly."""
 
         if metrics:
             metrics.record_tool_calls(tool_calls)
-            metrics.record_tokens(*self._extract_token_usage(result))
+            input_tokens, output_tokens = self._extract_token_usage(result)
+            metrics.record_tokens(input_tokens, output_tokens)
 
         return result
 
@@ -274,7 +252,7 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         ]
 
         structured_model = self.model.with_structured_output(
-            schema, method="function_calling"
+            schema, method="function_calling", include_raw=True
         )
         for attempt in range(max_retries):
             try:
@@ -283,13 +261,28 @@ Retry your response now, ensuring it matches the schema structure exactly."""
                     get_runnable_config(),
                 )
 
-                if metrics and isinstance(result, AIMessage):
-                    metrics.record_tokens(*self._extract_message_tokens(result))
+                if (
+                    metrics
+                    and isinstance(result, dict)
+                    and isinstance(result.get("raw"), AIMessage)
+                    and hasattr(result["raw"], "usage_metadata")
+                    and result["raw"].usage_metadata
+                ):
+                    input_tokens = result["raw"].usage_metadata.get("input_tokens", 0)
+                    output_tokens = result["raw"].usage_metadata.get("output_tokens", 0)
+                    metrics.record_tokens(input_tokens, output_tokens)
 
                 if result is None:
-                    self._raise_missing_structured_output(schema)
+                    schema_name = getattr(schema, "__name__", str(schema))
+                    raise StructuredOutputValidationError(
+                        tool_name=schema_name,
+                        source=ValueError(
+                            f"Model returned None instead of calling {schema_name} tool"
+                        ),
+                        ai_message=AIMessage(content="No tool call made"),
+                    )
 
-                return result
+                return result.get("parsed")
 
             except StructuredOutputValidationError as e:
                 is_last_attempt = attempt == max_retries - 1
@@ -328,8 +321,15 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         """Direct model invocation, returns content string."""
         result = self.model.invoke(messages, config=get_runnable_config())
 
-        if metrics and isinstance(result, AIMessage):
-            metrics.record_tokens(*self._extract_message_tokens(result))
+        if (
+            metrics
+            and isinstance(result, AIMessage)
+            and hasattr(result, "usage_metadata")
+            and result.usage_metadata
+        ):
+            input_tokens = result.usage_metadata.get("input_tokens", 0)
+            output_tokens = result.usage_metadata.get("output_tokens", 0)
+            metrics.record_tokens(input_tokens, output_tokens)
 
         if isinstance(result, AIMessage) and hasattr(result, "text"):
             return result.text

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -272,7 +272,11 @@ Retry your response now, ensuring it matches the schema structure exactly."""
                     output_tokens = result["raw"].usage_metadata.get("output_tokens", 0)
                     metrics.record_tokens(input_tokens, output_tokens)
 
-                if result is None:
+                parsed_result = (
+                    result.get("parsed") if isinstance(result, dict) else result
+                )
+
+                if parsed_result is None:
                     schema_name = getattr(schema, "__name__", str(schema))
                     raise StructuredOutputValidationError(
                         tool_name=schema_name,
@@ -282,7 +286,7 @@ Retry your response now, ensuring it matches the schema structure exactly."""
                         ai_message=AIMessage(content="No tool call made"),
                     )
 
-                return result.get("parsed")
+                return parsed_result
 
             except StructuredOutputValidationError as e:
                 is_last_attempt = attempt == max_retries - 1

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -86,15 +86,6 @@ Please provide a complete response that:
 
 Retry your response now, ensuring it matches the schema structure exactly."""
 
-    TOOL_CALL_CORRECTION = """ERROR: You provided a text response instead of calling the structured output tool.
-
-This is NOT acceptable. You MUST call the '{schema_name}' tool with your analysis.
-
-DO NOT write explanations. DO NOT write conversational text.
-ONLY call the tool with the required data.
-
-Try again now, and this time CALL THE TOOL."""
-
     def __init__(self, model: BaseChatModel | None = None):
         self.model = model or get_model()
         self.agent_id = str(uuid.uuid4())
@@ -210,6 +201,18 @@ Try again now, and this time CALL THE TOOL."""
 
         return input_tokens, output_tokens
 
+    @staticmethod
+    def _raise_missing_structured_output(schema: type) -> None:
+        """Raise error when model returns None instead of calling the structured output tool."""
+        schema_name = getattr(schema, "__name__", str(schema))
+        raise StructuredOutputValidationError(
+            tool_name=schema_name,
+            source=ValueError(
+                f"Model returned None instead of calling {schema_name} tool"
+            ),
+            ai_message=AIMessage(content="No tool call made"),
+        )
+
     def invoke_react(
         self,
         state: S,
@@ -284,24 +287,7 @@ Try again now, and this time CALL THE TOOL."""
                     metrics.record_tokens(*self._extract_message_tokens(result))
 
                 if result is None:
-                    is_last_attempt = attempt == max_retries - 1
-                    schema_name = getattr(schema, "__name__", str(schema))
-
-                    self._log.warning(
-                        f"Model returned None for structured output "
-                        f"for schema '{schema_name}' (attempt {attempt + 1}/{max_retries})"
-                    )
-
-                    if is_last_attempt:
-                        return None
-
-                    correction_message = self.TOOL_CALL_CORRECTION.format(
-                        schema_name=schema_name
-                    )
-                    current_messages.append(
-                        {"role": "user", "content": correction_message}
-                    )
-                    continue
+                    self._raise_missing_structured_output(schema)
 
                 return result
 

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -323,15 +323,21 @@ class TestBaseAgentInvokeStructured:
         return ConcreteAgent()
 
     @pytest.fixture
-    def mock_agent(self, agent):
-        """Create a mock agent returned by create_agent."""
-        from unittest.mock import Mock, patch
+    def mock_structured_model(self, agent):
+        """Mock the model's with_structured_output method."""
+        from unittest.mock import Mock
 
-        mock_created_agent = Mock()
-        with patch("src.base_agent.create_agent", return_value=mock_created_agent):
-            yield mock_created_agent
+        mock_structured = Mock()
+        mock_model = Mock()
+        mock_model.with_structured_output.return_value = mock_structured
 
-    def test_invoke_structured_records_tokens_with_metrics(self, agent, mock_agent):
+        agent.model = mock_model
+
+        return mock_structured
+
+    def test_invoke_structured_records_tokens_with_metrics(
+        self, agent, mock_structured_model
+    ):
         """Test that invoke_structured records tokens when metrics is provided."""
         from src.types.telemetry import AgentMetrics
 
@@ -340,109 +346,104 @@ class TestBaseAgentInvokeStructured:
             UsageMetadata, {"input_tokens": 500, "output_tokens": 200}
         )
 
-        mock_agent.invoke.return_value = {
-            "structured_response": {"field": "value"},
-            "messages": [ai_msg],
-        }
+        # New implementation returns the object directly, wrapped in AIMessage for tokens
+        mock_structured_model.invoke.return_value = ai_msg
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == {"field": "value"}
+        assert result == ai_msg
         assert metrics.input_tokens == 500
         assert metrics.output_tokens == 200
 
-    def test_invoke_structured_without_metrics(self, agent, mock_agent):
+    def test_invoke_structured_without_metrics(self, agent, mock_structured_model):
         """Test that invoke_structured works without metrics."""
         ai_msg = AIMessage(content="Response")
         ai_msg.usage_metadata = cast(
             UsageMetadata, {"input_tokens": 500, "output_tokens": 200}
         )
 
-        mock_agent.invoke.return_value = {
-            "structured_response": {"field": "value"},
-            "messages": [ai_msg],
-        }
+        mock_structured_model.invoke.return_value = ai_msg
 
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], None
         )
 
-        assert result == {"field": "value"}
+        assert result == ai_msg
 
-    def test_invoke_structured_without_structured_response(self, agent, mock_agent):
-        """Test that invoke_structured handles missing structured_response key."""
+    def test_invoke_structured_without_structured_response(
+        self, agent, mock_structured_model
+    ):
+        """Test that invoke_structured handles None result (model didn't call tool)."""
         from src.types.telemetry import AgentMetrics
 
-        mock_agent.invoke.return_value = {"messages": []}
+        # Model returns None when it doesn't call the tool
+        mock_structured_model.invoke.return_value = None
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
-            dict, [{"role": "user", "content": "test"}], metrics
+            dict, [{"role": "user", "content": "test"}], metrics, max_retries=1
         )
 
         assert result is None
         assert metrics.input_tokens == 0
         assert metrics.output_tokens == 0
 
-    def test_invoke_structured_without_usage_metadata(self, agent, mock_agent):
+    def test_invoke_structured_without_usage_metadata(
+        self, agent, mock_structured_model
+    ):
         """Test that invoke_structured handles messages without usage_metadata."""
         from src.types.telemetry import AgentMetrics
 
         ai_msg = AIMessage(content="Response")
 
-        mock_agent.invoke.return_value = {
-            "structured_response": {"field": "value"},
-            "messages": [ai_msg],
-        }
+        mock_structured_model.invoke.return_value = ai_msg
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == {"field": "value"}
+        assert result == ai_msg
         assert metrics.input_tokens == 0
         assert metrics.output_tokens == 0
 
-    def test_invoke_structured_with_none_usage_metadata(self, agent, mock_agent):
+    def test_invoke_structured_with_none_usage_metadata(
+        self, agent, mock_structured_model
+    ):
         """Test that invoke_structured handles messages with None usage_metadata."""
         from src.types.telemetry import AgentMetrics
 
         ai_msg = AIMessage(content="Response")
         ai_msg.usage_metadata = None
 
-        mock_agent.invoke.return_value = {
-            "structured_response": {"field": "value"},
-            "messages": [ai_msg],
-        }
+        mock_structured_model.invoke.return_value = ai_msg
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == {"field": "value"}
+        assert result == ai_msg
         assert metrics.input_tokens == 0
         assert metrics.output_tokens == 0
 
-    def test_invoke_structured_no_ai_messages(self, agent, mock_agent):
-        """Test that invoke_structured handles result with no AI messages."""
+    def test_invoke_structured_no_ai_messages(self, agent, mock_structured_model):
+        """Test that invoke_structured handles non-AIMessage result."""
         from src.types.telemetry import AgentMetrics
 
-        mock_agent.invoke.return_value = {
-            "structured_response": {"field": "value"},
-            "messages": [HumanMessage(content="test")],
-        }
+        # When model successfully parses, it might return the parsed object directly
+        parsed_result = {"field": "value"}
+        mock_structured_model.invoke.return_value = parsed_result
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == {"field": "value"}
+        assert result == parsed_result
         assert metrics.input_tokens == 0
         assert metrics.output_tokens == 0
 

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -346,15 +346,15 @@ class TestBaseAgentInvokeStructured:
             UsageMetadata, {"input_tokens": 500, "output_tokens": 200}
         )
 
-        # New implementation returns the object directly, wrapped in AIMessage for tokens
-        mock_structured_model.invoke.return_value = ai_msg
+        parsed_obj = {"field": "value"}
+        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == ai_msg
+        assert result == parsed_obj
         assert metrics.input_tokens == 500
         assert metrics.output_tokens == 200
 
@@ -365,13 +365,14 @@ class TestBaseAgentInvokeStructured:
             UsageMetadata, {"input_tokens": 500, "output_tokens": 200}
         )
 
-        mock_structured_model.invoke.return_value = ai_msg
+        parsed_obj = {"field": "value"}
+        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
 
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], None
         )
 
-        assert result == ai_msg
+        assert result == parsed_obj
 
     def test_invoke_structured_without_structured_response(
         self, agent, mock_structured_model
@@ -379,8 +380,7 @@ class TestBaseAgentInvokeStructured:
         """Test that invoke_structured handles None result (model didn't call tool)."""
         from src.types.telemetry import AgentMetrics
 
-        # Model returns None when it doesn't call the tool
-        mock_structured_model.invoke.return_value = None
+        mock_structured_model.invoke.return_value = {"raw": AIMessage(content=""), "parsed": None}
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
@@ -398,15 +398,16 @@ class TestBaseAgentInvokeStructured:
         from src.types.telemetry import AgentMetrics
 
         ai_msg = AIMessage(content="Response")
+        parsed_obj = {"field": "value"}
 
-        mock_structured_model.invoke.return_value = ai_msg
+        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == ai_msg
+        assert result == parsed_obj
         assert metrics.input_tokens == 0
         assert metrics.output_tokens == 0
 
@@ -418,25 +419,26 @@ class TestBaseAgentInvokeStructured:
 
         ai_msg = AIMessage(content="Response")
         ai_msg.usage_metadata = None
+        parsed_obj = {"field": "value"}
 
-        mock_structured_model.invoke.return_value = ai_msg
+        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], metrics
         )
 
-        assert result == ai_msg
+        assert result == parsed_obj
         assert metrics.input_tokens == 0
         assert metrics.output_tokens == 0
 
     def test_invoke_structured_no_ai_messages(self, agent, mock_structured_model):
-        """Test that invoke_structured handles non-AIMessage result."""
+        """Test that invoke_structured handles result without usage metadata."""
         from src.types.telemetry import AgentMetrics
 
-        # When model successfully parses, it might return the parsed object directly
+        ai_msg = AIMessage(content="Response")
         parsed_result = {"field": "value"}
-        mock_structured_model.invoke.return_value = parsed_result
+        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_result}
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -347,7 +347,10 @@ class TestBaseAgentInvokeStructured:
         )
 
         parsed_obj = {"field": "value"}
-        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
+        mock_structured_model.invoke.return_value = {
+            "raw": ai_msg,
+            "parsed": parsed_obj,
+        }
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
@@ -366,7 +369,10 @@ class TestBaseAgentInvokeStructured:
         )
 
         parsed_obj = {"field": "value"}
-        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
+        mock_structured_model.invoke.return_value = {
+            "raw": ai_msg,
+            "parsed": parsed_obj,
+        }
 
         result = agent.invoke_structured(
             dict, [{"role": "user", "content": "test"}], None
@@ -380,7 +386,10 @@ class TestBaseAgentInvokeStructured:
         """Test that invoke_structured handles None result (model didn't call tool)."""
         from src.types.telemetry import AgentMetrics
 
-        mock_structured_model.invoke.return_value = {"raw": AIMessage(content=""), "parsed": None}
+        mock_structured_model.invoke.return_value = {
+            "raw": AIMessage(content=""),
+            "parsed": None,
+        }
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
@@ -400,7 +409,10 @@ class TestBaseAgentInvokeStructured:
         ai_msg = AIMessage(content="Response")
         parsed_obj = {"field": "value"}
 
-        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
+        mock_structured_model.invoke.return_value = {
+            "raw": ai_msg,
+            "parsed": parsed_obj,
+        }
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
@@ -421,7 +433,10 @@ class TestBaseAgentInvokeStructured:
         ai_msg.usage_metadata = None
         parsed_obj = {"field": "value"}
 
-        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_obj}
+        mock_structured_model.invoke.return_value = {
+            "raw": ai_msg,
+            "parsed": parsed_obj,
+        }
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(
@@ -438,7 +453,10 @@ class TestBaseAgentInvokeStructured:
 
         ai_msg = AIMessage(content="Response")
         parsed_result = {"field": "value"}
-        mock_structured_model.invoke.return_value = {"raw": ai_msg, "parsed": parsed_result}
+        mock_structured_model.invoke.return_value = {
+            "raw": ai_msg,
+            "parsed": parsed_result,
+        }
 
         metrics = AgentMetrics(name="TestAgent")
         result = agent.invoke_structured(


### PR DESCRIPTION
  Make GPT-OSS (openai.gpt-oss-120b-1:0) compatible with x2a-convertor by fixing  structured output behavior and parsing issues.

  ## Problem

  GPT-OSS had multiple compatibility issues:

  1. model would return malformed JSON with Native Method
  2. Reasoning Content in Responses
  3. tool_choice Parameter Not Supported


  ## Changes

  ### Core Implementation (`src/base_agent.py`)

  - **Switched to `with_structured_output`**: Replaced `create_agent(response_format=schema)` with `model.with_structured_output(schema, method="function_calling")` for better reliability
  - **Added strong prompt instructions**: New class constants `STRUCTURED_OUTPUT_INSTRUCTION`, `STRUCTURED_ERROR`, and `TOOL_CALL_CORRECTION` to guide models toward tool calling
  - **Fixed reasoning_content handling**: Updated `invoke_llm` to use `.text` property instead of `.content` to properly handle reasoning blocks
  - **Refactored token extraction**: Created `_extract_message_tokens()` helper for single messages and updated `_extract_token_usage()` to use it
  - **Extracted error handling**: Created `_raise_missing_structured_output()` helper to fix TRY301 linter warning

