### PR TITLE
feat: Puppet fixes on expanding loops

### DIFF
--- a/prompts/puppet_analysis_system.md
+++ b/prompts/puppet_analysis_system.md
@@ -7,109 +7,123 @@ Your task is to write a detailed specification of the Puppet module — what it 
 
 **FORMATTING RULE: Do NOT use markdown tables anywhere in the migration plan. Use bullet lists, nested lists, or YAML code blocks instead. Tables are hard for downstream agents to parse reliably.**
 
-**MANDATORY ANALYSIS STEPS - DO THESE IN ORDER:**
+**ANALYSIS STEPS:**
 
-1. **Identify the service type from metadata and manifests:**
-   - Read `metadata.json` for description and dependencies
-   - Read manifest files to determine what packages are installed
-   - Identify if this is: web server, database, cache, load balancer, application stack, or other service type
-
-2. **Analyze class execution order:**
-   - Read `manifests/init.pp` for contain/include order and relationship chains (-> and ~>)
-   - Map out the dependency chain between classes
-   - Note notification relationships (~>) that trigger service restarts
-
-3. **Deep dive into each manifest:**
-   - Document EVERY Puppet resource in execution order
-   - Note iterations (.each, .map loops) - these are CRITICAL
-   - Track what triggers service restarts/reloads via notify/subscribe
-   - Identify ports, sockets, or IPC mechanisms
-   - Note exported resources (@@) and virtual resources (@)
-   - Flag PuppetDB queries and collectors
-
-4. **Analyze Hiera variable flow:**
-   - Use the `parse_hiera_config` tool to discover the hierarchy structure
-   - Read each data file to understand variable definitions
-   - Identify where variables are defined (common vs environment vs node)
-   - Note cross-level overrides (same key at multiple levels)
-   - Map merge behavior (first vs hash vs deep)
-
-5. **Examine templates and files:**
-   - Read .erb and .epp files referenced in manifests
-   - List EVERY variable referenced in each template (every `<%= @var %>` or `<%= $var %>`)
-   - Note how many times each template renders and from which manifest loop
-   - Identify the relationship between templates: does the main config render backends
-     inline, or are they separate files rendered via a loop? This is critical — the
-     write agent must not duplicate content between templates
-   - Identify complex Ruby logic that needs manual Jinja2 conversion
-   - Check for static files being deployed
-
-6. **Detect credentials and secrets:**
-   - Check for ENC[PKCS7,...] eyaml-encrypted values in Hiera data
-   - Check for Sensitive[String] typed parameters in manifests
-   - Look for passwords, tokens, API keys in variable names
-   - Check for certificate/key file deployments
-   - Note exec commands with embedded credentials
-   - For EACH detected credential, record: variable name, source file, encryption method, and usage context
-
-**USING STRUCTURED ANALYSIS DATA:**
-
-You will receive detailed structured analysis showing:
-- **Manifest analysis**: Class definitions, parameters, resources, includes, conditionals, iterations, exported/virtual resources, PuppetDB queries, relationship chains
-- **Hiera data analysis**: Variables with their types and encrypted values
-- **Template analysis**: Variables used, Ruby logic blocks
-- **Custom type analysis**: Types, providers, facts, functions
-- **Credential analysis**: Detected secrets
+1. **Identify the service type** from metadata and manifests — what packages are installed, what kind of service this is
+2. **Analyze class execution order** — contain/include order, relationship chains (`->` and `~>`), notification relationships
+3. **Deep dive into each manifest** — document EVERY resource in execution order, note iterations (.each loops), track notify/subscribe, identify exported (`@@`) and virtual (`@`) resources, flag PuppetDB queries
+4. **Analyze Hiera variable flow** — use `parse_hiera_config` to discover hierarchy, read data files, note cross-level overrides and merge behavior
+5. **Examine templates** — list ALL variables referenced, note render counts, identify complex Ruby logic
+6. **Detect credentials** — check for eyaml-encrypted values, Sensitive types, passwords/tokens/keys
 
 **PUPPET-SPECIFIC KNOWLEDGE:**
 
-Puppet resource types and their purpose:
-- `package` — Install/manage system packages
-- `service` — Manage system services (start, stop, enable)
-- `file` — Deploy files from templates or static content
-- `exec` — Run arbitrary commands (often with guards like `unless`, `onlyif`)
-- `cron` — Schedule recurring tasks
-- `user`/`group` — Manage system users and groups
-- `mount` — Manage filesystem mounts
-- Exported resources (`@@`) — Shared across nodes via PuppetDB
-- Virtual resources (`@`) — Defined but only realized conditionally
+Puppet resource types: `package`, `service`, `file`, `exec`, `cron`, `user`/`group`, `mount`, exported (`@@`), virtual (`@`)
 
-Class relationships:
-- `include` — loads a class (no containment)
-- `contain` — loads and contains (prevents ordering leaking)
-- `require` — loads and sets ordering dependency
-- `inherits` — class inheritance keyword
-- `->` — ordering (before)
-- `~>` — notification (triggers restart/reload)
+Class relationships: `include` (no containment), `contain` (contained), `require` (ordering), `inherits`, `->` (ordering), `~>` (notification)
 
-Hiera hierarchy concepts:
-- `common.yaml` — Base defaults for all nodes
-- Per-OS levels — Override per operating system family
-- Per-environment — Override per deployment environment
-- Per-node — Override per specific host
-- eyaml encrypted values (`ENC[PKCS7,...]`) — Secrets
-- Merge strategies: first (default), hash, deep
+Hiera hierarchy: `common.yaml` (defaults), per-OS, per-environment, per-node, eyaml secrets, merge strategies (first/hash/deep)
 
-**File Structure Requirements:**
-- List ONLY files that are actually used/executed/referenced
-- Include: manifests (.pp), templates (.erb, .epp), Hiera data files (.yaml), custom types/facts (.rb), static files
-- Exclude: README, LICENSE, test files, .gitignore, development configs
-- Group by type (manifests, templates, data, custom components, files)
+**FILE STRUCTURE:** List ONLY files referenced in the execution tree. Group by type (manifests, templates, data, custom components). Use paths exactly as shown in DIRECTORY LISTING. Exclude README, LICENSE, test files.
 
-**Module Explanation Requirements:**
-- For each class, list resources in execution order
-- Show relationship chains between classes
-- Expand ALL .each loops with actual item names from Hiera data
-- Show template source → destination path with render count
-- For each template, list ALL variables it references and note whether content is
-  rendered inline in the main config or as separate files via a loop
-- Note conditional resource inclusion based on facts/variables
+## Module Explanation Format
 
-**CRITICAL REQUIREMENTS:**
-- NEVER say "for each item" or "iterates over X" — expand with actual names
-- List every class by exact name
-- Every .each loop must show all items from the Hiera data
-- All package names must be real and verified from the manifests
+**RULES:**
+- Use **compact resource-per-line format**: `` `resource_type 'title'` → attribute: `value` ``
+- NEVER write prose like "Installs package X" — list the resource directly
+- NEVER use Puppet variable references (`$module::var`) — resolve to actual values
+- Expand ALL `.each` loops with actual item names from Hiera data
+- When a loop variable is empty: state "Loop runs 0 times" then describe the default/implicit instance with resolved values in an *Instance expansion* sub-section
+- Show template source → destination with render count and ALL variables
+- Show notification relationships and conditionals
+- Follow the execution tree EXACTLY — when a class includes another, walk through what it does
+- List EXACT package names, file paths, ports, and configuration values
+
+**GOOD EXAMPLE - PostgreSQL Module:**
+
+1. **postgresql** (`manifests/init.pp`):
+   - Sets class parameters: version=14, listen_addresses='*', max_connections=200
+   - `contain postgresql::install`
+   - `contain postgresql::config`
+   - `contain postgresql::service`
+   - Sets ordering: `postgresql::install -> postgresql::config ~> postgresql::service`
+
+2. **postgresql::install** (`manifests/install.pp`):
+   - `package 'postgresql-14'` → ensure: `present`
+   - `package 'postgresql-client-14'` → ensure: `present`
+   - `package 'postgresql-contrib-14'` → ensure: `present`
+   - `user 'postgres'` → uid: `26`, shell: `/bin/bash`
+   - `group 'postgres'` → gid: `26`
+   - `file '/var/lib/postgresql/14/main'` → owner: `postgres`, group: `postgres`, mode: `0700`
+   - `file '/var/log/postgresql'` → owner: `postgres`, group: `postgres`, mode: `0755`
+
+3. **postgresql::config** (`manifests/config.pp`):
+   - `file '/etc/postgresql/14/main/postgresql.conf'` (template `postgresql.conf.erb`) → mode: `0644`
+     - Passes: max_connections=200, shared_buffers=4GB, effective_cache_size=12GB
+   - `file '/etc/postgresql/14/main/pg_hba.conf'` (template `pg_hba.conf.erb`) → mode: `0640`
+   - **Iterations**: `$databases.each` — runs 3 times for: **production_db**, **staging_db**, **analytics_db**
+     - **production_db**:
+       - `postgresql::database 'production_db'`
+       - `postgresql::user 'prod_user'` → password from hiera, CREATEDB privilege
+       - `postgresql::grant 'prod_user on production_db'` → ALL privileges
+     - **staging_db**:
+       - `postgresql::database 'staging_db'`
+       - `postgresql::user 'staging_user'` → password from hiera
+       - `postgresql::grant 'staging_user on staging_db'` → ALL privileges
+     - **analytics_db**:
+       - `postgresql::database 'analytics_db'`
+       - `postgresql::user 'analytics_user'` → password from hiera, CREATEDB privilege
+       - `postgresql::grant 'analytics_user on analytics_db'` → ALL privileges
+   - **notifies**: `file[postgresql.conf] ~> service[postgresql]` (restart on config change)
+
+4. **postgresql::service** (`manifests/service.pp`):
+   - `service 'postgresql'` → ensure: `running`, enable: `true`, hasstatus: `true`, hasrestart: `true`
+
+**GOOD EXAMPLE - Service with Defined Type + Dependency Module:**
+
+1. **myapp** (`manifests/init.pp`):
+   - `contain myapp::install`
+   - `contain myapp::config`
+   - `contain myapp::service`
+
+2. **myapp::install** (`manifests/install.pp`):
+   - `package 'python3.11'` → ensure: `present`
+   - `package 'python3.11-venv'` → ensure: `present`
+   - `package 'git'` → ensure: `present`
+   - `user 'myapp'` → uid: `1001`, home: `/opt/myapp`, shell: `/bin/bash`
+   - `file '/opt/myapp'` → owner: `myapp`, group: `myapp`, mode: `0755`
+
+3. **myapp::config** (`manifests/config.pp`):
+   - Includes dependency module: `python` (from `migration-dependencies/python`)
+     - **python::virtualenv** (`migration-dependencies/python/manifests/virtualenv.pp`):
+       - `exec 'create-venv'` → `/opt/myapp/venv` (python: python3.11)
+       - `exec 'pip-install'` → installs from requirements.txt
+   - `file '/etc/myapp/app.conf'` (template `app.conf.erb`) → mode: `0644`, owner: `root`, group: `root`
+     - Passes: database_url, message_broker_url, log_level=info, worker_threads=8
+   - **Iterations**: `$workers.each` — runs 3 times for: **api**, **worker**, **scheduler**
+     - **api**: port 8000, workers=4, timeout=60
+       - `file '/etc/systemd/system/myapp-api.service'` (template `api.service.erb`) → mode: `0644`
+         - Sets: WorkingDirectory=/opt/myapp, User=myapp, ExecStart=/opt/myapp/venv/bin/gunicorn
+     - **worker**: background job processor, workers=2
+       - `file '/etc/systemd/system/myapp-worker.service'` (template `worker.service.erb`) → mode: `0644`
+         - Sets: WorkingDirectory=/opt/myapp, User=myapp, ExecStart=/opt/myapp/venv/bin/celery worker
+     - **scheduler**: cron job runner, workers=1
+       - `file '/etc/systemd/system/myapp-scheduler.service'` (template `scheduler.service.erb`) → mode: `0644`
+         - Sets: WorkingDirectory=/opt/myapp, User=myapp, ExecStart=/opt/myapp/venv/bin/celery beat
+   - **notifies**: `file[app.conf] ~> service[myapp-api], service[myapp-worker], service[myapp-scheduler]`
+
+4. **myapp::service** (`manifests/service.pp`):
+   - `service 'myapp-api'` → ensure: `running`, enable: `true`
+   - `service 'myapp-worker'` → ensure: `running`, enable: `true`
+   - `service 'myapp-scheduler'` → ensure: `running`, enable: `true`
+
+**BAD EXAMPLE (DO NOT DO THIS):**
+
+1. **myapp** (`manifests/init.pp`):
+   - Installs dependencies (WRONG - which dependencies? What versions?)
+   - Deploys configuration files (WRONG - which files? What variables? What paths?)
+   - Configures services (WRONG - which services? What ports?)
+   - Iterations: For each worker (WRONG - name them explicitly!)
 
 ## Migration Plan Template
 
@@ -132,204 +146,12 @@ Hiera hierarchy concepts:
 
 ## File Structure
 
-**CRITICAL REQUIREMENT: List files that appear in the EXECUTION TREE plus supporting files.**
-
-**Selection criteria**:
-1. Every .pp file mentioned in the execution tree (look at file path comments)
-2. Every .erb/.epp template file referenced in the execution tree
-3. All data/*.yaml Hiera files
-4. All lib/facter/*.rb custom facts
-5. All site/* control repo context files
-
-**Path format**: Use paths exactly as shown in DIRECTORY LISTING (do not modify or shorten them)
-
-**What to include**:
-- Module manifests: modules/*/manifests/*.pp that appear in the tree
-- Dependency manifests: modules/*/migration-dependencies/*/manifests/*.pp that appear in the tree
-- Templates: modules/*/templates/*.erb that appear in the tree
-- Dependency templates: modules/*/migration-dependencies/*/templates/*.epp that appear in the tree
-- Data files: All data/*.yaml files
-- Custom components: All lib/facter/*.rb files
-- Control repo: All site/*.pp files
-
-**What to exclude**:
-- Manifest files NOT referenced in the execution tree
-- Template files NOT used by any resource
-- Test files, README, LICENSE
+List files that appear in the EXECUTION TREE plus supporting files.
+Use exact paths from the DIRECTORY LISTING. Group by type.
 
 ## Module Explanation
 
-**CRITICAL**: Follow the execution tree EXACTLY. For each class in the tree, describe what it does step-by-step. When a class includes another class, you MUST describe what that included class does by following the execution tree into that class. Do not just say "includes class X" - walk through what class X actually does.
-
-The module performs operations in this order:
-
-**GOOD EXAMPLE - PostgreSQL Module:**
-
-1. **postgresql** (`manifests/init.pp`):
-   - Sets class parameters: version=14, listen_addresses='*', max_connections=200
-   - Includes postgresql::install class
-   - Includes postgresql::config class
-   - Includes postgresql::service class
-   - Sets ordering: install -> config ~> service (config changes notify service restart)
-   - Resources: None (orchestration only)
-
-2. **postgresql::install** (`manifests/install.pp`):
-   - Installs packages: postgresql-14, postgresql-client-14, postgresql-contrib-14
-   - Creates postgres system user (uid: 26, shell: /bin/bash)
-   - Creates postgres group (gid: 26)
-   - Creates directories:
-     - /var/lib/postgresql/14/main (owner: postgres, group: postgres, mode: 0700)
-     - /var/log/postgresql (owner: postgres, group: postgres, mode: 0755)
-   - Resources: package (3), user (1), group (1), directory (2)
-
-3. **postgresql::config** (`manifests/config.pp`):
-   - Deploys postgresql.conf template:
-     - Template: postgresql.conf.erb → /etc/postgresql/14/main/postgresql.conf (mode: 0644)
-     - Sets: max_connections=200, shared_buffers=4GB, effective_cache_size=12GB
-   - Deploys pg_hba.conf template:
-     - Template: pg_hba.conf.erb → /etc/postgresql/14/main/pg_hba.conf (mode: 0640)
-   - Resources: file (2)
-   - Iterations: Runs 3 times for databases defined in hiera ($databases hash): production_db, staging_db, analytics_db
-     - **production_db**:
-       - Creates database via postgresql::database['production_db']
-       - Creates user 'prod_user' with password from hiera, CREATEDB privilege
-       - Grants ALL privileges on production_db to prod_user
-     - **staging_db**:
-       - Creates database via postgresql::database['staging_db']
-       - Creates user 'staging_user' with password from hiera
-       - Grants ALL privileges on staging_db to staging_user
-     - **analytics_db**:
-       - Creates database via postgresql::database['analytics_db']
-       - Creates user 'analytics_user' with password from hiera, CREATEDB privilege
-       - Grants ALL privileges on analytics_db to analytics_user
-   - **notifies**: file[postgresql.conf] ~> service[postgresql] (restart on config change)
-
-4. **postgresql::service** (`manifests/service.pp`):
-   - Manages service: postgresql
-     - ensure: running
-     - enable: true
-     - hasstatus: true
-     - hasrestart: true
-   - Resources: service (1)
-
-**GOOD EXAMPLE - Service with Custom Defined Type:**
-
-1. **myapp** (`manifests/init.pp`):
-   - Contains myapp::install
-   - Contains myapp::config
-   - Contains myapp::service
-   - Resources: None (orchestration only)
-
-2. **myapp::install** (`manifests/install.pp`):
-   - Installs packages: python3.11, python3.11-venv, python3.11-dev, git
-   - Creates system user 'myapp' (uid: 1001, home: /opt/myapp, shell: /bin/bash)
-   - Creates directories:
-     - /opt/myapp (owner: myapp, group: myapp, mode: 0755)
-     - /var/log/myapp (owner: myapp, group: myapp, mode: 0755)
-     - /etc/myapp (owner: root, group: root, mode: 0755)
-   - Resources: package (4), user (1), directory (3)
-
-3. **myapp::config** (`manifests/config.pp`):
-   - Includes dependency module: python (from migration-dependencies/python)
-     - **python::virtualenv** (`migration-dependencies/python/manifests/virtualenv.pp`):
-       - Creates virtual environment at /opt/myapp/venv (python: python3.11)
-       - Installs packages from requirements.txt via pip
-       - Resources: exec (2)
-   - Deploys app.conf template:
-     - Template: app.conf.erb → /etc/myapp/app.conf (mode: 0644, owner: root, group: root)
-     - Sets: database_url, redis_url, log_level=info, worker_threads=8
-   - Iterations: Runs 3 times for workers defined in hiera ($workers hash): api, worker, scheduler
-     - **api**: Listens on port 8000, workers=4, timeout=60
-       - Deploys systemd unit: api.service.erb → /etc/systemd/system/myapp-api.service (mode: 0644)
-       - Sets: WorkingDirectory=/opt/myapp, User=myapp, ExecStart=/opt/myapp/venv/bin/gunicorn
-     - **worker**: Background job processor, workers=2
-       - Deploys systemd unit: worker.service.erb → /etc/systemd/system/myapp-worker.service (mode: 0644)
-       - Sets: WorkingDirectory=/opt/myapp, User=myapp, ExecStart=/opt/myapp/venv/bin/celery worker
-     - **scheduler**: Cron job runner, workers=1
-       - Deploys systemd unit: scheduler.service.erb → /etc/systemd/system/myapp-scheduler.service (mode: 0644)
-       - Sets: WorkingDirectory=/opt/myapp, User=myapp, ExecStart=/opt/myapp/venv/bin/celery beat
-   - Resources: file (4), systemd::unit (3)
-   - **notifies**: file[app.conf] ~> service[myapp-api], service[myapp-worker], service[myapp-scheduler]
-
-4. **myapp::service** (`manifests/service.pp`):
-   - Manages services:
-     - myapp-api (ensure: running, enable: true)
-     - myapp-worker (ensure: running, enable: true)
-     - myapp-scheduler (ensure: running, enable: true)
-   - Resources: service (3)
-
-**GOOD EXAMPLE - Nginx Load Balancer:**
-
-1. **profile_nginx** (`manifests/init.pp`):
-   - Sets class parameters from hiera: backends (hash), ssl_cert, ssl_key, client_max_body_size=50m
-   - Includes nginx class from dependency module
-     - **nginx** (`migration-dependencies/nginx/manifests/init.pp`):
-       - Installs package: nginx
-       - Creates directories: /etc/nginx/conf.d, /etc/nginx/sites-available, /etc/nginx/sites-enabled
-       - Deploys nginx.conf template:
-         - Template: nginx.conf.erb → /etc/nginx/nginx.conf (mode: 0644)
-         - Sets: worker_processes=auto, worker_connections=1024, keepalive_timeout=65
-       - Manages service: nginx (ensure: running, enable: true)
-       - Resources: package (1), directory (3), file (1), service (1)
-   - Iterations: Runs 2 times for backends defined in hiera ($backends hash): web, api
-     - **web**:
-       - Backend servers: web1.internal:8080, web2.internal:8080, web3.internal:8080
-       - Load balancing: roundrobin
-       - Health check: / (expect 200)
-       - Deploys upstream config: web-upstream.conf.erb → /etc/nginx/conf.d/web-upstream.conf (mode: 0644)
-       - Deploys site config: web-site.conf.erb → /etc/nginx/sites-available/web.conf (mode: 0644)
-       - Creates symlink: /etc/nginx/sites-enabled/web.conf → /etc/nginx/sites-available/web.conf
-     - **api**:
-       - Backend servers: api1.internal:3000, api2.internal:3000
-       - Load balancing: least_conn
-       - Health check: /health (expect 200)
-       - Deploys upstream config: api-upstream.conf.erb → /etc/nginx/conf.d/api-upstream.conf (mode: 0644)
-       - Deploys site config: api-site.conf.erb → /etc/nginx/sites-available/api.conf (mode: 0644)
-       - Creates symlink: /etc/nginx/sites-enabled/api.conf → /etc/nginx/sites-available/api.conf
-   - Resources: file (6)
-   - **notifies**: file[/etc/nginx/conf.d/*] ~> service[nginx] (reload on config change)
-
-**BAD EXAMPLE - PostgreSQL (DO NOT DO THIS):**
-
-1. **postgresql** (`manifests/init.pp`):
-   - Installs and configures PostgreSQL (WRONG - what version? What packages?)
-   - Sets up databases (WRONG - which databases? How many?)
-   - Iterations: Runs for each database (WRONG - name them explicitly!)
-   - Resources: Various Puppet resources (WRONG - which resources? In what order?)
-
-**BAD EXAMPLE - Application (DO NOT DO THIS):**
-
-1. **myapp** (`manifests/init.pp`):
-   - Installs dependencies (WRONG - which dependencies? What versions?)
-   - Deploys configuration files (WRONG - which files? What variables? What paths?)
-   - Configures services (WRONG - which services? What ports? How many workers?)
-   - Iterations: For each worker (WRONG - name the workers explicitly!)
-
-**VALIDATION RULES:**
-- List EXACT package names and versions when available
-- List EXACT file paths (full /etc/... or /opt/... paths)
-- List EXACT template mappings: source.erb → /destination/path (mode: 0644)
-- List EXACT iteration items by name (database names, backend names, service names)
-- Show resource counts per class: Resources: package (3), file (2), service (1)
-- Show notification relationships: resource ~> service (describes what triggers restarts)
-- Show conditionals with branching: "if systemd → ... otherwise → ..."
-- Expand into dependency modules and describe what they do (don't just say "includes nginx")
-
-1. **[class-name]** (`manifests/[class-name].pp`):
-   - [List exact resources with parameters]
-   - [Template mappings: source → destination (mode)]
-   - [Package names, service names, file paths]
-   - When this class includes another class, expand into that class's execution tree branch:
-     - **[included-class-name]** (`path/to/included/class.pp`):
-       - [What this included class does with specific resources]
-       - [Resources it manages with exact names and parameters]
-       - [Further nested includes - keep following the tree]
-   - Iterations: Runs N times for items from hiera: item1, item2, item3
-     - **item1**: [specific details with exact values]
-     - **item2**: [specific details with exact values]
-     - **item3**: [specific details with exact values]
-   - Resources: resource_type (count), another_type (count)
-   - **notifies**: [what notifies what for service restarts]
+Follow the execution tree step-by-step using the compact resource-per-line format from the examples above.
 
 ## Variables
 
@@ -337,79 +159,27 @@ The module performs operations in this order:
 
 ### Variable Definitions
 
-For each Hiera data file, list the variables it defines with their exact values and types.
-Group by hierarchy level.
+For each Hiera data file, list variables with exact values and types. Group by hierarchy level.
 
-**common.yaml (defaults)** → Migration note: Base defaults for all nodes
+**common.yaml (defaults)**
 - `module::variable_name`: `value` (type: string)
-- `module::backends`: (type: hash)
-  ```yaml
-  web:
-    balance: roundrobin
-    port: 8080
-  api:
-    balance: leastconn
-    port: 3000
-  ```
-
-**os/RedHat.yaml (OS-specific overrides)** → Migration note: OS-specific variables, loaded conditionally based on OS family
-- `module::extra_packages`: `[hatop]` (type: array)
-
-**environment/production.yaml (environment overrides)** → Migration note: Environment-specific variables, loaded based on deployment environment
-- `module::global_maxconn`: `16384` (type: integer)
-
-[Continue for each hierarchy level with data]
 
 ### Variable Migration Summary
 
-- **Common defaults**: [N] variables from common.yaml (base configuration for all nodes)
-- **OS-specific variables**: [N] variables that vary by operating system family
-- **Environment-specific variables**: [N] variables that vary by deployment environment (dev, staging, prod)
-- **Host-specific variables**: [N] variables for individual host overrides
-- **Encrypted variables**: [N] variables that are encrypted (eyaml) and need secure storage
+- **Common defaults**: [N] variables
+- **OS-specific**: [N] variables
+- **Environment-specific**: [N] variables
+- **Host-specific**: [N] variables
+- **Encrypted**: [N] variables needing secure storage
 
 ### Cross-Level Overrides
 
-Variables defined at multiple Hiera levels:
+Variables defined at multiple levels:
 - **[variable]**: defined at [levels], merge strategy: [first/hash/deep]
-
-### Merge Strategy Notes
-
-- Variables using `hash` merge - Hash values from multiple levels are merged (shallow merge)
-- Variables using `deep` merge - Hash values are recursively merged (deep merge)
-- Variables using `first` (default) - First value found wins, no merging
-
-### Variable Loading Notes
-
-- Variables from common.yaml provide base defaults for all nodes
-- Per-OS variables override based on operating system family (RedHat, Debian, etc.)
-- Per-environment variables override based on deployment environment (production, staging, etc.)
-- Per-node variables provide host-specific overrides
-- Variable naming in Puppet uses double-colon namespacing (e.g., `profile_haproxy::backends`)
 
 ## Custom Types and Providers
 
-If the module defines custom Puppet types, providers, facts, or functions in `lib/`, document each one in detail:
-
-For each custom type (`lib/puppet/type/*.rb`):
-- **Name**: [type name]
-- **Purpose**: [what it manages]
-- **Parameters/Properties**: List all with types, defaults, and validation rules
-- **Autorequire rules**: [any auto-dependency logic]
-- **Migration notes**: [Describe what this type does and what functionality needs to be replicated]
-
-For each provider (`lib/puppet/provider/**/*.rb`):
-- **Name**: [provider name] for type [type name]
-- **Commands used**: [system commands invoked]
-- **Key methods**: [create, destroy, exists?, flush, etc.]
-- **Platform constraints**: [Windows-only, specific OS, etc.]
-
-For each custom fact or function:
-- **Name**: [name]
-- **Purpose**: [what it returns/computes]
-- **Migration notes**: [How this fact/function should be handled in the migration - describe the behavior, not specific Ansible code]
-
-If no custom types exist, omit this section.
+If the module defines custom types/providers/facts/functions in `lib/`, document each one. Omit if none.
 
 ## Dependencies
 
@@ -417,76 +187,22 @@ If no custom types exist, omit this section.
 **System package dependencies**: [from manifests]
 **Service dependencies**: [ordering requirements]
 
-### Dependency Details
-
-For each dependency in the Puppetfile or metadata.json:
-- **[module-name]**: [purpose], version [version]
-  - Source: [forge/git]
-  - Used for: [what resources/functionality it provides]
-
 ## Puppet Facts Used
 
-List ALL Puppet fact references found in manifests and templates.
-For each fact, note what system information it provides.
-
-- `$facts['os']['family']` - Operating system family (RedHat, Debian, etc.)
-- `$::osfamily` - Operating system family (legacy syntax)
-- `$facts['networking']['ip']` - Primary IP address
-- `$facts['hostname']` - Short hostname
-- `$facts['fqdn']` - Fully qualified domain name
-
-If no facts are used, state: "No Puppet facts referenced in this module."
+List ALL fact references. For each, note what system information it provides.
 
 ## Template Conversion Notes
 
-For each template, document the variables and logic that will need to be converted:
-
-### [template-name.erb]
-- **Variables used**: List all variables referenced in the template
-- **Ruby logic blocks**: Describe each `<% %>` block and what it computes
-- **Conditional rendering**: Describe any if/unless/case logic
-- **Iterations**: Describe any loops (.each, .map, etc.) and what they iterate over
-- **Complex expressions**: Note any Ruby-specific constructs that will need special handling
-
-If no templates exist or all are straightforward variable substitutions, omit this section.
+For each template: variables used, Ruby logic blocks, conditional rendering, iterations, complex expressions. Omit if straightforward.
 
 ## PuppetDB Dependencies
 
-**Context**: PuppetDB provides a centralized data store for cross-node resource sharing, node facts, and infrastructure queries. Document all PuppetDB usage patterns found in this module.
-
-For each PuppetDB usage found, document:
-
-### Exported Resources (`@@`)
-For each exported resource:
-- **Resource type**: [e.g., `@@nagios_service`, `@@concat::fragment`]
-- **What it exports**: [what data/config is shared across nodes]
-- **Collected by**: [which classes/nodes collect this resource]
-- **Migration notes**: Exported resources enable cross-node data sharing - one node publishes data that other nodes consume. The migration needs to replicate this pattern using inventory data or an external data source.
-
-### Resource Collectors (`<<| |>>`)
-For each collector:
-- **Collects**: [resource type and filter condition]
-- **Purpose**: [why it collects from other nodes]
-- **Migration notes**: Collectors query PuppetDB to find resources exported by other nodes. The migration needs to discover these nodes through inventory or external data queries.
-
-### PuppetDB Queries (`puppetdb_query()`)
-For each query:
-- **Query**: [exact PQL query string]
-- **Returns**: [what data the query provides]
-- **Used for**: [how the result is consumed in the manifest]
-- **Migration notes**: Direct PuppetDB queries retrieve infrastructure data. The migration needs equivalent queries against inventory or an external CMDB/database.
-
-### Host Identity Data
-If the module uses PuppetDB for node identity/classification:
-- **Data used**: [certname, environment, node facts, etc.]
-- **Migration notes**: Document what host identity information is needed and how it's used for node classification.
-
-If no PuppetDB dependencies exist, omit this section entirely.
+Document exported resources (`@@`), collectors (`<<| |>>`), and `puppetdb_query()` calls. Omit if none.
 
 ## Verification Points
 
 **Files to verify**: [ALL files]
 **Service endpoints to check**: [ports/sockets]
 **Templates rendered**: [list with render counts]
-**Pre-flight checks**: [Service status commands, config validation, connectivity checks]
+**Pre-flight checks**: [Service status commands, config validation]
 ```

--- a/prompts/puppet_analysis_task.md
+++ b/prompts/puppet_analysis_task.md
@@ -3,33 +3,21 @@
 
 ---
 
-# YOUR DATA SOURCES
+# DATA SOURCES
 
-You have everything you need below. Do NOT read manifest files - the execution tree already shows what they do.
+The execution tree, directory listing, dependencies, credentials, and control repo context are provided below. Do NOT re-read files already covered here.
 
-## EXECUTION TREE (Your primary source)
+## EXECUTION TREE (Primary source)
 
 ```
 {execution_tree}
 ```
-
-This tree shows:
-- Every class in execution order with file paths
-- Every resource (package, file, service, etc.) with ALL its attributes
-- All conditionals (if/unless/case) and what they check
-- All loops (.each) with the collection being iterated
-- Relationship chains (-> and ~>)
 
 ## DIRECTORY LISTING
 
 ```
 {directory_listing}
 ```
-
-**For File Structure section**: List files that appear in the EXECUTION TREE above.
-- Include: Every .pp file path shown in the tree, all data/*.yaml files, all templates used by resources
-- Use exact paths from the listing above (do not shorten or modify)
-- Include dependency files from migration-dependencies/* if they appear in the tree
 
 ## EXTERNAL DEPENDENCIES
 
@@ -63,53 +51,22 @@ This tree shows:
 
 ---
 
-# YOUR TASK
+# TASK
 
-Write a detailed migration plan by walking through the execution tree step-by-step.
+Write a migration plan by walking through the execution tree step-by-step.
 
-**Step 1:** Use the `parse_hiera_config` tool
+1. Call `parse_hiera_config` ONCE, then read the Hiera YAML files it reports.
+2. If the tree contains loops, read `init.pp` ONCE for class parameter defaults to resolve loop variables.
+3. Write the migration plan using the format and examples from the system prompt. Resolve all Puppet variables to actual values.
 
-**Step 2:** Use `read_file` to read the Hiera YAML files shown by parse_hiera_config
-
-**Step 3:** Write the migration plan following the template and examples from the system prompt
-
----
-
-# CRITICAL RULES
-
-1. **Use the execution tree as your source** - Every resource, class, and relationship is shown there
-2. **List ALL resource details** - Package names, file paths, service names, template mappings, exact attribute values
-3. **Expand iterations** - When the tree shows a loop, list every item explicitly by name (get names from Hiera data)
-4. **Follow the tree into dependencies** - When a class includes another class, describe what that class does by following its branch in the tree
-5. **Be specific** - Use exact paths, exact package names, exact ports, exact configuration values
-6. **No vague language** - Never say "configures X" or "sets up Y" - say exactly what packages, files, services are managed
-7. **Follow the examples** - The system prompt has detailed examples showing the level of detail expected
+**STOP after step 3.** You should need at most 5-8 tool calls total.
 
 ---
 
-# WHAT NOT TO DO
+# KEY RULES
 
-- Don't read manifest files (.pp) - use the execution tree instead
-- Don't read template files (.erb, .epp) - they're already analyzed
-- Don't say "for each item" - list the items explicitly
-- Don't be vague - be specific about every resource
-- Don't skip dependency modules - expand into them and describe what they do
-
----
-
-# OUTPUT FORMAT
-
-Your response should be markdown text following the template from the system prompt.
-
-Look at the **GOOD EXAMPLES** in the system prompt - that's the level of detail expected.
-
-**File Structure:** One file per line, exact paths from directory listing above
-
-**Module Explanation:** Walk through the execution tree, listing:
-- Exact package names
-- File paths with modes and owners
-- Template source → destination mappings
-- Service names with ensure/enable values
-- All loop iterations with explicit item names from Hiera
-- Resource counts per class
-
+- Use the execution tree as your source — every resource and relationship is shown there
+- Follow all formatting rules from the system prompt (compact resource-per-line format, resolved values, expanded loops)
+- When a class includes another, walk through what that class does
+- When a loop variable is empty: state "Loop runs 0 times" then describe the default/implicit instance with resolved values
+- Do NOT read manifest files for execution order, read template files, or call `parse_hiera_config` more than once

--- a/prompts/puppet_analysis_validation_system.md
+++ b/prompts/puppet_analysis_validation_system.md
@@ -43,7 +43,7 @@ The following issues were found:
    - This class contains 4 resources that should be migrated
 
 2. **Template Render Count Mismatch**
-   - Template `haproxy.cfg.erb` renders once per backend
+   - Template `app.conf.erb` renders once per backend
    - Migration plan says it renders once total
 ```
 

--- a/prompts/puppet_custom_type_analysis_system.j2
+++ b/prompts/puppet_custom_type_analysis_system.j2
@@ -4,17 +4,17 @@ COMPONENT TYPES:
 
 1. Custom Types (lib/puppet/type/*.rb):
    - Define new resource types with parameters and properties
-   - Example: Puppet::Type.newtype(:redis_health) do ... end
+   - Example: Puppet::Type.newtype(:app_health) do ... end
    - Extract: name, parameters (with types/defaults), validation rules
 
 2. Custom Providers (lib/puppet/provider/**/*.rb):
    - Implement how resources are managed on the system
-   - Example: Puppet::Type.type(:redis_health).provide(:cli) do ... end
+   - Example: Puppet::Type.type(:app_health).provide(:cli) do ... end
    - Extract: name, commands used, methods implemented
 
 3. Custom Facts (lib/facter/*.rb):
    - Gather system information
-   - Example: Facter.add('redis_role') do ... end
+   - Example: Facter.add('app_role') do ... end
    - Extract: fact name, how it's computed, what it returns
 
 4. Custom Functions (lib/puppet/functions/*.rb):

--- a/prompts/puppet_dependency_fetcher_task.j2
+++ b/prompts/puppet_dependency_fetcher_task.j2
@@ -57,8 +57,8 @@ mod 'puppetlabs-firewall', '8.1.3'
 mod 'puppetlabs-stdlib', '9.7.0'
 
 # Custom git module
-mod 'custom_haproxy',
-  :git => 'https://github.com/example/puppet-haproxy.git',
+mod 'custom_webapp',
+  :git => 'https://github.com/example/puppet-webapp.git',
   :tag => 'v2.3.0'
 
 mod 'puppetlabs-concat', '9.0.2'
@@ -68,7 +68,7 @@ mod 'puppetlabs-concat', '9.0.2'
 ```
 /home/user/puppet-module/migration-dependencies/
 ├── stdlib/
-├── custom_haproxy/
+├── custom_webapp/
 └── concat/
 ```
 
@@ -85,11 +85,11 @@ mod 'puppetlabs-concat', '9.0.2'
       "path": "/home/user/puppet-module/migration-dependencies/stdlib"
     },
     {
-      "name": "custom_haproxy",
+      "name": "custom_webapp",
       "source": "git",
       "version": "v2.3.0",
-      "url": "https://github.com/example/puppet-haproxy.git",
-      "path": "/home/user/puppet-module/migration-dependencies/custom_haproxy"
+      "url": "https://github.com/example/puppet-webapp.git",
+      "path": "/home/user/puppet-module/migration-dependencies/custom_webapp"
     },
     {
       "name": "puppetlabs-concat",

--- a/prompts/puppet_hiera_analysis_system.j2
+++ b/prompts/puppet_hiera_analysis_system.j2
@@ -23,7 +23,7 @@ Based on the Hiera hierarchy level, map variables to Ansible targets:
 | role/%{role}.yaml | group_vars/{role}.yml |
 
 ANSIBLE VARIABLE NAMING:
-- Strip the module prefix: profile_haproxy::backends -> haproxy_backends
+- Strip the module prefix: profile_webapp::backends -> webapp_backends
 - Convert to snake_case if not already
 - Prefix with a short module identifier to avoid collisions
 

--- a/prompts/puppet_manifest_analysis_system.j2
+++ b/prompts/puppet_manifest_analysis_system.j2
@@ -2,7 +2,7 @@ You are a Puppet manifest analyzer. Extract the complete execution flow of a Pup
 
 MOST IMPORTANT — CLASS NAME EXTRACTION:
 Every Puppet manifest that contains `class <name> {` or `class <name> (` declares a class.
-You MUST extract the fully qualified class name (e.g., "profile_haproxy::install", "redis", "apache::vhost").
+You MUST extract the fully qualified class name (e.g., "profile_webapp::install", "postgresql", "apache::vhost").
 The class_name field must ALWAYS be populated when a class or defined type declaration exists in the file.
 Look for these patterns:
 - `class module::subclass {` or `class module::subclass (`  → class_name: "module::subclass"
@@ -41,8 +41,8 @@ Class inheritance:
 When a class uses `inherits`, set class_inherits as an OBJECT (not a string) with:
 - parent_class: the inherited class name
 - child_class: the inheriting class name
-Example: `class redis::sentinel (...) inherits redis::params {` →
-  class_inherits: {"parent_class": "redis::params", "child_class": "redis::sentinel"}
+Example: `class tomcat::instance (...) inherits tomcat::params {` →
+  class_inherits: {"parent_class": "tomcat::params", "child_class": "tomcat::instance"}
 
 Class parameter serialization format:
 Serialize each parameter as: "param_name": "Type, default: value"
@@ -52,10 +52,30 @@ For parameters with no default: "enable_ssl": "Boolean"
 Resource attributes:
 Extract ALL attributes for each resource — ensure, source, content, command, owner, group, mode, path, creates, unless, onlyif, require, notify, subscribe, etc. Do not filter or limit attributes.
 
+Iteration blocks (.each, .map, .filter, .reduce):
+For each iteration, create an item with type "iteration" and populate:
+- iterator_type: the function name ("each", "map", "filter", or "reduce")
+- collection_variable: the variable or expression being iterated (e.g., "$instances", "$packages")
+- item_variable: the loop variable(s) bound to each element, comma-separated with $ prefix
+  - Single variable: "$pkg"
+  - Multiple variables (key/value): "$key, $values"
+- execution_order: the resources inside the loop body
+
+Example: `$instances.each | String $key, Hash $values | { tomcat::instance { $key: * => $values } }` →
+  type: "iteration", iterator_type: "each", collection_variable: "$instances", item_variable: "$key, $values",
+  execution_order: [{"type": "resource", "resource_type": "tomcat::instance", "title": "$key", "attributes": {"*": "$values"}}]
+
 ANALYSIS APPROACH:
 1. Find the class/define declaration and extract its name and parameters
-2. Walk the class body top-to-bottom, recording each resource, include, conditional, and iteration in sequential order
+2. Walk the ENTIRE class body from opening { to closing }, recording EVERY resource, include, conditional, and iteration in sequential order
+   - Do NOT stop after extracting conditionals
+   - Do NOT skip resources that appear after conditionals or variable assignments
+   - Variable assignments ($var = ...) are NOT execution items and should not be in execution_order
+   - Include EVERY resource declaration: file {}, exec {}, service {}, package {}, etc.
 3. Extract relationship chains, PuppetDB queries, and fact references
+4. VERIFY: The execution_order should represent the COMPLETE execution flow, not just the first few items
+
+CRITICAL: Scan the ENTIRE class body to the end. Many manifests have resources AFTER conditionals and variable assignments. These must ALL be in execution_order.
 
 EXAMPLE:
-{"class_name": "profile::webserver", "class_parameters": {"port": "Integer, default: 8080"}, "execution_order": [{"type": "class_include", "class_name": "profile::base", "relationship": "include"}, {"type": "resource", "resource_type": "package", "title": "nginx", "attributes": {"ensure": "installed"}}], "fact_references": ["$facts['os']['family']"]}
+{"class_name": "profile::webserver", "class_parameters": {"port": "Integer, default: 8080"}, "execution_order": [{"type": "class_include", "class_name": "profile::base", "relationship": "include"}, {"type": "conditional", "condition_type": "if", "condition": "$enable_ssl", "execution_order": [{"type": "resource", "resource_type": "package", "title": "ssl-cert", "attributes": {"ensure": "installed"}}]}, {"type": "resource", "resource_type": "package", "title": "nginx", "attributes": {"ensure": "installed"}}, {"type": "resource", "resource_type": "service", "title": "nginx", "attributes": {"ensure": "running", "enable": true}}], "fact_references": ["$facts['os']['family']"]}

--- a/prompts/puppet_manifest_analysis_task.j2
+++ b/prompts/puppet_manifest_analysis_task.j2
@@ -1,8 +1,22 @@
-Analyze this Puppet manifest. Extract the class name, parameters, and complete execution order.
+Analyze this Puppet manifest and extract the COMPLETE execution order.
+
+CRITICAL: Walk through the ENTIRE class/define body from START to END. Extract EVERY resource, conditional, iteration, and class include in sequential order. Do NOT stop after extracting conditionals - continue to the end of the class body.
 
 FILE: {{ file_path }}
 ```puppet
 {{ file_content }}
 ```
 
-Return the complete analysis. Include all fields that have values — especially class_name.
+REQUIREMENTS:
+1. Extract class_name and all parameters
+2. Walk through the class body sequentially and extract EVERY execution item:
+   - ALL conditionals (if, unless, case)
+   - ALL resources (file, exec, service, package, etc.)
+   - ALL class includes
+   - ALL iterations (.each, .map, etc.)
+3. Extract all relationship chains (->,-~>)
+4. Extract all fact references
+
+IMPORTANT: The execution_order list must include EVERY resource and control structure in the order they appear in the class body, from the opening { to the closing }.
+
+Return the complete analysis. Include all fields that have values — especially class_name and a COMPLETE execution_order list.

--- a/src/inputs/puppet/execution_tree_builder.py
+++ b/src/inputs/puppet/execution_tree_builder.py
@@ -6,7 +6,8 @@ with iterations expanded and resource details inline.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -23,46 +24,188 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
-def _format_class(n: ExecutionTreeNode) -> str:
-    label = f"[class] {n.name}"
-    if n.file_path:
-        label += f"  # {n.file_path}"
-    if n.details:
-        label += f" ({n.details})"
-    return label
-
-
-_LABEL_FORMATTERS: dict[str, Callable[[ExecutionTreeNode], str]] = {
-    "class": _format_class,
-    "resource": lambda n: f"[resource] {n.name}",
-    "iteration": lambda n: f"LOOP {n.name}",
-    "conditional": lambda n: f"[conditional] {n.name}",
-    "exported": lambda n: f"[exported @@] {n.name}",
-    "virtual": lambda n: f"[virtual @] {n.name}",
-    "collector": lambda n: f"[collector <<| |>>] {n.name}",
-    "puppetdb_query": lambda n: f"[puppetdb_query] {n.name}",
-    "relationship": lambda n: f"[ordering] {n.name}",
-    "fact": lambda n: f"[fact] {n.name}",
-}
+# ============================================================================
+# Execution Tree Node Hierarchy
+# ============================================================================
 
 
 @dataclass
-class ExecutionTreeNode:
-    """Node in the Puppet execution tree."""
+class ExecutionTreeNode(ABC):
+    """Base class for all execution tree nodes."""
 
-    node_type: (
-        str  # "class", "resource", "iteration", "conditional", "exported", "virtual"
-    )
     name: str
     file_path: str | None = None
     details: str | None = None
     children: list[ExecutionTreeNode] = field(default_factory=list)
 
+    @property
+    @abstractmethod
+    def node_type(self) -> str: ...
+
+    @abstractmethod
+    def format_label(self) -> str: ...
+
+
+@dataclass
+class ClassNode(ExecutionTreeNode):
+    """A Puppet class in the execution tree."""
+
+    @property
+    def node_type(self) -> str:
+        return "class"
+
     def format_label(self) -> str:
-        formatter = _LABEL_FORMATTERS.get(self.node_type)
-        if formatter:
-            return formatter(self)
-        return f"{self.name} ({self.details})" if self.details else self.name
+        label = f"[class] {self.name}"
+        if self.file_path:
+            label += f"  # {self.file_path}"
+        if self.details:
+            label += f" ({self.details})"
+        return label
+
+
+@dataclass
+class ResourceNode(ExecutionTreeNode):
+    """A Puppet resource (package, file, service, exec, etc.)."""
+
+    @property
+    def node_type(self) -> str:
+        return "resource"
+
+    def format_label(self) -> str:
+        return f"[resource] {self.name}"
+
+
+@dataclass
+class DefinedTypeNode(ExecutionTreeNode):
+    """An expanded Puppet defined type instance."""
+
+    @property
+    def node_type(self) -> str:
+        return "defined_type"
+
+    def format_label(self) -> str:
+        label = f"[defined_type] {self.name}"
+        if self.file_path:
+            label += f"  # {self.file_path}"
+        if self.details:
+            label += f" ({self.details})"
+        return label
+
+
+@dataclass
+class IterationNode(ExecutionTreeNode):
+    """A loop (.each, .map, etc.) in the execution tree."""
+
+    @property
+    def node_type(self) -> str:
+        return "iteration"
+
+    def format_label(self) -> str:
+        return f"LOOP {self.name}"
+
+
+@dataclass
+class ConditionalNode(ExecutionTreeNode):
+    """A conditional (if, unless, case) in the execution tree."""
+
+    @property
+    def node_type(self) -> str:
+        return "conditional"
+
+    def format_label(self) -> str:
+        return f"[conditional] {self.name}"
+
+
+@dataclass
+class ExportedResourceNode(ExecutionTreeNode):
+    """An exported resource (@@) shared via PuppetDB."""
+
+    @property
+    def node_type(self) -> str:
+        return "exported"
+
+    def format_label(self) -> str:
+        return f"[exported @@] {self.name}"
+
+
+@dataclass
+class VirtualResourceNode(ExecutionTreeNode):
+    """A virtual resource (@) realized conditionally."""
+
+    @property
+    def node_type(self) -> str:
+        return "virtual"
+
+    def format_label(self) -> str:
+        return f"[virtual @] {self.name}"
+
+
+@dataclass
+class CollectorNode(ExecutionTreeNode):
+    """A resource collector (<<| |>>)."""
+
+    @property
+    def node_type(self) -> str:
+        return "collector"
+
+    def format_label(self) -> str:
+        return f"[collector <<| |>>] {self.name}"
+
+
+@dataclass
+class PuppetDBQueryNode(ExecutionTreeNode):
+    """A PuppetDB query node."""
+
+    @property
+    def node_type(self) -> str:
+        return "puppetdb_query"
+
+    def format_label(self) -> str:
+        return f"[puppetdb_query] {self.name}"
+
+
+@dataclass
+class RelationshipNode(ExecutionTreeNode):
+    """An ordering/notification relationship chain."""
+
+    @property
+    def node_type(self) -> str:
+        return "relationship"
+
+    def format_label(self) -> str:
+        return f"[ordering] {self.name}"
+
+
+@dataclass
+class FactNode(ExecutionTreeNode):
+    """A Puppet fact reference."""
+
+    @property
+    def node_type(self) -> str:
+        return "fact"
+
+    def format_label(self) -> str:
+        return f"[fact] {self.name}"
+
+
+@dataclass
+class TemplateNode(ExecutionTreeNode):
+    """A template reference within a resource."""
+
+    @property
+    def node_type(self) -> str:
+        return "template"
+
+    def format_label(self) -> str:
+        label = f"[template] {self.name}"
+        if self.details:
+            label += f" ({self.details})"
+        return label
+
+
+# ============================================================================
+# Execution Tree Builder
+# ============================================================================
 
 
 class PuppetExecutionTreeBuilder:
@@ -88,8 +231,7 @@ class PuppetExecutionTreeBuilder:
             entry_class = self._find_entry_class()
 
         if entry_class is None:
-            return ExecutionTreeNode(
-                node_type="class",
+            return ClassNode(
                 name="(no entry class found)",
                 details="No init.pp or main class detected",
             )
@@ -116,11 +258,7 @@ class PuppetExecutionTreeBuilder:
         return "\n".join(lines)
 
     def collect_file_paths(self, node: ExecutionTreeNode) -> set[str]:
-        """Collect all file paths from execution tree nodes.
-
-        Only class nodes have file_path set. This traverses the tree
-        depth-first and collects all non-None file paths.
-        """
+        """Collect all file paths from execution tree nodes."""
         paths = set()
 
         if node.file_path:
@@ -131,8 +269,11 @@ class PuppetExecutionTreeBuilder:
 
         return paths
 
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
     def _normalize_class_name(self, class_name: str) -> str:
-        """Normalize class name by removing leading :: for consistent lookups."""
         return class_name.lstrip(":")
 
     def _find_entry_class(self) -> str | None:
@@ -143,12 +284,11 @@ class PuppetExecutionTreeBuilder:
             return self.analysis.manifests[0].analysis.class_name
         return None
 
-    def _expand_class(self, class_name: str) -> ExecutionTreeNode:
+    def _expand_class(self, class_name: str) -> ClassNode:
         normalized = self._normalize_class_name(class_name)
 
         if normalized in self._visited:
-            return ExecutionTreeNode(
-                node_type="class",
+            return ClassNode(
                 name=class_name,
                 details="[CIRCULAR - already visited]",
             )
@@ -162,23 +302,14 @@ class PuppetExecutionTreeBuilder:
                 resolved = self.path_resolver.resolve_class(class_name)
                 if resolved:
                     details = f"external class — {resolved}"
-            return ExecutionTreeNode(
-                node_type="class",
-                name=class_name,
-                details=details,
-            )
+            return ClassNode(name=class_name, details=details)
 
         analysis = manifest.analysis
-        node = ExecutionTreeNode(
-            node_type="class",
-            name=class_name,
-            file_path=manifest.file_path,
-        )
+        node = ClassNode(name=class_name, file_path=manifest.file_path)
 
         if analysis.class_inherits:
             node.children.append(
-                ExecutionTreeNode(
-                    node_type="class",
+                ClassNode(
                     name=f"inherits {analysis.class_inherits.parent_class}",
                     details=f"overrides: {', '.join(analysis.class_inherits.overridden_params)}"
                     if analysis.class_inherits.overridden_params
@@ -188,58 +319,147 @@ class PuppetExecutionTreeBuilder:
 
         node.children.extend(self._build_execution_nodes(analysis.execution_order))
 
-        if analysis.relationship_chains:
-            for chain in analysis.relationship_chains:
-                node.children.append(
-                    ExecutionTreeNode(node_type="relationship", name=chain)
-                )
+        for chain in analysis.relationship_chains:
+            node.children.append(RelationshipNode(name=chain))
 
-        if analysis.fact_references:
-            for fact in analysis.fact_references:
-                node.children.append(ExecutionTreeNode(node_type="fact", name=fact))
+        for fact in analysis.fact_references:
+            node.children.append(FactNode(name=fact))
 
         return node
 
-    def _build_execution_nodes(self, execution_order: list) -> list[ExecutionTreeNode]:
-        """Build tree nodes from execution order list.
+    def _expand_defined_type(self, defined_type: str, title: str) -> ExecutionTreeNode:
+        normalized = self._normalize_class_name(defined_type)
 
-        Handles both ExecutionItem (top-level) and NestedExecutionItem (nested).
-        Only ExecutionItem supports conditional/iteration with recursion.
-        """
+        visit_key = f"{normalized}[{title}]"
+        if visit_key in self._visited:
+            return ResourceNode(
+                name=f"{defined_type}[{title}]",
+                details="[CIRCULAR - already visited]",
+            )
+
+        self._visited.add(visit_key)
+
+        manifest = self._manifest_map.get(normalized)
+        if manifest is None:
+            return ResourceNode(
+                name=f"{defined_type}[{title}]",
+                details="defined type not analyzed",
+            )
+
+        analysis = manifest.analysis
+
+        details = None
+        if analysis.class_parameters:
+            details = f"{len(analysis.class_parameters)} parameters"
+
+        node = DefinedTypeNode(
+            name=f"{defined_type}[{title}]",
+            file_path=manifest.file_path,
+            details=details,
+        )
+
+        node.children.extend(self._build_execution_nodes(analysis.execution_order))
+        return node
+
+    def _is_defined_type(self, resource_type: str) -> bool:
+        normalized = self._normalize_class_name(resource_type)
+        return normalized in self._manifest_map
+
+    def _extract_template_reference(self, item) -> TemplateNode | None:
+        if not hasattr(item, "attributes") or not item.attributes:
+            return None
+
+        template_attrs = ["content", "source"]
+        for attr_name in template_attrs:
+            if attr_name not in item.attributes:
+                continue
+
+            value = str(item.attributes[attr_name])
+            for pattern in [
+                r"(?:template|epp|erb|inline_epp)\(['\"]([^'\"]+)['\"]",
+                r"(?:template|epp|erb|inline_epp)\('([^']+)'",
+                r'(?:template|epp|erb|inline_epp)\("([^"]+)"',
+            ]:
+                match = re.search(pattern, value)
+                if not match:
+                    continue
+
+                template_path = match.group(1)
+                template_info = self._find_template_info(template_path)
+
+                if template_info:
+                    details = f"{len(template_info['variables'])} variables"
+                    if template_info["logic"]:
+                        details += f", {len(template_info['logic'])} logic blocks"
+                else:
+                    details = "template file"
+
+                return TemplateNode(name=template_path, details=details)
+
+        return None
+
+    def _find_template_info(self, template_path: str) -> dict | None:
+        if not self.analysis or not hasattr(self.analysis, "templates"):
+            return None
+
+        for template in self.analysis.templates:
+            file_path = template.file_path
+
+            template_filename = template_path.split("/")[-1]
+            if template_filename in file_path and all(
+                part in file_path for part in template_path.split("/")[:-1]
+            ):
+                return {
+                    "file_path": file_path,
+                    "variables": template.analysis.variables_used,
+                    "logic": template.analysis.ruby_logic,
+                }
+
+            if template_path in file_path:
+                return {
+                    "file_path": file_path,
+                    "variables": template.analysis.variables_used,
+                    "logic": template.analysis.ruby_logic,
+                }
+
+        return None
+
+    def _build_execution_nodes(self, execution_order: list) -> list[ExecutionTreeNode]:
         nodes: list[ExecutionTreeNode] = []
 
         for item in execution_order:
             if item.type == "resource":
-                # Special case: class resources (class { 'name': ... }) should be expanded
                 if item.resource_type and item.resource_type.lower() == "class":
-                    # This is a parameterized class declaration - expand it
                     child = self._expand_class(item.title)
                     nodes.append(child)
+                elif item.resource_type and self._is_defined_type(item.resource_type):
+                    child = self._expand_defined_type(item.resource_type, item.title)
+                    nodes.append(child)
                 else:
-                    # Regular resource - just show it
-                    details_parts = []
-                    if item.attributes:
-                        for key, value in item.attributes.items():
-                            details_parts.append(f"{key}: {value}")
+                    details_parts = [
+                        f"{key}: {value}"
+                        for key, value in (item.attributes or {}).items()
+                    ]
                     detail = ", ".join(details_parts) if details_parts else None
 
-                    nodes.append(
-                        ExecutionTreeNode(
-                            node_type="resource",
-                            name=f"{item.resource_type}[{item.title}]",
-                            details=detail,
-                        )
+                    resource_node = ResourceNode(
+                        name=f"{item.resource_type}[{item.title}]",
+                        details=detail,
                     )
+
+                    template_child = self._extract_template_reference(item)
+                    if template_child:
+                        resource_node.children.append(template_child)
+
+                    nodes.append(resource_node)
 
             elif item.type == "class_include":
                 child = self._expand_class(item.class_name)
                 nodes.append(child)
 
             elif item.type == "conditional":
-                # Only ExecutionItem has these fields, not NestedExecutionItem
                 if hasattr(item, "execution_order"):
-                    cond_node = ExecutionTreeNode(
-                        node_type="conditional",
+                    cond_node = ConditionalNode(
                         name=f"{item.condition_type} {item.condition}",
                     )
                     cond_node.children.extend(
@@ -248,10 +468,8 @@ class PuppetExecutionTreeBuilder:
                     nodes.append(cond_node)
 
             elif item.type == "iteration":
-                # Only ExecutionItem has these fields, not NestedExecutionItem
                 if hasattr(item, "execution_order"):
-                    iter_node = ExecutionTreeNode(
-                        node_type="iteration",
+                    iter_node = IterationNode(
                         name=f"{item.collection_variable}.{item.iterator_type} |{item.item_variable}|",
                     )
                     iter_node.children.extend(
@@ -261,24 +479,21 @@ class PuppetExecutionTreeBuilder:
 
             elif item.type == "exported_resource":
                 nodes.append(
-                    ExecutionTreeNode(
-                        node_type="exported",
+                    ExportedResourceNode(
                         name=f"{item.resource_type}[{item.title}]",
                     )
                 )
 
             elif item.type == "virtual_resource":
                 nodes.append(
-                    ExecutionTreeNode(
-                        node_type="virtual",
+                    VirtualResourceNode(
                         name=f"{item.resource_type}[{item.title}]",
                     )
                 )
 
             elif item.type == "collector":
                 nodes.append(
-                    ExecutionTreeNode(
-                        node_type="collector",
+                    CollectorNode(
                         name=f"{item.resource_type} <| {item.query} |>",
                     )
                 )

--- a/src/inputs/puppet/report_writer_agent.py
+++ b/src/inputs/puppet/report_writer_agent.py
@@ -63,7 +63,6 @@ class ReportWriterAgent(InputAgent[PuppetState]):
             control_repo_summary,
         )
         result = self.invoke_react(state, messages, metrics)
-
         response_messages = result.get("messages", [])
         if len(response_messages) < 2:
             return state.mark_failed("Invalid response from Puppet agent")

--- a/tests/inputs/puppet/test_execution_tree_builder.py
+++ b/tests/inputs/puppet/test_execution_tree_builder.py
@@ -1,8 +1,16 @@
 """Tests for Puppet execution tree builder."""
 
 from src.inputs.puppet.execution_tree_builder import (
+    ClassNode,
+    CollectorNode,
+    ConditionalNode,
     ExecutionTreeNode,
+    ExportedResourceNode,
+    IterationNode,
     PuppetExecutionTreeBuilder,
+    RelationshipNode,
+    ResourceNode,
+    VirtualResourceNode,
 )
 from src.inputs.puppet.models import (
     ClassInheritance,
@@ -20,21 +28,20 @@ def _make_manifest(class_name, file_path, **kwargs) -> ManifestAnalysisResult:
     )
 
 
-class TestExecutionTreeNode:
+class TestExecutionTreeNodes:
     def test_class_format(self):
-        node = ExecutionTreeNode(
-            node_type="class",
-            name="profile_haproxy",
+        node = ClassNode(
+            name="profile_webapp",
             file_path="manifests/init.pp",
         )
         label = node.format_label()
-        assert "[class] profile_haproxy" in label
+        assert "[class] profile_webapp" in label
         assert "manifests/init.pp" in label
+        assert node.node_type == "class"
 
     def test_class_with_details(self):
-        node = ExecutionTreeNode(
-            node_type="class",
-            name="profile_haproxy",
+        node = ClassNode(
+            name="profile_webapp",
             file_path="manifests/init.pp",
             details="entry point",
         )
@@ -42,32 +49,45 @@ class TestExecutionTreeNode:
         assert "(entry point)" in label
 
     def test_resource_format(self):
-        node = ExecutionTreeNode(node_type="resource", name="package[haproxy]")
-        assert node.format_label() == "[resource] package[haproxy]"
+        node = ResourceNode(name="package[webapp]")
+        assert node.format_label() == "[resource] package[webapp]"
+        assert node.node_type == "resource"
 
     def test_iteration_format(self):
-        node = ExecutionTreeNode(node_type="iteration", name="$backends.each |$name|")
+        node = IterationNode(name="$backends.each |$name|")
         assert "LOOP" in node.format_label()
+        assert node.node_type == "iteration"
 
     def test_conditional_format(self):
-        node = ExecutionTreeNode(node_type="conditional", name="if $ssl_enabled")
+        node = ConditionalNode(name="if $ssl_enabled")
         assert "[conditional]" in node.format_label()
+        assert node.node_type == "conditional"
 
     def test_exported_format(self):
-        node = ExecutionTreeNode(node_type="exported", name="nagios_host[web01]")
+        node = ExportedResourceNode(name="nagios_host[web01]")
         assert "@@" in node.format_label()
+        assert node.node_type == "exported"
 
     def test_virtual_format(self):
-        node = ExecutionTreeNode(node_type="virtual", name="user[deploy]")
+        node = VirtualResourceNode(name="user[deploy]")
         assert "@" in node.format_label()
+        assert node.node_type == "virtual"
 
-    def test_unknown_type_format(self):
-        node = ExecutionTreeNode(node_type="unknown", name="something")
-        assert node.format_label() == "something"
+    def test_collector_format(self):
+        node = CollectorNode(name="Nagios_host <| tag == production |>")
+        assert "<<| |>>" in node.format_label()
+        assert node.node_type == "collector"
 
-    def test_unknown_type_with_details(self):
-        node = ExecutionTreeNode(node_type="unknown", name="something", details="extra")
-        assert node.format_label() == "something (extra)"
+    def test_relationship_format(self):
+        node = RelationshipNode(name="Package[nginx] -> Service[nginx]")
+        assert "[ordering]" in node.format_label()
+        assert node.node_type == "relationship"
+
+    def test_base_class_is_abstract(self):
+        import pytest
+
+        with pytest.raises(TypeError):
+            ExecutionTreeNode(name="test")  # pyrefly: ignore[bad-instantiation]
 
 
 class TestPuppetExecutionTreeBuilder:
@@ -75,24 +95,24 @@ class TestPuppetExecutionTreeBuilder:
         analysis = PuppetStructuredAnalysis(
             manifests=[
                 _make_manifest(
-                    "profile_haproxy",
+                    "profile_webapp",
                     "manifests/init.pp",
                     execution_order=[
                         ExecutionItem(
                             type="class_include",
-                            class_name="profile_haproxy::install",
+                            class_name="profile_webapp::install",
                             relationship="include",
                         ),
                     ],
                 ),
                 _make_manifest(
-                    "profile_haproxy::install",
+                    "profile_webapp::install",
                     "manifests/install.pp",
                     execution_order=[
                         ExecutionItem(
                             type="resource",
                             resource_type="package",
-                            title="haproxy",
+                            title="webapp",
                             attributes={"ensure": "installed"},
                         ),
                     ],
@@ -102,35 +122,38 @@ class TestPuppetExecutionTreeBuilder:
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
 
-        assert root.name == "profile_haproxy"
+        assert root.name == "profile_webapp"
         assert root.node_type == "class"
+        assert isinstance(root, ClassNode)
         assert len(root.children) == 1
         child = root.children[0]
-        assert child.name == "profile_haproxy::install"
+        assert child.name == "profile_webapp::install"
+        assert isinstance(child, ClassNode)
         assert len(child.children) == 1
+        assert isinstance(child.children[0], ResourceNode)
         assert "package" in child.children[0].name
 
     def test_entry_class_detection_via_init_pp(self):
         analysis = PuppetStructuredAnalysis(
             manifests=[
-                _make_manifest("profile_haproxy::config", "manifests/config.pp"),
-                _make_manifest("profile_haproxy", "manifests/init.pp"),
+                _make_manifest("profile_webapp::config", "manifests/config.pp"),
+                _make_manifest("profile_webapp", "manifests/init.pp"),
             ]
         )
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
-        assert root.name == "profile_haproxy"
+        assert root.name == "profile_webapp"
 
     def test_entry_class_fallback_to_first(self):
         analysis = PuppetStructuredAnalysis(
             manifests=[
-                _make_manifest("profile_haproxy::config", "manifests/config.pp"),
-                _make_manifest("profile_haproxy::install", "manifests/install.pp"),
+                _make_manifest("profile_webapp::config", "manifests/config.pp"),
+                _make_manifest("profile_webapp::install", "manifests/install.pp"),
             ]
         )
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
-        assert root.name == "profile_haproxy::config"
+        assert root.name == "profile_webapp::config"
 
     def test_no_manifests(self):
         analysis = PuppetStructuredAnalysis()
@@ -232,7 +255,7 @@ class TestPuppetExecutionTreeBuilder:
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
 
-        cond_nodes = [c for c in root.children if c.node_type == "conditional"]
+        cond_nodes = [c for c in root.children if isinstance(c, ConditionalNode)]
         assert len(cond_nodes) == 1
         assert "ssl_enabled" in cond_nodes[0].name
 
@@ -257,7 +280,7 @@ class TestPuppetExecutionTreeBuilder:
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
 
-        iter_nodes = [c for c in root.children if c.node_type == "iteration"]
+        iter_nodes = [c for c in root.children if isinstance(c, IterationNode)]
         assert len(iter_nodes) == 1
         assert "$backends" in iter_nodes[0].name
 
@@ -285,8 +308,8 @@ class TestPuppetExecutionTreeBuilder:
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
 
-        exported = [c for c in root.children if c.node_type == "exported"]
-        virtual = [c for c in root.children if c.node_type == "virtual"]
+        exported = [c for c in root.children if isinstance(c, ExportedResourceNode)]
+        virtual = [c for c in root.children if isinstance(c, VirtualResourceNode)]
         assert len(exported) == 1
         assert "nagios_host" in exported[0].name
         assert len(virtual) == 1
@@ -299,7 +322,7 @@ class TestPuppetExecutionTreeBuilder:
                     "main",
                     "manifests/init.pp",
                     relationship_chains=[
-                        "Package[haproxy] -> File[haproxy.cfg] ~> Service[haproxy]"
+                        "Package[webapp] -> File[webapp.cfg] ~> Service[webapp]"
                     ],
                 ),
             ]
@@ -307,9 +330,9 @@ class TestPuppetExecutionTreeBuilder:
         builder = PuppetExecutionTreeBuilder(analysis)
         root = builder.build_tree()
 
-        rel_nodes = [c for c in root.children if c.node_type == "relationship"]
+        rel_nodes = [c for c in root.children if isinstance(c, RelationshipNode)]
         assert len(rel_nodes) == 1
-        assert "Package[haproxy]" in rel_nodes[0].name
+        assert "Package[webapp]" in rel_nodes[0].name
 
     def test_resource_details_extraction(self):
         analysis = PuppetStructuredAnalysis(
@@ -321,7 +344,7 @@ class TestPuppetExecutionTreeBuilder:
                         ExecutionItem(
                             type="resource",
                             resource_type="file",
-                            title="/etc/haproxy/haproxy.cfg",
+                            title="/etc/webapp/app.cfg",
                             attributes={
                                 "ensure": "file",
                                 "owner": "root",
@@ -332,7 +355,7 @@ class TestPuppetExecutionTreeBuilder:
                             type="resource",
                             resource_type="exec",
                             title="reload_config",
-                            attributes={"command": "/usr/sbin/haproxy -c"},
+                            attributes={"command": "/usr/sbin/webapp -c"},
                         ),
                     ],
                 ),
@@ -342,8 +365,10 @@ class TestPuppetExecutionTreeBuilder:
         root = builder.build_tree()
 
         file_node = root.children[0]
+        assert isinstance(file_node, ResourceNode)
         assert "ensure: file" in (file_node.details or "")
         exec_node = root.children[1]
+        assert isinstance(exec_node, ResourceNode)
         assert "command:" in (exec_node.details or "")
 
 
@@ -356,7 +381,7 @@ class TestFormatTree:
                     "manifests/init.pp",
                     execution_order=[
                         ExecutionItem(
-                            type="resource", resource_type="package", title="haproxy"
+                            type="resource", resource_type="package", title="webapp"
                         ),
                         ExecutionItem(
                             type="class_include",
@@ -373,7 +398,7 @@ class TestFormatTree:
         output = builder.format_tree(root)
 
         assert "[class] main" in output
-        assert "[resource] package[haproxy]" in output
+        assert "[resource] package[webapp]" in output
         assert "[class] main::config" in output
         assert "├── " in output or "└── " in output
 

--- a/tests/inputs/puppet/test_instances_execution_tree.py
+++ b/tests/inputs/puppet/test_instances_execution_tree.py
@@ -1,0 +1,123 @@
+"""Test that defined types (like redis::instance) are expanded in the execution tree."""
+
+from src.inputs.puppet.execution_tree_builder import PuppetExecutionTreeBuilder
+from src.inputs.puppet.models import (
+    ExecutionItem,
+    ManifestAnalysisResult,
+    ManifestExecutionAnalysis,
+    NestedExecutionItem,
+    PuppetStructuredAnalysis,
+)
+
+
+def test_defined_type_expansion():
+    """Test that defined types are expanded to show their execution order."""
+    # Main class that uses a defined type
+    main_class = ManifestAnalysisResult(
+        file_path="manifests/init.pp",
+        analysis=ManifestExecutionAnalysis(
+            class_name="redis",
+            execution_order=[
+                # Loop that creates instances
+                ExecutionItem(
+                    type="iteration",
+                    iterator_type="each",
+                    collection_variable="$instances",
+                    item_variable="$key",
+                    execution_order=[
+                        NestedExecutionItem(
+                            type="resource",
+                            resource_type="redis::instance",
+                            title="$key",
+                        )
+                    ],
+                )
+            ],
+        ),
+    )
+
+    # Defined type manifest
+    instance_type = ManifestAnalysisResult(
+        file_path="manifests/instance.pp",
+        analysis=ManifestExecutionAnalysis(
+            class_name="redis::instance",
+            class_parameters={"port": "6379", "bind": "127.0.0.1"},
+            execution_order=[
+                ExecutionItem(
+                    type="conditional",
+                    condition_type="if",
+                    condition="$log_dir != $redis::log_dir",
+                    execution_order=[
+                        NestedExecutionItem(
+                            type="resource",
+                            resource_type="file",
+                            title="$log_dir",
+                            attributes={"ensure": "directory"},
+                        )
+                    ],
+                ),
+                ExecutionItem(
+                    type="resource",
+                    resource_type="file",
+                    title="$config_file",
+                    attributes={"ensure": "file", "content": "template()"},
+                ),
+            ],
+        ),
+    )
+
+    # Build the tree
+    structured = PuppetStructuredAnalysis(
+        manifests=[main_class, instance_type],
+        hiera_data=[],
+        templates=[],
+        custom_types=[],
+    )
+
+    builder = PuppetExecutionTreeBuilder(structured, path_resolver=None)
+    tree = builder.build_tree(entry_class="redis")
+
+    # Format the tree
+    formatted = builder.format_tree(tree)
+
+    # Verify the tree structure
+    assert "LOOP $instances.each |$key|" in formatted
+    assert "[defined_type] redis::instance[$key]" in formatted
+    assert "manifests/instance.pp" in formatted
+    assert "2 parameters" in formatted
+
+    # Most importantly: verify that the defined type's execution order is shown
+    assert "[conditional] if $log_dir != $redis::log_dir" in formatted
+    assert "[resource] file[$log_dir]" in formatted
+    assert "[resource] file[$config_file]" in formatted
+
+    print("\n" + formatted)
+
+
+def test_defined_type_not_analyzed():
+    """Test that undefined types are shown as regular resources when not analyzed."""
+    main_class = ManifestAnalysisResult(
+        file_path="manifests/init.pp",
+        analysis=ManifestExecutionAnalysis(
+            class_name="mymodule",
+            execution_order=[
+                ExecutionItem(
+                    type="resource",
+                    resource_type="unknown::type",
+                    title="instance1",
+                )
+            ],
+        ),
+    )
+
+    structured = PuppetStructuredAnalysis(
+        manifests=[main_class], hiera_data=[], templates=[], custom_types=[]
+    )
+
+    builder = PuppetExecutionTreeBuilder(structured, path_resolver=None)
+    tree = builder.build_tree(entry_class="mymodule")
+
+    formatted = builder.format_tree(tree)
+
+    # Should show as a regular resource (not expanded)
+    assert "[resource] unknown::type[instance1]" in formatted

--- a/tests/inputs/puppet/test_manifest_analysis.py
+++ b/tests/inputs/puppet/test_manifest_analysis.py
@@ -1,0 +1,142 @@
+"""Evaluation tests for Puppet ManifestAnalysisService.
+
+These tests send Puppet manifest strings through the LLM via
+ManifestAnalysisService and verify that the ManifestExecutionAnalysis
+output correctly extracts iterations, conditionals, and class names.
+"""
+
+import pytest
+
+from src.inputs.puppet.models import ManifestExecutionAnalysis
+from src.inputs.puppet.services import ManifestAnalysisService
+from src.types.file_analysis_state import FileAnalysisState
+
+pytestmark = [pytest.mark.eval]
+
+
+class TestManifestAnalysisEval:
+    @pytest.fixture(scope="class")
+    def manifest_service(self):
+        from src.model import get_model
+
+        return ManifestAnalysisService(model=get_model())
+
+    def _analyze(self, service, tmp_path, content, filename="init.pp"):
+        pp_file = tmp_path / filename
+        pp_file.write_text(content)
+        state = FileAnalysisState(user_message="", path=str(pp_file))
+        result_state = service(state)
+        return result_state.result
+
+    def test_each_loop_extraction(self, manifest_service, tmp_path):
+        manifest = """\
+class profile_webapp::config (
+  Hash $backends = {},
+) {
+  $backends.each |String $name, Hash $config| {
+    file { "/etc/webapp/conf.d/${name}.conf":
+      ensure  => file,
+      content => template('profile_webapp/backend.conf.erb'),
+      mode    => '0644',
+    }
+  }
+}
+"""
+        result = self._analyze(manifest_service, tmp_path, manifest, "config.pp")
+
+        assert isinstance(result, ManifestExecutionAnalysis)
+        assert result.class_name == "profile_webapp::config"
+
+        iteration_items = [
+            item for item in result.execution_order if item.type == "iteration"
+        ]
+        assert len(iteration_items) >= 1, (
+            f"Expected at least 1 iteration item, got {len(iteration_items)}. "
+            f"Types found: {[i.type for i in result.execution_order]}"
+        )
+
+        iter_item = iteration_items[0]
+        assert iter_item.iterator_type == "each"
+        assert "$backends" in (iter_item.collection_variable or "")
+        assert len(iter_item.execution_order) >= 1, (
+            "Iteration body should contain at least 1 nested resource"
+        )
+
+        nested_resources = [
+            n for n in iter_item.execution_order if n.type == "resource"
+        ]
+        assert len(nested_resources) >= 1
+        assert nested_resources[0].resource_type == "file"
+
+    def test_all_resources_after_conditional(self, manifest_service, tmp_path):
+        manifest = """\
+class profile_webapp (
+  Boolean $enable_ssl = false,
+) {
+  if $enable_ssl {
+    package { 'openssl':
+      ensure => installed,
+    }
+  }
+
+  package { 'webapp':
+    ensure => installed,
+  }
+
+  file { '/etc/webapp/app.conf':
+    ensure => file,
+    mode   => '0644',
+  }
+
+  service { 'webapp':
+    ensure => running,
+    enable => true,
+  }
+}
+"""
+        result = self._analyze(manifest_service, tmp_path, manifest)
+
+        assert isinstance(result, ManifestExecutionAnalysis)
+        assert result.class_name == "profile_webapp"
+
+        assert len(result.execution_order) >= 4, (
+            f"Expected at least 4 execution items (1 conditional + 3 resources), "
+            f"got {len(result.execution_order)}: "
+            f"{[(i.type, getattr(i, 'resource_type', None) or getattr(i, 'condition_type', None)) for i in result.execution_order]}"
+        )
+
+        types = [item.type for item in result.execution_order]
+        assert "conditional" in types, "Should extract the if-block as a conditional"
+
+        resource_items = [
+            item for item in result.execution_order if item.type == "resource"
+        ]
+        resource_names = [
+            f"{item.resource_type}[{item.title}]" for item in resource_items
+        ]
+        assert any("webapp" in name and "package" in name for name in resource_names), (
+            f"Missing package[webapp], found: {resource_names}"
+        )
+        assert any("app.conf" in name for name in resource_names), (
+            f"Missing file[/etc/webapp/app.conf], found: {resource_names}"
+        )
+        assert any("service" in name for name in resource_names), (
+            f"Missing service[webapp], found: {resource_names}"
+        )
+
+    def test_class_name_extraction(self, manifest_service, tmp_path):
+        manifest = """\
+class profile_webapp::install {
+  package { 'webapp-server':
+    ensure => present,
+  }
+}
+"""
+        result = self._analyze(manifest_service, tmp_path, manifest, "install.pp")
+
+        assert isinstance(result, ManifestExecutionAnalysis)
+        assert result.class_name == "profile_webapp::install"
+        assert len(result.execution_order) == 1
+        assert result.execution_order[0].type == "resource"
+        assert result.execution_order[0].resource_type == "package"
+        assert result.execution_order[0].title == "webapp-server"


### PR DESCRIPTION
Currently we're not getting a good explanation where there are complicated loops or iterations, this change creates a better migration plan when there are more inhereance.

Example output:
```
5. **`redis`** (`modules/profile_redis_cluster/migration-dependencies/redis/manifests/init.pp`):
   - Inherits `redis::params` (OS‑specific defaults).
   - Containment order: `redis::preinstall -> redis::install -> redis::config -> redis::service`.

   5.1 **`redis::preinstall`** (`preinstall.pp`):
        - Conditional `if $redis::manage_repo` (default `false`; no repo actions).
        - Uses `$facts['os']['family']` and `$facts['os']['name']` for OS defaults.

   5.2 **`redis::install`** (`install.pp`):
        - Conditional `if $redis::manage_package` (true) → installs package `$redis::package_name`.
        - Conditional `if $redis::dnf_module_stream` (false on Debian family) → no dnfmodule.

   5.3 **`redis::config`** (`config.pp`):
        - Creates directories: `$redis::config_dir`, `$redis::log_dir`, `$redis::workdir`.
        - Includes `redis::ulimit` when `$redis::ulimit_managed` is true (default false).
        - OS‑specific file: `/etc/default/redis-server` on Debian family.
        - Because `$redis::default_install` defaults to `true`, it declares the **default instance** `redis::instance['default']`.

   5.4 **`redis::ulimit`** (`ulimit.pp`):
        - If `$redis::managed_by_cluster_manager` (default `false`) → creates `/etc/security/limits.d/redis.conf`.
        - Always creates systemd drop‑in `/etc/systemd/system/${redis::service_name}.service.d/limit.conf`.

   5.5 **`redis::instance['default']`** (`instance.pp`):
        - Parameters resolved from profile overrides and OS defaults (see detailed list below).
        - Resources created:
          1. Systemd unit file (`systemd::unit_file`).
          2. Rendered configuration file `/etc/redis/redis.conf.puppet`.
          3. Exec to copy rendered file to live location `/etc/redis/redis.conf`.
          4. Service resource managed later by `redis::service`.

   5.6 **`redis::service`** (`service.pp`):
        - Conditional `if $redis::service_manage` (true) → ensures `service { $redis::service_name: ensure => running, enable => true }`.

6. **Loop `$instances.each`** (`config.pp`):
   - No `$instances` data found in Hiera; the loop runs **0 times**. No additional instances are created.
```

Fix FLPATH-4473