### PR TITLE
write adversarial telemetry and summary to caller's workdir

### DIFF
--- a/app.py
+++ b/app.py
@@ -326,8 +326,6 @@ def report(
     "--source-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
     default=".",
-    callback=change_dir_callback,
-    is_eager=True,
     help="Source directory containing migration artifacts to review",
 )
 @click.option(

--- a/src/adversarial/__init__.py
+++ b/src/adversarial/__init__.py
@@ -1,6 +1,7 @@
 """Adversarial agents package for validating migration artifacts."""
 
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -34,6 +35,12 @@ def run_adversarial(
     """
     _log.info(f"Starting adversarial run for phase '{phase}'")
 
+    # Capture the caller's working directory before changing into source_dir so
+    # telemetry and the JSON summary are written there, not inside source_dir.
+    work_dir = Path.cwd()
+
+    os.chdir(source_dir)
+
     telemetry = Telemetry(phase=f"adversarial-{phase}")
     state = BaseState(user_message="", path=source_dir)
     manager = AdversarialAgentManager(phase=phase, config_path=config_path)
@@ -42,6 +49,7 @@ def run_adversarial(
         state=state, telemetry=telemetry, report_path=report_path
     )
 
+    os.chdir(work_dir)
     telemetry.stop().save()
     _log.info(f"Telemetry summary:\n{telemetry.to_summary()}")
 

--- a/src/report/report.py
+++ b/src/report/report.py
@@ -24,6 +24,7 @@ class ArtifactType(StrEnum):
     MIGRATED_SOURCES = "migrated_sources"
     PROJECT_METADATA = "project_metadata"
     ANSIBLE_PROJECT = "ansible_project"
+    ADVERSARIAL_REPORT = "adversarial_report"
 
 
 class ReportClient:

--- a/tests/report/test_report.py
+++ b/tests/report/test_report.py
@@ -28,9 +28,10 @@ class TestArtifactType:
         assert ArtifactType.MIGRATED_SOURCES.value == "migrated_sources"
         assert ArtifactType.PROJECT_METADATA.value == "project_metadata"
         assert ArtifactType.ANSIBLE_PROJECT.value == "ansible_project"
+        assert ArtifactType.ADVERSARIAL_REPORT.value == "adversarial_report"
 
     def test_enum_count(self):
-        assert len(ArtifactType) == 5
+        assert len(ArtifactType) == 6
 
 
 class TestReportClientParseArtifact:


### PR DESCRIPTION
The adversarial agents need to run from inside source_dir to see the migration files, but the output files (telemetry, JSON summary) should land in the job's work directory, not inside the repo being  reviewed