### PR TITLE
fix: aap discovery message format

### DIFF
--- a/src/exporters/aap_discovery_agent.py
+++ b/src/exporters/aap_discovery_agent.py
@@ -161,7 +161,7 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
         message = self.get_last_ai_message(result)
         if message is None:
             return ""
-        return str(message.content)
+        return str(message.text)
 
     # -------------------------------------------------------------------------
     # Collection Extraction


### PR DESCRIPTION
When using GPT-OSS it shows the reasoning content, not the real text to the next agent. Using text is safest!