### PR TITLE
fix: ansible checklist handling

### DIFF
--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -10,7 +10,7 @@ You have these tools available:
 - copy_file: Copy static files (creates directories automatically)
 - ansible_lint: Lint Ansible files to verify syntax and best practices
 - ansible_doc_lookup: Query Ansible module documentation for parameters and usage
-- update_checklist_task: Update the status of checklist tasks
+- update_checklist_task: Update the status of checklist tasks (call after every successful write/copy)
 - list_checklist_tasks: List all existing tasks in the checklist
 
 Your task is to create MISSING files from the checklist. NEVER write files marked as "complete" in the checklist - only write files that are "pending" or "missing".

--- a/prompts/export_ansible_write_task.j2
+++ b/prompts/export_ansible_write_task.j2
@@ -86,14 +86,15 @@ Process every item that is NOT marked "complete". For EACH pending item, execute
    - For tasks using non-builtin modules: Call ansible_doc_lookup FIRST
    - Validate all parameter names match documentation
    - For parameters with `choices=[...]`, ensure defaults/vars use ONLY those exact values
-5. **Write file**: Call appropriate tool:
-   - `ansible_write`: For tasks, handlers, defaults, vars, meta (YAML files)
-   - `write_file`: For templates (.j2) and other non-YAML files
-   - `copy_file`: For static files from files/ directory
-6. **Handle errors**:
-   - **ERROR** (file not written): Fix YAML and retry
-   - **WARNING** (file written with issues): Try fixing up to 3 times, then mark complete and move on
-7. **Update checklist**: Call update_checklist_task with exact paths, status "complete", and notes
+5. **Write file and update checklist** (always do both together):
+   a. Call the appropriate write tool:
+      - `ansible_write`: For tasks, handlers, defaults, vars, meta (YAML files)
+      - `write_file`: For templates (.j2) and other non-YAML files
+      - `copy_file`: For static files from files/ directory
+   b. Handle errors:
+      - **ERROR** (file not written): Fix YAML and retry
+      - **WARNING** (file written with issues): Try fixing up to 3 times, then mark complete and move on
+   c. Call `update_checklist_task` with exact source_path and target_path from the checklist, status "complete", before moving to the next file
 
 **IMPORTANT**: Do NOT ask which item to process. Process ALL pending items automatically.
 


### PR DESCRIPTION
When the system creates more than 100 todo list, not always was updated the checklist, this fix PR add better guidelines on when the agent must write.