### PR TITLE
fix: wrap string prompts in message dicts for invoke_structured

### DIFF
--- a/src/exporters/aap_discovery_agent.py
+++ b/src/exporters/aap_discovery_agent.py
@@ -188,8 +188,9 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
         )
 
         try:
+            messages = [{"role": "user", "content": extraction_prompt}]
             extraction_result = self.invoke_structured(
-                CollectionExtractionOutput, extraction_prompt
+                CollectionExtractionOutput, messages
             )
             if isinstance(extraction_result, CollectionExtractionOutput):
                 return extraction_result.collections

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -76,7 +76,8 @@ class CredentialAgent(ExportAgent[ExportState]):
     def _extract_credentials(self, prompt: str, metrics: AgentMetrics | None) -> list:
         """Extract credentials using LLM structured output."""
         try:
-            result = self.invoke_structured(CredentialExtractionOutput, prompt, metrics)
+            messages = [{"role": "user", "content": prompt}]
+            result = self.invoke_structured(CredentialExtractionOutput, messages, metrics)
             if isinstance(result, CredentialExtractionOutput):
                 return result.credentials
             return []

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -77,7 +77,9 @@ class CredentialAgent(ExportAgent[ExportState]):
         """Extract credentials using LLM structured output."""
         try:
             messages = [{"role": "user", "content": prompt}]
-            result = self.invoke_structured(CredentialExtractionOutput, messages, metrics)
+            result = self.invoke_structured(
+                CredentialExtractionOutput, messages, metrics
+            )
             if isinstance(result, CredentialExtractionOutput):
                 return result.credentials
             return []


### PR DESCRIPTION
credential_agent and aap_discovery_agent passed plain strings to invoke_structured, where *messages unpacked them into individual characters instead of message dicts