### PR TITLE
scope credential extraction to module migration plan only

### DIFF
--- a/prompts/export_credential_extraction_system.md
+++ b/prompts/export_credential_extraction_system.md
@@ -42,6 +42,16 @@ Rules:
 
 ---
 
+## High-Level Migration Plan
+
+Read this for naming conventions, prefixes, and credential handling instructions
+that apply across the project.
+
+{high_level_migration_plan}
+
 ## Module Migration Plan
+
+Extract all credentials from this section. This is the plan for the specific module
+being migrated.
 
 {migration_plan}

--- a/prompts/export_credential_extraction_system.md
+++ b/prompts/export_credential_extraction_system.md
@@ -42,10 +42,6 @@ Rules:
 
 ---
 
-## High-Level Migration Plan
-
-{high_level_migration_plan}
-
 ## Module Migration Plan
 
 {migration_plan}

--- a/prompts/export_credential_extraction_system.md
+++ b/prompts/export_credential_extraction_system.md
@@ -44,14 +44,12 @@ Rules:
 
 ## High-Level Migration Plan
 
-Read this for naming conventions, prefixes, and credential handling instructions
-that apply across the project.
+Read this for naming conventions, prefixes, and credential handling instructions that apply across the project.
 
 {high_level_migration_plan}
 
 ## Module Migration Plan
 
-Extract all credentials from this section. This is the plan for the specific module
-being migrated.
+Extract all credentials from this section. This is the plan for the specific module being migrated.
 
 {migration_plan}

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -69,6 +69,7 @@ class CredentialAgent(ExportAgent[ExportState]):
     def _build_extraction_prompt(self, state: ExportState) -> str:
         """Build the prompt for credential extraction from migration plan."""
         return get_prompt(self.EXTRACTION_PROMPT_NAME).format(
+            high_level_migration_plan=state.high_level_migration_plan.to_document(),
             migration_plan=state.module_migration_plan.to_document(),
         )
 

--- a/src/exporters/credential_agent.py
+++ b/src/exporters/credential_agent.py
@@ -69,7 +69,6 @@ class CredentialAgent(ExportAgent[ExportState]):
     def _build_extraction_prompt(self, state: ExportState) -> str:
         """Build the prompt for credential extraction from migration plan."""
         return get_prompt(self.EXTRACTION_PROMPT_NAME).format(
-            high_level_migration_plan=state.high_level_migration_plan.to_document(),
             migration_plan=state.module_migration_plan.to_document(),
         )
 


### PR DESCRIPTION
The CredentialAgent was including the high-level plan in its extraction prompt alongside the module-specific plan. Since the high-level plan documents credentials from every  module in the repo, the LLM was extracting credentials for all of them and writing them into the output for the module being migrated.