### PR TITLE
feat(puppet): filepaths with the execution tree

### DIFF
--- a/src/inputs/puppet/analyzer.py
+++ b/src/inputs/puppet/analyzer.py
@@ -274,6 +274,11 @@ class PuppetSubagent:
                 tree_builder, tree_root, structured_analysis
             )
 
+            execution_tree_files = sorted(tree_builder.collect_file_paths(tree_root))
+            slog.info(
+                f"Execution tree includes {len(execution_tree_files)} manifest files"
+            )
+
             if metrics:
                 metrics.record_metric("manifests_analyzed", len(manifests))
                 metrics.record_metric("hiera_files_analyzed", len(hiera_data))
@@ -286,6 +291,7 @@ class PuppetSubagent:
         return state.update(
             structured_analysis=structured_analysis,
             execution_tree_summary=execution_tree_summary,
+            execution_tree_file_paths=execution_tree_files,
             credentials_analysis=credentials_analysis,
         )
 

--- a/src/inputs/puppet/execution_tree_builder.py
+++ b/src/inputs/puppet/execution_tree_builder.py
@@ -115,6 +115,22 @@ class PuppetExecutionTreeBuilder:
 
         return "\n".join(lines)
 
+    def collect_file_paths(self, node: ExecutionTreeNode) -> set[str]:
+        """Collect all file paths from execution tree nodes.
+
+        Only class nodes have file_path set. This traverses the tree
+        depth-first and collects all non-None file paths.
+        """
+        paths = set()
+
+        if node.file_path:
+            paths.add(node.file_path)
+
+        for child in node.children:
+            paths.update(self.collect_file_paths(child))
+
+        return paths
+
     def _normalize_class_name(self, class_name: str) -> str:
         """Normalize class name by removing leading :: for consistent lookups."""
         return class_name.lstrip(":")

--- a/src/inputs/puppet/report_writer_agent.py
+++ b/src/inputs/puppet/report_writer_agent.py
@@ -72,11 +72,11 @@ class ReportWriterAgent(InputAgent[PuppetState]):
         return state.update(specification=response_messages[-1].content)
 
     def _build_file_listing(self, state: PuppetState) -> str:
-        if not state.structured_analysis:
+        """Build file listing from execution tree files only."""
+        if not state.execution_tree_file_paths:
             return ""
 
-        file_paths = set(state.structured_analysis.analyzed_file_paths)
-        return "\n".join(sorted(file_paths))
+        return "\n".join(state.execution_tree_file_paths)
 
     def _generate_tree_sitter_report(self, path: str) -> str:
         analyzer = TreeSitterAnalyzer()

--- a/src/inputs/puppet/state.py
+++ b/src/inputs/puppet/state.py
@@ -32,6 +32,7 @@ class PuppetState(BaseState):
         default=None, kw_only=True
     )
     execution_tree_summary: str = field(default="", kw_only=True)
+    execution_tree_file_paths: list[str] = field(kw_only=True, default_factory=list)
     credentials_analysis: list[CredentialAnalysisResult] | None = field(
         default=None, kw_only=True
     )


### PR DESCRIPTION
Instead of getting the full list from the folders, just use the files from the execution tree, so it's easier to get it right on the Ansible part.