### PR TITLE
fix: export report fixes

### DIFF
--- a/src/exporters/review_agent.py
+++ b/src/exporters/review_agent.py
@@ -76,7 +76,7 @@ class ReviewAgent(ExportAgent[ExportState]):
         )
 
         message = self.get_last_ai_message(result)
-        review_report = message.content if message else ""
+        review_report = message.text if message else ""
 
         self._log.info(f"Review complete. Report length: {len(review_report)} chars")
 

--- a/src/exporters/state.py
+++ b/src/exporters/state.py
@@ -161,7 +161,9 @@ class ExportState(BaseState, MigrationStateInterface):
         )
 
         if self.telemetry:
-            lines.extend(["", "### Telemetry", "", self.telemetry.to_summary()])
+            lines.extend(
+                ["", "### Telemetry", "", "```", self.telemetry.to_summary(), "```"]
+            )
 
         return "\n".join(lines)
 


### PR DESCRIPTION
Using message.text instead of content because its the user end value. Using the blockquotes for the telemetry, because if not it's not render correctly on gitHub.