### PR TITLE
fixed instance of goal validator running without it's tools

### DIFF
--- a/src/middleware/goal_validation.py
+++ b/src/middleware/goal_validation.py
@@ -1,35 +1,38 @@
 """Goal validation middleware with retry logic."""
 
-from collections.abc import Callable
 from copy import deepcopy
-from typing import Any, ClassVar
+from typing import Any
 
 from langchain.agents.middleware.types import AgentMiddleware, hook_config
-from langchain_community.tools.file_management.file_search import FileSearchTool
-from langchain_community.tools.file_management.list_dir import ListDirectoryTool
-from langchain_community.tools.file_management.read import ReadFileTool
 from langchain_core.messages import HumanMessage
 from langchain_core.messages.utils import get_buffer_string
-from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from src.utils.logging import get_logger
 
-VALIDATION_PROMPT_TEMPLATE = """You are a read-only goal validation agent. Your ONLY job is to CHECK whether the following goal was achieved. You must NEVER create, write, or modify any files.
+EXPLORE_PROMPT_TEMPLATE = """You are a read-only verification agent. Use the available tools to check whether the following goal was achieved. Do NOT create, write, or modify any files.
 
 <goal>
-GOAL: {goal}
+{goal}
 </goal>
 
 CONVERSATION CONTEXT:
 <messages>
 {context}
 </messages>
-Use ONLY the read-only tools (read_file, list_directory, file_search) to inspect existing files and verify the goal was met. Do NOT attempt to fix, create, or write anything.
 
-Provide:
-- achieved: true if the goal is fully met, false otherwise
-- feedback: Specific details about what was verified or what is missing/incorrect
+Use the tools to inspect the relevant files and report exactly what you found.
+"""
+
+CLASSIFY_PROMPT_TEMPLATE = """Based on the following verification findings, determine whether the goal was achieved.
+
+<goal>
+{goal}
+</goal>
+
+<findings>
+{findings}
+</findings>
 """
 
 RETRY_MESSAGE_TEMPLATE = """The goal was not achieved. Please address the following issues:
@@ -58,17 +61,16 @@ class GoalValidationMiddleware(AgentMiddleware):
     CONTEXT_HEAD = 3
     CONTEXT_TAIL = 2
 
-    BASE_TOOLS: ClassVar[list[Callable[[], BaseTool]]] = [
-        lambda: FileSearchTool(),
-        lambda: ListDirectoryTool(),
-        lambda: ReadFileTool(),
-    ]
-
     def __init__(self, goal_description: str, agent: Any):
         self._log = get_logger(__name__)
         self.goal_description = goal_description
         self.agent = agent
         self.retry_count = 0
+        # Guards against re-entrant validation: invoke_react runs through the
+        # agent's cached middleware stack, which includes this same instance.
+        # Without this flag, after_agent would fire again after the explore
+        # phase completes, causing infinite recursion.
+        self._in_validation = False
 
     def _extract_context_messages(self, messages: list) -> list:
         max_passthrough = self.CONTEXT_HEAD + self.CONTEXT_TAIL
@@ -76,44 +78,59 @@ class GoalValidationMiddleware(AgentMiddleware):
             return messages
         return messages[: self.CONTEXT_HEAD] + messages[-self.CONTEXT_TAIL :]
 
-    def _build_validation_prompt(self, context_messages: list) -> str:
-        context_text = get_buffer_string(context_messages)
-        return VALIDATION_PROMPT_TEMPLATE.format(
-            goal=self.goal_description, context=context_text
-        )
-
     def _run_validation(self, state: dict) -> tuple[bool, str]:
         self._log.info("Running goal validation", retry_count=self.retry_count)
 
         messages = state.get("messages", [])
         context_messages = self._extract_context_messages(messages)
-        validation_prompt = self._build_validation_prompt(context_messages)
+        context_text = get_buffer_string(context_messages)
+
+        explore_prompt = EXPLORE_PROMPT_TEMPLATE.format(
+            goal=self.goal_description,
+            context=context_text,
+        )
 
         try:
-            validation_tools = [factory() for factory in self.BASE_TOOLS]
-            validation_result = self.agent.invoke_structured(
-                schema=GoalValidationResult,
-                messages=[{"role": "user", "content": validation_prompt}],
-                metrics=None,
-                tools=validation_tools,
+            self._in_validation = True
+            explore_result = self.agent.invoke_react(
+                state=state,
+                messages=[{"role": "user", "content": explore_prompt}],
             )
-            if not validation_result:
+
+            last_ai = self.agent.get_last_ai_message(explore_result)
+            findings = str(last_ai.content) if last_ai else "No findings available"
+
+            classify_prompt = CLASSIFY_PROMPT_TEMPLATE.format(
+                goal=self.goal_description,
+                findings=findings,
+            )
+            result = self.agent.invoke_structured(
+                schema=GoalValidationResult,
+                messages=[{"role": "user", "content": classify_prompt}],
+            )
+
+            if not result:
                 self._log.warning("No response from validation")
                 return False, "Validation did not respond"
 
             self._log.debug(
                 "Validation result",
-                achieved=validation_result.achieved,
-                feedback=validation_result.feedback,
+                achieved=result.achieved,
+                feedback=result.feedback,
             )
-            return validation_result.achieved, validation_result.feedback
+            return result.achieved, result.feedback
 
         except Exception as e:
             self._log.error("Validation failed", error=str(e))
             return False, f"Validation error: {e!s}"
+        finally:
+            self._in_validation = False
 
     @hook_config(can_jump_to=["model"])
     def after_agent(self, state, runtime):
+        if self._in_validation:
+            return state
+
         original_state = deepcopy(state)
 
         self._log.info(

--- a/src/middleware/goal_validation.py
+++ b/src/middleware/goal_validation.py
@@ -98,7 +98,7 @@ class GoalValidationMiddleware(AgentMiddleware):
             )
 
             last_ai = self.agent.get_last_ai_message(explore_result)
-            findings = str(last_ai.content) if last_ai else "No findings available"
+            findings = last_ai.text if last_ai else "No findings available"
 
             classify_prompt = CLASSIFY_PROMPT_TEMPLATE.format(
                 goal=self.goal_description,

--- a/tests/test_goal_validation.py
+++ b/tests/test_goal_validation.py
@@ -1,7 +1,6 @@
 """Tests for GoalValidationMiddleware."""
 
 from copy import deepcopy
-from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,21 +11,37 @@ from src.middleware.goal_validation import (
     GoalValidationResult,
 )
 
+EXPLORE_FINDINGS = "Verified: migration-plan.md exists and contains expected content."
+
 
 class FakeAgent:
-    BASE_TOOLS: ClassVar[list] = [lambda: MagicMock()]
-
-    def __init__(self, structured_result=None):
+    def __init__(self, structured_result=None, explore_content=EXPLORE_FINDINGS):
         self._structured_result = structured_result
+        self._explore_content = explore_content
 
-    def invoke_structured(self, **kwargs):
+    def invoke_react(self, state, messages, metrics=None):
+        return {"messages": [AIMessage(content=self._explore_content)]}
+
+    def invoke_structured(self, schema, messages, metrics=None, max_retries=3):
         return self._structured_result
+
+    @staticmethod
+    def get_last_ai_message(result):
+        messages = result.get("messages", [])
+        return next(
+            (msg for msg in reversed(messages) if isinstance(msg, AIMessage)),
+            None,
+        )
 
 
 @pytest.fixture
 def make_middleware():
-    def _factory(goal="Test goal", structured_result=None):
-        agent = FakeAgent(structured_result=structured_result)
+    def _factory(
+        goal="Test goal", structured_result=None, explore_content=EXPLORE_FINDINGS
+    ):
+        agent = FakeAgent(
+            structured_result=structured_result, explore_content=explore_content
+        )
         return GoalValidationMiddleware(goal, agent=agent)
 
     return _factory
@@ -69,27 +84,6 @@ class TestExtractContextMessages:
         assert mw._extract_context_messages([]) == []
 
 
-class TestBuildValidationPrompt:
-    def test_includes_goal_and_context(self, make_middleware):
-        mw = make_middleware(goal="Create output.txt")
-        messages = [HumanMessage(content="Hello"), AIMessage(content="Done")]
-
-        prompt = mw._build_validation_prompt(messages)
-
-        assert "Create output.txt" in prompt
-        assert "Human: Hello" in prompt
-        assert "AI: Done" in prompt
-
-    def test_formats_messages_correctly(self, make_middleware):
-        mw = make_middleware()
-        msg_with_content = HumanMessage(content="visible")
-
-        prompt = mw._build_validation_prompt([msg_with_content])
-
-        assert "visible" in prompt
-        assert "Human: visible" in prompt
-
-
 class TestRunValidation:
     def test_goal_achieved(self, make_middleware):
         mw = make_middleware(
@@ -97,9 +91,7 @@ class TestRunValidation:
                 achieved=True, feedback="File exists"
             )
         )
-        state = {"messages": [HumanMessage(content="create file")]}
-
-        achieved, feedback = mw._run_validation(state)
+        achieved, feedback = mw._run_validation({"messages": []})
 
         assert achieved is True
         assert feedback == "File exists"
@@ -110,36 +102,37 @@ class TestRunValidation:
                 achieved=False, feedback="File missing"
             )
         )
-        state = {"messages": [HumanMessage(content="create file")]}
-
-        achieved, feedback = mw._run_validation(state)
+        achieved, feedback = mw._run_validation({"messages": []})
 
         assert achieved is False
         assert feedback == "File missing"
 
     def test_none_result_returns_false(self, make_middleware):
         mw = make_middleware(structured_result=None)
-        state = {"messages": []}
-
-        achieved, feedback = mw._run_validation(state)
+        achieved, feedback = mw._run_validation({"messages": []})
 
         assert achieved is False
         assert "did not respond" in feedback
 
-    def test_exception_returns_false(self, make_middleware):
-        mw = make_middleware()
-        mw.agent.invoke_structured = MagicMock(
-            side_effect=RuntimeError("LLM unavailable")
-        )
-        state = {"messages": []}
-
-        achieved, feedback = mw._run_validation(state)
-
-        assert achieved is False
-        assert "LLM unavailable" in feedback
-
-    def test_passes_middleware_tools_not_agent_tools(self):
+    def test_explore_prompt_contains_goal(self):
         agent = MagicMock()
+        agent.invoke_react.return_value = {"messages": [AIMessage(content="findings")]}
+        agent.get_last_ai_message.return_value = AIMessage(content="findings")
+        agent.invoke_structured.return_value = GoalValidationResult(
+            achieved=True, feedback="ok"
+        )
+        mw = GoalValidationMiddleware("Create output.txt", agent=agent)
+
+        mw._run_validation({"messages": []})
+
+        explore_messages = agent.invoke_react.call_args[1]["messages"]
+        assert any("Create output.txt" in m["content"] for m in explore_messages)
+
+    def test_classify_prompt_contains_findings(self):
+        findings = "Found migration-plan.md with 3 modules listed."
+        agent = MagicMock()
+        agent.invoke_react.return_value = {"messages": [AIMessage(content=findings)]}
+        agent.get_last_ai_message.return_value = AIMessage(content=findings)
         agent.invoke_structured.return_value = GoalValidationResult(
             achieved=True, feedback="ok"
         )
@@ -147,12 +140,55 @@ class TestRunValidation:
 
         mw._run_validation({"messages": []})
 
-        call_kwargs = agent.invoke_structured.call_args[1]
-        tool_types = {type(t).__name__ for t in call_kwargs["tools"]}
-        assert "FileSearchTool" in tool_types
-        assert "ListDirectoryTool" in tool_types
-        assert "ReadFileTool" in tool_types
-        assert "WriteFileTool" not in tool_types
+        classify_messages = agent.invoke_structured.call_args[1]["messages"]
+        assert any(findings in m["content"] for m in classify_messages)
+
+    def test_invoke_react_called_before_invoke_structured(self):
+        call_order = []
+        agent = MagicMock()
+        agent.invoke_react.side_effect = lambda **kw: (
+            call_order.append("react"),
+            {"messages": [AIMessage(content="findings")]},
+        )[1]
+        agent.get_last_ai_message.return_value = AIMessage(content="findings")
+        agent.invoke_structured.side_effect = lambda **kw: (
+            call_order.append("structured"),
+            GoalValidationResult(achieved=True, feedback="ok"),
+        )[1]
+        mw = GoalValidationMiddleware("goal", agent=agent)
+
+        mw._run_validation({"messages": []})
+
+        assert call_order == ["react", "structured"]
+
+    def test_exception_in_explore_returns_false(self, make_middleware):
+        mw = make_middleware()
+        mw.agent.invoke_react = MagicMock(side_effect=RuntimeError("LLM unavailable"))
+        achieved, feedback = mw._run_validation({"messages": []})
+
+        assert achieved is False
+        assert "LLM unavailable" in feedback
+
+    def test_exception_in_classify_returns_false(self, make_middleware):
+        mw = make_middleware()
+        mw.agent.invoke_structured = MagicMock(side_effect=RuntimeError("timeout"))
+        achieved, feedback = mw._run_validation({"messages": []})
+
+        assert achieved is False
+        assert "timeout" in feedback
+
+    def test_in_validation_flag_cleared_after_success(self, make_middleware):
+        mw = make_middleware(
+            structured_result=GoalValidationResult(achieved=True, feedback="ok")
+        )
+        mw._run_validation({"messages": []})
+        assert mw._in_validation is False
+
+    def test_in_validation_flag_cleared_after_exception(self, make_middleware):
+        mw = make_middleware()
+        mw.agent.invoke_react = MagicMock(side_effect=RuntimeError("fail"))
+        mw._run_validation({"messages": []})
+        assert mw._in_validation is False
 
 
 class TestAfterAgent:
@@ -240,3 +276,12 @@ class TestAfterAgent:
         assert result["messages"][0].content == "original"
         assert len(result["messages"]) == 2
         assert len(state["messages"]) == 1
+
+    def test_skips_validation_when_in_validation(self, make_middleware):
+        mw = make_middleware()
+        mw._in_validation = True
+        state = {"messages": [HumanMessage(content="msg")]}
+
+        result = mw.after_agent(state, runtime=None)
+
+        assert result is state


### PR DESCRIPTION
  GoalValidationMiddleware._run_validation passed file tools (read_file, list_directory, file_search) to invoke_structured, but invoke_structured dropped them via **kwargs - only the GoalValidationResult schema was ever bound. The validation prompt still told the model to use those tools.

the goal was validated because of the message context and not because of tool calls.

  Fix: Replaced the single invoke_structured call with a two-phase approach:
  1. Explore (invoke_react): the agent uses its own file tools to actively inspect the filesystem and report findings
  2. Classify (invoke_structured): receives the plain findings text and produces a GoalValidationResult