### PR TITLE
feat: add X2A summarization middleware that preserves original messages

### DIFF
--- a/prompts/x2a_summarize.j2
+++ b/prompts/x2a_summarize.j2
@@ -1,0 +1,26 @@
+You are a conversation summarizer for an infrastructure migration agent.
+
+The original task instructions are preserved separately — do NOT restate them.
+
+Summarize ONLY the actions taken and findings discovered during the conversation below.
+
+Structure your summary as:
+
+## Actions Completed
+- List each tool call and its key result (file read, directory listed, search performed, etc.)
+- Include specific file paths, resource names, and values discovered
+
+## Key Findings
+- Important facts, configurations, or patterns discovered
+- Decisions made and reasoning behind them
+
+## Current Progress
+- What has been accomplished toward the goal
+- What remains to be done next
+
+Be concise. Focus on facts and data that the agent needs to continue working.
+Do NOT include general instructions, role descriptions, or task definitions.
+
+<messages>
+{{ messages }}
+</messages>

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -13,17 +13,18 @@ from collections.abc import Callable
 from typing import Any, ClassVar
 
 from langchain.agents import create_agent
-from langchain.agents.middleware import SummarizationMiddleware
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain.agents.structured_output import StructuredOutputValidationError
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_core.tools import BaseTool
 
 from src.config import get_settings
+from src.const import X2A_ORIGINAL_MESSAGE
 from src.middleware.agent_dump import AgentDumpMiddleware
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
+from src.middleware.x2a_summarize import X2ASummarizationMiddleware
 from src.model import get_model, get_runnable_config, report_tool_calls
 from src.types.base_state import BaseState
 from src.types.telemetry import AgentMetrics, telemetry_context
@@ -46,7 +47,7 @@ class BaseAgent[S: BaseState](ABC):
     RULES_FILE: ClassVar[str | None] = None
     GOAL: ClassVar[str | None] = None
     MAX_TOKENS_BEFORE_SUMMARY: ClassVar[int] = 20000
-    MESSAGES_TO_KEEP: ClassVar[int] = 20
+    MESSAGES_TO_KEEP: ClassVar[int] = 6
 
     STRUCTURED_OUTPUT_INSTRUCTION = """CRITICAL INSTRUCTION - STRUCTURED OUTPUT REQUIRED:
 
@@ -134,9 +135,9 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         if self.RULES_FILE:
             stack.append(RulesMiddleware(self.RULES_FILE))
         stack.append(
-            SummarizationMiddleware(
+            X2ASummarizationMiddleware(
                 model=self.model,
-                max_tokens_before_summary=self.MAX_TOKENS_BEFORE_SUMMARY,
+                max_tokens=self.MAX_TOKENS_BEFORE_SUMMARY,
                 messages_to_keep=self.MESSAGES_TO_KEEP,
             ),
         )
@@ -203,13 +204,14 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         Returns the raw result dict from the agent.
         """
         tools = self._get_tools(state)
+        tagged_messages = self._tag_original_messages(messages)
 
         agent = create_agent(
             model=self.model, middleware=self.middleware(), tools=tools
         )
 
         result = agent.invoke(
-            {"messages": messages},
+            {"messages": tagged_messages},
             get_runnable_config(),
         )
 
@@ -342,6 +344,26 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         if isinstance(result.content, str):
             return result.content
         return str(result.content)
+
+    @staticmethod
+    def _tag_original_messages(
+        messages: list[dict[str, str]],
+    ) -> list[HumanMessage | SystemMessage]:
+        """Convert raw message dicts into tagged LangChain message objects."""
+        tag = {X2A_ORIGINAL_MESSAGE: True}
+        tagged: list[HumanMessage | SystemMessage] = []
+        for msg in messages:
+            role = msg.get("role", "user")
+            content = msg.get("content", "")
+            if role == "system":
+                tagged.append(
+                    SystemMessage(content=content, additional_kwargs=tag.copy())
+                )
+            else:
+                tagged.append(
+                    HumanMessage(content=content, additional_kwargs=tag.copy())
+                )
+        return tagged
 
     @staticmethod
     def get_last_ai_message(result: dict) -> AIMessage | None:

--- a/src/const.py
+++ b/src/const.py
@@ -14,3 +14,5 @@ METADATA_FILENAME = "generated-project-metadata.json"
 
 INPUT_AGENTS_FILE = "INPUT-AGENTS.md"
 EXPORT_AGENTS_FILE = "EXPORT-AGENTS.md"
+
+X2A_ORIGINAL_MESSAGE = "x2a_original_message"

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -69,8 +69,8 @@ class WriteAgent(ExportAgent[ExportState]):
     # 1. Large checklists with many items must stay in context
     # 2. File writing operations generate verbose tool results
     # 3. For smaller models (GPT-OSS-120b), summarization can cause premature completion
-    MAX_TOKENS_BEFORE_SUMMARY = 50000  # Increased from default 20000
-    MESSAGES_TO_KEEP = 30  # Increased from default 20
+    MAX_TOKENS_BEFORE_SUMMARY = 30000  # Increased from default 20000
+    MESSAGES_TO_KEEP = 8  # Increased from default 20
 
     def __init__(self, model=None, max_attempts=None):
         super().__init__(model)

--- a/src/middleware/__init__.py
+++ b/src/middleware/__init__.py
@@ -1,5 +1,6 @@
 """Middleware components for agent pipelines."""
 
 from src.middleware.rules import RulesMiddleware
+from src.middleware.x2a_summarize import X2ASummarizationMiddleware
 
-__all__ = ["RulesMiddleware"]
+__all__ = ["RulesMiddleware", "X2ASummarizationMiddleware"]

--- a/src/middleware/x2a_summarize.py
+++ b/src/middleware/x2a_summarize.py
@@ -1,0 +1,227 @@
+"""Middleware that summarizes non-original conversation messages when context grows too large.
+
+Preserves the original system/user messages (tagged via additional_kwargs) verbatim
+and only summarizes the tool-call/AI-response conversation that follows.
+"""
+
+from __future__ import annotations
+
+import uuid
+from functools import partial
+from typing import Any
+
+from langchain.agents.middleware.types import AgentMiddleware
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AnyMessage, RemoveMessage, ToolMessage
+from langchain_core.messages.ai import AIMessage
+from langchain_core.messages.human import HumanMessage
+from langchain_core.messages.utils import count_tokens_approximately, get_buffer_string
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+from langgraph.runtime import Runtime
+
+from prompts.get_prompt import get_prompt
+from src.const import X2A_ORIGINAL_MESSAGE
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class X2ASummarizationMiddleware(AgentMiddleware):
+    """Summarizes non-original messages when token usage exceeds a threshold.
+
+    Original messages (tagged with X2A_ORIGINAL_MESSAGE in additional_kwargs)
+    are always preserved verbatim. Only the tool-call/AI-response conversation
+    is summarized into a concise action log.
+    """
+
+    def __init__(
+        self,
+        model: BaseChatModel,
+        *,
+        messages_to_keep: int = 6,
+        max_tokens: int = 20_000,
+        original_messages_tag: str = X2A_ORIGINAL_MESSAGE,
+    ) -> None:
+        self._model = model
+        self._messages_to_keep = messages_to_keep
+        self._max_tokens = max_tokens
+        self._original_messages_tag = original_messages_tag
+        self._token_counter = partial(
+            count_tokens_approximately, use_usage_metadata_scaling=True
+        )
+
+    def before_model(self, state: Any, runtime: Runtime) -> dict[str, Any] | None:
+        messages: list[AnyMessage] = state["messages"]
+        self._ensure_message_ids(messages)
+
+        token_count = self._token_counter(messages)
+        if token_count < self._max_tokens:
+            return None
+
+        logger.info(
+            "Token threshold exceeded, summarizing",
+            token_count=token_count,
+            max_tokens=self._max_tokens,
+            message_count=len(messages),
+        )
+
+        original, non_original = self._partition_by_tag(messages)
+
+        if not non_original:
+            return None
+
+        kept = self._select_recent_messages(non_original)
+        to_summarize = non_original[: len(non_original) - len(kept)]
+
+        if not to_summarize:
+            return None
+
+        summary_text = self._create_summary(to_summarize)
+        summary_message = HumanMessage(
+            content=f"Summary of previous actions:\n\n{summary_text}",
+            id=str(uuid.uuid4()),
+        )
+
+        logger.info(
+            "Summarization complete",
+            original_count=len(original),
+            summarized_count=len(to_summarize),
+            kept_count=len(kept),
+        )
+        return {
+            "messages": [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                *original,
+                summary_message,
+                *kept,
+            ]
+        }
+
+    async def abefore_model(
+        self, state: Any, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        messages: list[AnyMessage] = state["messages"]
+        self._ensure_message_ids(messages)
+
+        token_count = self._token_counter(messages)
+        if token_count < self._max_tokens:
+            return None
+
+        logger.info(
+            "Token threshold exceeded, summarizing (async)",
+            token_count=token_count,
+            max_tokens=self._max_tokens,
+            message_count=len(messages),
+        )
+
+        original, non_original = self._partition_by_tag(messages)
+
+        if not non_original:
+            return None
+
+        kept = self._select_recent_messages(non_original)
+        to_summarize = non_original[: len(non_original) - len(kept)]
+
+        if not to_summarize:
+            return None
+
+        summary_text = await self._acreate_summary(to_summarize)
+        summary_message = HumanMessage(
+            content=f"Summary of previous actions:\n\n{summary_text}",
+            id=str(uuid.uuid4()),
+        )
+
+        logger.info(
+            "Summarization complete (async)",
+            original_count=len(original),
+            summarized_count=len(to_summarize),
+            kept_count=len(kept),
+        )
+        return {
+            "messages": [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                *original,
+                summary_message,
+                *kept,
+            ]
+        }
+
+    def _partition_by_tag(
+        self, messages: list[AnyMessage]
+    ) -> tuple[list[AnyMessage], list[AnyMessage]]:
+        original = [
+            msg
+            for msg in messages
+            if getattr(msg, "additional_kwargs", {}).get(self._original_messages_tag)
+        ]
+        non_original = [
+            msg
+            for msg in messages
+            if not getattr(msg, "additional_kwargs", {}).get(
+                self._original_messages_tag
+            )
+        ]
+        return original, non_original
+
+    def _select_recent_messages(self, messages: list[AnyMessage]) -> list[AnyMessage]:
+        if len(messages) <= self._messages_to_keep:
+            return list(messages)
+
+        cutoff = len(messages) - self._messages_to_keep
+        cutoff = self._adjust_cutoff_for_tool_pairs(messages, cutoff)
+        return messages[cutoff:]
+
+    def _create_summary(self, messages: list[AnyMessage]) -> str:
+        if not messages:
+            return "No previous actions to summarize."
+
+        formatted = get_buffer_string(messages)
+        prompt_template = get_prompt("x2a_summarize")
+        prompt_text = prompt_template.format(messages=formatted)
+
+        try:
+            response = self._model.invoke(prompt_text)
+            return response.text.strip()
+        except Exception as e:
+            logger.error("Summarization failed", error=str(e))
+            return f"Error generating summary: {e!s}"
+
+    async def _acreate_summary(self, messages: list[AnyMessage]) -> str:
+        if not messages:
+            return "No previous actions to summarize."
+
+        formatted = get_buffer_string(messages)
+        prompt_template = get_prompt("x2a_summarize")
+        prompt_text = prompt_template.format(messages=formatted)
+
+        try:
+            response = await self._model.ainvoke(prompt_text)
+            return response.text.strip()
+        except Exception as e:
+            logger.error("Summarization failed (async)", error=str(e))
+            return f"Error generating summary: {e!s}"
+
+    @staticmethod
+    def _adjust_cutoff_for_tool_pairs(messages: list[AnyMessage], cutoff: int) -> int:
+        if cutoff >= len(messages):
+            return cutoff
+
+        if not isinstance(messages[cutoff], ToolMessage):
+            return cutoff
+
+        for i in range(cutoff - 1, -1, -1):
+            if isinstance(messages[i], AIMessage) and getattr(
+                messages[i], "tool_calls", None
+            ):
+                return i
+
+        idx = cutoff
+        while idx < len(messages) and isinstance(messages[idx], ToolMessage):
+            idx += 1
+        return idx
+
+    @staticmethod
+    def _ensure_message_ids(messages: list[AnyMessage]) -> None:
+        for msg in messages:
+            if msg.id is None:
+                msg.id = str(uuid.uuid4())

--- a/src/middleware/x2a_summarize.py
+++ b/src/middleware/x2a_summarize.py
@@ -54,6 +54,38 @@ class X2ASummarizationMiddleware(AgentMiddleware):
         messages: list[AnyMessage] = state["messages"]
         self._ensure_message_ids(messages)
 
+        result = self._prepare_summarization(messages)
+        if result is None:
+            return None
+
+        original, to_summarize, kept = result
+        summary_text = self._create_summary(to_summarize)
+
+        if summary_text is None:
+            return None
+        return self._build_result(original, summary_text, kept, len(to_summarize))
+
+    async def abefore_model(
+        self, state: Any, runtime: Runtime
+    ) -> dict[str, Any] | None:
+        messages: list[AnyMessage] = state["messages"]
+        self._ensure_message_ids(messages)
+
+        result = self._prepare_summarization(messages)
+        if result is None:
+            return None
+
+        original, to_summarize, kept = result
+        summary_text = await self._acreate_summary(to_summarize)
+
+        if summary_text is None:
+            return None
+
+        return self._build_result(original, summary_text, kept, len(to_summarize))
+
+    def _prepare_summarization(
+        self, messages: list[AnyMessage]
+    ) -> tuple[list[AnyMessage], list[AnyMessage], list[AnyMessage]] | None:
         token_count = self._token_counter(messages)
         if token_count < self._max_tokens:
             return None
@@ -76,75 +108,7 @@ class X2ASummarizationMiddleware(AgentMiddleware):
         if not to_summarize:
             return None
 
-        summary_text = self._create_summary(to_summarize)
-        summary_message = HumanMessage(
-            content=f"Summary of previous actions:\n\n{summary_text}",
-            id=str(uuid.uuid4()),
-        )
-
-        logger.info(
-            "Summarization complete",
-            original_count=len(original),
-            summarized_count=len(to_summarize),
-            kept_count=len(kept),
-        )
-        return {
-            "messages": [
-                RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                *original,
-                summary_message,
-                *kept,
-            ]
-        }
-
-    async def abefore_model(
-        self, state: Any, runtime: Runtime
-    ) -> dict[str, Any] | None:
-        messages: list[AnyMessage] = state["messages"]
-        self._ensure_message_ids(messages)
-
-        token_count = self._token_counter(messages)
-        if token_count < self._max_tokens:
-            return None
-
-        logger.info(
-            "Token threshold exceeded, summarizing (async)",
-            token_count=token_count,
-            max_tokens=self._max_tokens,
-            message_count=len(messages),
-        )
-
-        original, non_original = self._partition_by_tag(messages)
-
-        if not non_original:
-            return None
-
-        kept = self._select_recent_messages(non_original)
-        to_summarize = non_original[: len(non_original) - len(kept)]
-
-        if not to_summarize:
-            return None
-
-        summary_text = await self._acreate_summary(to_summarize)
-        summary_message = HumanMessage(
-            content=f"Summary of previous actions:\n\n{summary_text}",
-            id=str(uuid.uuid4()),
-        )
-
-        logger.info(
-            "Summarization complete (async)",
-            original_count=len(original),
-            summarized_count=len(to_summarize),
-            kept_count=len(kept),
-        )
-        return {
-            "messages": [
-                RemoveMessage(id=REMOVE_ALL_MESSAGES),
-                *original,
-                summary_message,
-                *kept,
-            ]
-        }
+        return original, to_summarize, kept
 
     def _partition_by_tag(
         self, messages: list[AnyMessage]
@@ -163,6 +127,34 @@ class X2ASummarizationMiddleware(AgentMiddleware):
         ]
         return original, non_original
 
+    def _build_result(
+        self,
+        original: list[AnyMessage],
+        summary_text: str,
+        kept: list[AnyMessage],
+        summarized_count: int,
+    ) -> dict[str, Any]:
+        summary_message = HumanMessage(
+            content=f"Summary of previous actions:\n\n{summary_text}",
+            id=str(uuid.uuid4()),
+        )
+
+        logger.info(
+            "Summarization complete",
+            original_count=len(original),
+            summarized_count=summarized_count,
+            kept_count=len(kept),
+        )
+
+        return {
+            "messages": [
+                RemoveMessage(id=REMOVE_ALL_MESSAGES),
+                *original,
+                summary_message,
+                *kept,
+            ]
+        }
+
     def _select_recent_messages(self, messages: list[AnyMessage]) -> list[AnyMessage]:
         if len(messages) <= self._messages_to_keep:
             return list(messages)
@@ -171,35 +163,40 @@ class X2ASummarizationMiddleware(AgentMiddleware):
         cutoff = self._adjust_cutoff_for_tool_pairs(messages, cutoff)
         return messages[cutoff:]
 
-    def _create_summary(self, messages: list[AnyMessage]) -> str:
+    def _create_summary(self, messages: list[AnyMessage]) -> str | None:
         if not messages:
             return "No previous actions to summarize."
 
-        formatted = get_buffer_string(messages)
-        prompt_template = get_prompt("x2a_summarize")
-        prompt_text = prompt_template.format(messages=formatted)
+        prompt_text = self._build_summary_prompt(messages)
 
         try:
             response = self._model.invoke(prompt_text)
             return response.text.strip()
         except Exception as e:
-            logger.error("Summarization failed", error=str(e))
-            return f"Error generating summary: {e!s}"
+            logger.error(
+                "Summarization failed, keeping original messages", error=str(e)
+            )
+            return None
 
-    async def _acreate_summary(self, messages: list[AnyMessage]) -> str:
+    async def _acreate_summary(self, messages: list[AnyMessage]) -> str | None:
         if not messages:
             return "No previous actions to summarize."
 
-        formatted = get_buffer_string(messages)
-        prompt_template = get_prompt("x2a_summarize")
-        prompt_text = prompt_template.format(messages=formatted)
+        prompt_text = self._build_summary_prompt(messages)
 
         try:
             response = await self._model.ainvoke(prompt_text)
             return response.text.strip()
         except Exception as e:
-            logger.error("Summarization failed (async)", error=str(e))
-            return f"Error generating summary: {e!s}"
+            logger.error(
+                "Summarization failed, keeping original messages", error=str(e)
+            )
+            return None
+
+    def _build_summary_prompt(self, messages: list[AnyMessage]) -> str:
+        formatted = get_buffer_string(messages)
+        prompt_template = get_prompt("x2a_summarize")
+        return prompt_template.format(messages=formatted)
 
     @staticmethod
     def _adjust_cutoff_for_tool_pairs(messages: list[AnyMessage], cutoff: int) -> int:

--- a/tests/middleware/test_x2a_summarize.py
+++ b/tests/middleware/test_x2a_summarize.py
@@ -629,7 +629,7 @@ class TestSummaryCreation:
 
         result = middleware._create_summary(messages)
 
-        assert "Error generating summary" in result
+        assert result is None
 
 
 class TestEndToEndScenarios:
@@ -721,3 +721,28 @@ class TestEndToEndScenarios:
 
         assert result is None
         model.invoke.assert_not_called()
+
+    def test_summarization_failure_keeps_original_messages(self, model, runtime):
+        """Test that when summarization fails, original messages are preserved."""
+        model.invoke.side_effect = Exception("Model unavailable")
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=2
+        )
+
+        system_msg = SystemMessage(
+            content="You are a migration assistant",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        ai1 = AIMessage(content="Processing " * 50, id="msg2")
+        ai2 = AIMessage(content="Analyzing " * 50, id="msg3")
+        ai3 = AIMessage(content="Converting " * 50, id="msg4")
+        ai4 = AIMessage(content="Recent message", id="msg5")
+
+        messages = [system_msg, ai1, ai2, ai3, ai4]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is None
+        model.invoke.assert_called_once()

--- a/tests/middleware/test_x2a_summarize.py
+++ b/tests/middleware/test_x2a_summarize.py
@@ -1,0 +1,723 @@
+"""Tests for X2ASummarizationMiddleware."""
+
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    AnyMessage,
+    HumanMessage,
+    RemoveMessage,
+    SystemMessage,
+    ToolMessage,
+)
+from langgraph.graph.message import REMOVE_ALL_MESSAGES
+
+from src.const import X2A_ORIGINAL_MESSAGE
+from src.middleware.x2a_summarize import X2ASummarizationMiddleware
+
+
+class MockRuntime:
+    """Mock runtime for testing."""
+
+
+class TestX2ASummarizationMiddleware:
+    """Tests for X2ASummarizationMiddleware initialization and configuration."""
+
+    def test_init_with_defaults(self):
+        """Test middleware initialization with default parameters."""
+        model = Mock()
+        middleware = X2ASummarizationMiddleware(model)
+
+        assert middleware._model is model
+        assert middleware._messages_to_keep == 6
+        assert middleware._max_tokens == 20_000
+        assert middleware._original_messages_tag == X2A_ORIGINAL_MESSAGE
+
+    def test_init_with_custom_parameters(self):
+        """Test middleware initialization with custom parameters."""
+        model = Mock()
+        middleware = X2ASummarizationMiddleware(
+            model,
+            messages_to_keep=10,
+            max_tokens=50_000,
+            original_messages_tag="custom_tag",
+        )
+
+        assert middleware._messages_to_keep == 10
+        assert middleware._max_tokens == 50_000
+        assert middleware._original_messages_tag == "custom_tag"
+
+
+class TestPartitionByTag:
+    """Tests for _partition_by_tag method."""
+
+    @pytest.fixture
+    def middleware(self):
+        """Create a middleware instance."""
+        return X2ASummarizationMiddleware(Mock())
+
+    def test_partition_all_original(self, middleware):
+        """Test partitioning when all messages are tagged as original."""
+        messages = [
+            HumanMessage(
+                content="First", additional_kwargs={X2A_ORIGINAL_MESSAGE: True}
+            ),
+            SystemMessage(
+                content="Second", additional_kwargs={X2A_ORIGINAL_MESSAGE: True}
+            ),
+        ]
+
+        original, non_original = middleware._partition_by_tag(messages)
+
+        assert len(original) == 2
+        assert len(non_original) == 0
+        assert original == messages
+
+    def test_partition_all_non_original(self, middleware):
+        """Test partitioning when no messages are tagged as original."""
+        messages = [
+            AIMessage(content="First"),
+            ToolMessage(content="Result", tool_call_id="123"),
+        ]
+
+        original, non_original = middleware._partition_by_tag(messages)
+
+        assert len(original) == 0
+        assert len(non_original) == 2
+        assert non_original == messages
+
+    def test_partition_mixed(self, middleware):
+        """Test partitioning with mixed original and non-original messages."""
+        msg1 = HumanMessage(
+            content="Original", additional_kwargs={X2A_ORIGINAL_MESSAGE: True}
+        )
+        msg2 = AIMessage(content="Response")
+        msg3 = ToolMessage(content="Tool result", tool_call_id="123")
+
+        messages = [msg1, msg2, msg3]
+
+        original, non_original = middleware._partition_by_tag(messages)
+
+        assert len(original) == 1
+        assert len(non_original) == 2
+        assert original[0] is msg1
+        assert msg2 in non_original
+        assert msg3 in non_original
+
+    def test_partition_empty_list(self, middleware):
+        """Test partitioning with empty message list."""
+        messages = []
+
+        original, non_original = middleware._partition_by_tag(messages)
+
+        assert len(original) == 0
+        assert len(non_original) == 0
+
+    def test_partition_false_tag_value(self, middleware):
+        """Test that False tag value is treated as non-original."""
+        messages = [
+            HumanMessage(
+                content="Not original", additional_kwargs={X2A_ORIGINAL_MESSAGE: False}
+            ),
+        ]
+
+        original, non_original = middleware._partition_by_tag(messages)
+
+        assert len(original) == 0
+        assert len(non_original) == 1
+
+
+class TestSelectRecentMessages:
+    """Tests for _select_recent_messages method."""
+
+    @pytest.fixture
+    def middleware(self):
+        """Create a middleware instance with 3 messages to keep."""
+        return X2ASummarizationMiddleware(Mock(), messages_to_keep=3)
+
+    def test_select_fewer_than_limit(self, middleware):
+        """Test selection when message count is below the limit."""
+        messages = [
+            AIMessage(content="1"),
+            AIMessage(content="2"),
+        ]
+
+        result = middleware._select_recent_messages(messages)
+
+        assert len(result) == 2
+        assert result == messages
+
+    def test_select_exact_limit(self, middleware):
+        """Test selection when message count equals the limit."""
+        messages = [
+            AIMessage(content="1"),
+            AIMessage(content="2"),
+            AIMessage(content="3"),
+        ]
+
+        result = middleware._select_recent_messages(messages)
+
+        assert len(result) == 3
+        assert result == messages
+
+    def test_select_more_than_limit(self, middleware):
+        """Test selection when message count exceeds the limit."""
+        messages = [
+            AIMessage(content="1"),
+            AIMessage(content="2"),
+            AIMessage(content="3"),
+            AIMessage(content="4"),
+            AIMessage(content="5"),
+        ]
+
+        result = middleware._select_recent_messages(messages)
+
+        assert len(result) == 3
+        assert result == messages[-3:]
+
+    def test_select_adjusts_cutoff_for_tool_pairs(self, middleware):
+        """Test that cutoff is adjusted to preserve AI-Tool message pairs."""
+        from langchain_core.tools import tool
+
+        @tool
+        def test_tool() -> str:
+            """Test tool."""
+            return "result"
+
+        ai_msg = AIMessage(
+            content="AI",
+            tool_calls=[
+                {
+                    "name": "test_tool",
+                    "args": {},
+                    "id": "123",
+                    "type": "tool_call",
+                }
+            ],
+        )
+        tool_msg = ToolMessage(content="Tool result", tool_call_id="123")
+
+        messages = [
+            AIMessage(content="1"),
+            AIMessage(content="2"),
+            ai_msg,  # Should keep this...
+            tool_msg,  # ...and its corresponding tool message
+            AIMessage(content="5"),
+        ]
+
+        result = middleware._select_recent_messages(messages)
+
+        # Should include the AI-Tool pair even if it means keeping more than 3
+        assert ai_msg in result
+        assert tool_msg in result
+
+    def test_select_empty_list(self, middleware):
+        """Test selection with empty message list."""
+        messages = []
+
+        result = middleware._select_recent_messages(messages)
+
+        assert len(result) == 0
+
+
+class TestAdjustCutoffForToolPairs:
+    """Tests for _adjust_cutoff_for_tool_pairs static method."""
+
+    def test_cutoff_beyond_messages(self):
+        """Test when cutoff is beyond message list length."""
+        messages: list[AnyMessage] = [AIMessage(content="1")]
+        cutoff = 10
+
+        result = X2ASummarizationMiddleware._adjust_cutoff_for_tool_pairs(
+            messages, cutoff
+        )
+
+        assert result == cutoff
+
+    def test_cutoff_not_on_tool_message(self):
+        """Test when cutoff doesn't land on a ToolMessage."""
+        messages: list[AnyMessage] = [
+            AIMessage(content="1"),
+            AIMessage(content="2"),
+            AIMessage(content="3"),
+        ]
+        cutoff = 1
+
+        result = X2ASummarizationMiddleware._adjust_cutoff_for_tool_pairs(
+            messages, cutoff
+        )
+
+        assert result == cutoff
+
+    def test_cutoff_on_tool_message_finds_ai_message(self):
+        """Test when cutoff is on ToolMessage and finds matching AIMessage."""
+        ai_msg = AIMessage(
+            content="AI",
+            tool_calls=[
+                {
+                    "name": "test_tool",
+                    "args": {},
+                    "id": "123",
+                    "type": "tool_call",
+                }
+            ],
+        )
+        tool_msg = ToolMessage(content="Result", tool_call_id="123")
+
+        messages: list[AnyMessage] = [
+            AIMessage(content="1"),
+            ai_msg,
+            tool_msg,  # Cutoff here
+            AIMessage(content="4"),
+        ]
+        cutoff = 2
+
+        result = X2ASummarizationMiddleware._adjust_cutoff_for_tool_pairs(
+            messages, cutoff
+        )
+
+        assert result == 1  # Adjusted to include the AI message
+
+    def test_cutoff_on_tool_message_no_ai_message(self):
+        """Test when cutoff is on ToolMessage but no matching AIMessage found."""
+        tool_msg1 = ToolMessage(content="Result1", tool_call_id="123")
+        tool_msg2 = ToolMessage(content="Result2", tool_call_id="456")
+
+        messages: list[AnyMessage] = [
+            AIMessage(content="1"),
+            tool_msg1,  # Cutoff here
+            tool_msg2,
+            AIMessage(content="4"),
+        ]
+        cutoff = 1
+
+        result = X2ASummarizationMiddleware._adjust_cutoff_for_tool_pairs(
+            messages, cutoff
+        )
+
+        # Should skip past consecutive tool messages
+        assert result == 3
+
+    def test_cutoff_on_multiple_consecutive_tool_messages(self):
+        """Test adjustment skips all consecutive ToolMessages."""
+        messages: list[AnyMessage] = [
+            AIMessage(content="1"),
+            ToolMessage(content="Result1", tool_call_id="123"),  # Cutoff
+            ToolMessage(content="Result2", tool_call_id="456"),
+            ToolMessage(content="Result3", tool_call_id="789"),
+            AIMessage(content="5"),
+        ]
+        cutoff = 1
+
+        result = X2ASummarizationMiddleware._adjust_cutoff_for_tool_pairs(
+            messages, cutoff
+        )
+
+        assert result == 4  # Skip all consecutive tool messages
+
+
+class TestEnsureMessageIds:
+    """Tests for _ensure_message_ids static method."""
+
+    def test_ensure_ids_for_messages_without_ids(self):
+        """Test that messages without IDs get assigned UUIDs."""
+        messages: list[AnyMessage] = [
+            AIMessage(content="1"),
+            HumanMessage(content="2"),
+            SystemMessage(content="3"),
+        ]
+
+        X2ASummarizationMiddleware._ensure_message_ids(messages)
+
+        for msg in messages:
+            assert msg.id is not None
+            assert isinstance(msg.id, str)
+            assert len(msg.id) == 36  # UUID format
+
+    def test_ensure_ids_preserves_existing_ids(self):
+        """Test that existing IDs are not overwritten."""
+        existing_id = "existing-id-123"
+        messages: list[AnyMessage] = [
+            AIMessage(content="1", id=existing_id),
+            HumanMessage(content="2"),
+        ]
+
+        X2ASummarizationMiddleware._ensure_message_ids(messages)
+
+        assert messages[0].id == existing_id
+        assert messages[1].id is not None
+
+    def test_ensure_ids_empty_list(self):
+        """Test with empty message list."""
+        messages = []
+        X2ASummarizationMiddleware._ensure_message_ids(messages)
+        assert len(messages) == 0
+
+
+class TestBeforeModelTokenThreshold:
+    """Tests for before_model method token threshold behavior."""
+
+    @pytest.fixture
+    def model(self):
+        """Create a mock model."""
+        return Mock()
+
+    @pytest.fixture
+    def runtime(self):
+        """Create a mock runtime."""
+        return MockRuntime()
+
+    def test_before_model_below_threshold_returns_none(self, model, runtime):
+        """Test that middleware does nothing when below token threshold."""
+        middleware = X2ASummarizationMiddleware(model, max_tokens=100_000)
+
+        messages = [
+            HumanMessage(
+                content="Short message", additional_kwargs={X2A_ORIGINAL_MESSAGE: True}
+            ),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is None
+
+    def test_before_model_above_threshold_triggers_summary(self, model, runtime):
+        """Test that middleware triggers summary when above threshold."""
+        model.invoke.return_value = Mock(text="Summary of actions")
+
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=1
+        )
+
+        original = HumanMessage(
+            content="Original",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        messages = [
+            original,
+            AIMessage(content="Long response " * 100, id="msg2"),
+            ToolMessage(content="Tool result " * 100, tool_call_id="123", id="msg3"),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        assert "messages" in result
+        assert model.invoke.called
+
+
+class TestBeforeModelSummarization:
+    """Tests for before_model summarization logic."""
+
+    @pytest.fixture
+    def model(self):
+        """Create a mock model."""
+        mock = Mock()
+        mock.invoke.return_value = Mock(text="Summarized content")
+        return mock
+
+    @pytest.fixture
+    def runtime(self):
+        """Create a mock runtime."""
+        return MockRuntime()
+
+    def test_before_model_preserves_original_messages(self, model, runtime):
+        """Test that original messages are preserved verbatim."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=1
+        )
+
+        original1 = SystemMessage(
+            content="System prompt",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        original2 = HumanMessage(
+            content="User input",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg2",
+        )
+        non_original1 = AIMessage(content="Response " * 100, id="msg3")
+        non_original2 = AIMessage(content="Another " * 100, id="msg4")
+
+        messages = [original1, original2, non_original1, non_original2]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        result_messages = result["messages"]
+
+        # Filter out RemoveMessage
+        preserved = [
+            msg for msg in result_messages if not isinstance(msg, RemoveMessage)
+        ]
+
+        assert original1 in preserved
+        assert original2 in preserved
+
+    def test_before_model_creates_summary_message(self, model, runtime):
+        """Test that a summary HumanMessage is created."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=1
+        )
+
+        original = HumanMessage(
+            content="Original",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        messages = [
+            original,
+            AIMessage(content="AI response " * 100, id="msg2"),
+            ToolMessage(content="Tool result " * 100, tool_call_id="123", id="msg3"),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        result_messages = result["messages"]
+        human_messages = [
+            msg for msg in result_messages if isinstance(msg, HumanMessage)
+        ]
+
+        # Should have original + summary
+        assert len(human_messages) == 2
+        summary_msg = next(msg for msg in human_messages if msg is not original)
+        assert "Summary of previous actions:" in summary_msg.content
+
+    def test_before_model_keeps_recent_messages(self, model, runtime):
+        """Test that recent messages are preserved."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=2
+        )
+
+        original = HumanMessage(
+            content="Original",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        ai1 = AIMessage(content="AI 1 " * 100, id="msg2")
+        ai2 = AIMessage(content="AI 2", id="msg3")
+        ai3 = AIMessage(content="AI 3", id="msg4")
+
+        messages = [original, ai1, ai2, ai3]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        result_messages = [
+            msg for msg in result["messages"] if not isinstance(msg, RemoveMessage)
+        ]
+
+        # Should have: original, summary, ai2, ai3 (last 2 non-original)
+        assert ai2 in result_messages
+        assert ai3 in result_messages
+
+    def test_before_model_removes_all_old_messages(self, model, runtime):
+        """Test that RemoveMessage with REMOVE_ALL_MESSAGES is issued."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=1
+        )
+
+        messages = [
+            HumanMessage(
+                content="Original",
+                additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+                id="msg1",
+            ),
+            AIMessage(content="AI1 " * 100, id="msg2"),
+            AIMessage(content="AI2 " * 100, id="msg3"),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        result_messages = result["messages"]
+        remove_messages = [
+            msg for msg in result_messages if isinstance(msg, RemoveMessage)
+        ]
+
+        assert len(remove_messages) == 1
+        assert remove_messages[0].id == REMOVE_ALL_MESSAGES
+
+    def test_before_model_no_non_original_messages(self, model, runtime):
+        """Test when all messages are original (no summarization needed)."""
+        middleware = X2ASummarizationMiddleware(model, max_tokens=10)
+
+        messages = [
+            HumanMessage(
+                content="Original " * 100,
+                additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            ),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        # Should return None since there's nothing to summarize
+        assert result is None
+
+    def test_before_model_no_messages_to_summarize(self, model, runtime):
+        """Test when all non-original messages should be kept."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=10
+        )
+
+        messages = [
+            HumanMessage(
+                content="Original", additional_kwargs={X2A_ORIGINAL_MESSAGE: True}
+            ),
+            AIMessage(content="AI " * 100),
+            AIMessage(content="AI2"),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        # Should return None since we're keeping all non-original messages
+        assert result is None
+
+
+class TestSummaryCreation:
+    """Tests for _create_summary method."""
+
+    @pytest.fixture
+    def model(self):
+        """Create a mock model."""
+        mock = Mock()
+        mock.invoke.return_value = Mock(text="Summary text")
+        return mock
+
+    @pytest.fixture
+    def middleware(self, model):
+        """Create middleware instance."""
+        return X2ASummarizationMiddleware(model)
+
+    def test_create_summary_with_messages(self, middleware, model):
+        """Test summary creation with valid messages."""
+        messages = [
+            AIMessage(content="First"),
+            ToolMessage(content="Result", tool_call_id="123"),
+        ]
+
+        result = middleware._create_summary(messages)
+
+        assert result == "Summary text"
+        model.invoke.assert_called_once()
+
+    def test_create_summary_empty_messages(self, middleware, model):
+        """Test summary creation with empty message list."""
+        messages = []
+
+        result = middleware._create_summary(messages)
+
+        assert result == "No previous actions to summarize."
+        model.invoke.assert_not_called()
+
+    def test_create_summary_model_error(self, middleware, model):
+        """Test summary creation handles model errors gracefully."""
+        model.invoke.side_effect = Exception("Model error")
+        messages = [AIMessage(content="Message")]
+
+        result = middleware._create_summary(messages)
+
+        assert "Error generating summary" in result
+
+
+class TestEndToEndScenarios:
+    """End-to-end integration tests for the middleware."""
+
+    @pytest.fixture
+    def model(self):
+        """Create a mock model."""
+        mock = Mock()
+        mock.invoke.return_value = Mock(text="Actions completed:\n- Read file")
+        return mock
+
+    @pytest.fixture
+    def runtime(self):
+        """Create a mock runtime."""
+        return MockRuntime()
+
+    def test_complete_summarization_flow(self, model, runtime):
+        """Test a complete summarization flow from start to finish."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=2
+        )
+
+        # Set up realistic scenario
+        system_msg = SystemMessage(
+            content="You are a migration assistant",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        user_msg = HumanMessage(
+            content="Migrate this Chef code",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg2",
+        )
+
+        # Conversation that gets summarized
+        ai1 = AIMessage(content="Reading file " * 50, id="msg3")
+        tool1 = ToolMessage(content="File contents " * 50, tool_call_id="1", id="msg4")
+        ai2 = AIMessage(content="Analyzing " * 50, id="msg5")
+
+        # Recent messages to keep
+        ai3 = AIMessage(content="Recent finding", id="msg6")
+        tool2 = ToolMessage(content="Recent result", tool_call_id="2", id="msg7")
+
+        messages = [system_msg, user_msg, ai1, tool1, ai2, ai3, tool2]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        result_messages = result["messages"]
+
+        # Should have: RemoveMessage, system_msg, user_msg, summary, ai3, tool2
+        non_remove = [
+            msg for msg in result_messages if not isinstance(msg, RemoveMessage)
+        ]
+
+        # Check structure
+        assert system_msg in non_remove
+        assert user_msg in non_remove
+        assert ai3 in non_remove
+        assert tool2 in non_remove
+
+        # Check summary was created
+        summary_messages = [
+            msg
+            for msg in non_remove
+            if isinstance(msg, HumanMessage) and msg is not user_msg
+        ]
+        assert len(summary_messages) == 1
+        assert "Summary of previous actions:" in summary_messages[0].content
+
+    def test_no_summarization_when_not_needed(self, model, runtime):
+        """Test that no summarization occurs when conditions aren't met."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=100_000, messages_to_keep=10
+        )
+
+        messages = [
+            HumanMessage(
+                content="Short message",
+                additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            ),
+            AIMessage(content="Short response"),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is None
+        model.invoke.assert_not_called()

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -3,13 +3,13 @@
 from typing import cast
 
 import pytest
-from langchain.agents.middleware import SummarizationMiddleware
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.messages.ai import UsageMetadata
 
 from src.base_agent import BaseAgent
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
+from src.middleware.x2a_summarize import X2ASummarizationMiddleware
 from src.types.base_state import BaseState
 
 
@@ -468,6 +468,160 @@ class TestBaseAgentInvokeStructured:
         assert metrics.output_tokens == 0
 
 
+class TestBaseAgentTagOriginalMessages:
+    """Tests for BaseAgent._tag_original_messages static method."""
+
+    def test_tag_single_user_message(self):
+        messages = [{"role": "user", "content": "Hello"}]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 1
+        assert isinstance(result[0], HumanMessage)
+        assert result[0].content == "Hello"
+        assert result[0].additional_kwargs.get("x2a_original_message") is True
+
+    def test_tag_single_system_message(self):
+        from langchain_core.messages import SystemMessage
+
+        messages = [{"role": "system", "content": "You are a helpful assistant"}]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 1
+        assert isinstance(result[0], SystemMessage)
+        assert result[0].content == "You are a helpful assistant"
+        assert result[0].additional_kwargs.get("x2a_original_message") is True
+
+    def test_tag_mixed_messages(self):
+        from langchain_core.messages import SystemMessage
+
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "User question"},
+        ]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 2
+        assert isinstance(result[0], SystemMessage)
+        assert isinstance(result[1], HumanMessage)
+        assert result[0].additional_kwargs.get("x2a_original_message") is True
+        assert result[1].additional_kwargs.get("x2a_original_message") is True
+
+    def test_tag_multiple_user_messages(self):
+        messages = [
+            {"role": "user", "content": "First"},
+            {"role": "user", "content": "Second"},
+            {"role": "user", "content": "Third"},
+        ]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 3
+        for msg in result:
+            assert isinstance(msg, HumanMessage)
+            assert msg.additional_kwargs.get("x2a_original_message") is True
+
+    def test_tag_empty_content(self):
+        messages = [{"role": "user", "content": ""}]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 1
+        assert result[0].content == ""
+        assert result[0].additional_kwargs.get("x2a_original_message") is True
+
+    def test_tag_missing_role_defaults_to_user(self):
+        messages = [{"content": "Message without role"}]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 1
+        assert isinstance(result[0], HumanMessage)
+        assert result[0].additional_kwargs.get("x2a_original_message") is True
+
+    def test_tag_missing_content_defaults_to_empty(self):
+        messages = [{"role": "user"}]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        assert len(result) == 1
+        assert result[0].content == ""
+
+    def test_tag_preserves_independence(self):
+        """Ensure each message gets its own independent tag dict."""
+        messages = [
+            {"role": "user", "content": "First"},
+            {"role": "user", "content": "Second"},
+        ]
+        result = ConcreteAgent._tag_original_messages(messages)
+
+        # Modify one tag and ensure the other is unaffected
+        result[0].additional_kwargs["modified"] = True
+        assert "modified" not in result[1].additional_kwargs
+
+
+class TestBaseAgentInvokeReact:
+    """Tests for BaseAgent.invoke_react message tagging."""
+
+    @pytest.fixture
+    def agent(self):
+        """Create a test agent instance."""
+        return ConcreteAgent()
+
+    @pytest.fixture
+    def mock_agent_create(self, monkeypatch):
+        """Mock the create_agent function."""
+        from unittest.mock import Mock
+
+        mock_create = Mock()
+        monkeypatch.setattr("src.base_agent.create_agent", mock_create)
+        return mock_create
+
+    def test_invoke_react_tags_messages(self, agent, mock_agent_create):
+        """Test that invoke_react tags messages before passing to agent."""
+        from unittest.mock import Mock
+
+        from langchain_core.messages import SystemMessage
+
+        mock_agent_instance = Mock()
+        mock_agent_instance.invoke.return_value = {"messages": []}
+        mock_agent_create.return_value = mock_agent_instance
+
+        messages = [
+            {"role": "system", "content": "System prompt"},
+            {"role": "user", "content": "User input"},
+        ]
+
+        state = BaseState(user_message="test", path="/test")
+        agent.invoke_react(state, messages)
+
+        # Verify create_agent was called
+        assert mock_agent_create.called
+
+        # Verify invoke was called with tagged messages
+        invoke_call = mock_agent_instance.invoke.call_args
+        invoked_messages = invoke_call[0][0]["messages"]
+
+        assert len(invoked_messages) == 2
+        assert isinstance(invoked_messages[0], SystemMessage)
+        assert isinstance(invoked_messages[1], HumanMessage)
+        assert invoked_messages[0].additional_kwargs.get("x2a_original_message") is True
+        assert invoked_messages[1].additional_kwargs.get("x2a_original_message") is True
+
+    def test_invoke_react_preserves_message_content(self, agent, mock_agent_create):
+        """Test that message content is preserved during tagging."""
+        from unittest.mock import Mock
+
+        mock_agent_instance = Mock()
+        mock_agent_instance.invoke.return_value = {"messages": []}
+        mock_agent_create.return_value = mock_agent_instance
+
+        messages = [{"role": "user", "content": "Specific content to preserve"}]
+
+        state = BaseState(user_message="test", path="/test")
+        agent.invoke_react(state, messages)
+
+        invoke_call = mock_agent_instance.invoke.call_args
+        invoked_messages = invoke_call[0][0]["messages"]
+
+        assert invoked_messages[0].content == "Specific content to preserve"
+
+
 class TestBaseAgentMiddleware:
     """Tests for BaseAgent.middleware() configuration."""
 
@@ -476,7 +630,7 @@ class TestBaseAgentMiddleware:
         stack = agent.middleware()
 
         assert len(stack) == 1
-        assert isinstance(stack[0], SummarizationMiddleware)
+        assert isinstance(stack[0], X2ASummarizationMiddleware)
 
     def test_middleware_with_rules_file(self):
         agent = RuledAgent()
@@ -484,7 +638,7 @@ class TestBaseAgentMiddleware:
 
         assert len(stack) == 2
         assert isinstance(stack[0], RulesMiddleware)
-        assert isinstance(stack[1], SummarizationMiddleware)
+        assert isinstance(stack[1], X2ASummarizationMiddleware)
 
     def test_middleware_with_goal(self):
         agent = GoalAgent()
@@ -492,7 +646,7 @@ class TestBaseAgentMiddleware:
 
         assert len(stack) == 2
         assert isinstance(stack[0], GoalValidationMiddleware)
-        assert isinstance(stack[1], SummarizationMiddleware)
+        assert isinstance(stack[1], X2ASummarizationMiddleware)
 
     def test_middleware_with_goal_passes_agent_reference(self):
         agent = GoalAgent()


### PR DESCRIPTION
Replace langchain's generic SummarizationMiddleware with a domain-aware middleware that tags initial system/user messages as "original" and only summarizes the tool-call/AI-response conversation, keeping the agent's mission instructions intact after context compaction.