### PR TITLE
fix: use AIMessage.text instead of .content when reading LLM output

### DIFF
--- a/src/exporters/validation_agent.py
+++ b/src/exporters/validation_agent.py
@@ -297,7 +297,7 @@ class ValidationAgent(ExportAgent[ExportState]):
 
         message = self.get_last_ai_message(result)
         if message:
-            export_state = export_state.update(validation_report=message.content)
+            export_state = export_state.update(validation_report=message.text)
 
         state.export_state = export_state
         state.last_result = result

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -266,7 +266,7 @@ class WriteAgent(ExportAgent[ExportState]):
         slog.info(f"Checklist after writing:\n{export_state.checklist.to_markdown()}")
         message = self.get_last_ai_message(result)
         if message:
-            export_state = export_state.update(last_output=message.content)
+            export_state = export_state.update(last_output=message.text)
             slog.info("Write iteration completed")
         else:
             slog.warning("Write agent did not produce output")

--- a/src/inputs/ansible/report_writer_agent.py
+++ b/src/inputs/ansible/report_writer_agent.py
@@ -52,7 +52,7 @@ class ReportWriterAgent(InputAgent[AnsibleAnalysisState]):
             return state.mark_failed("Invalid response from Ansible agent")
 
         self._log.info("Migration specification generated")
-        return state.update(specification=response_messages[-1].content)
+        return state.update(specification=response_messages[-1].text)
 
     def _build_file_listing(self, state: AnsibleAnalysisState) -> str:
         """Build file listing from structured analysis."""

--- a/src/inputs/chef/report_writer_agent.py
+++ b/src/inputs/chef/report_writer_agent.py
@@ -61,7 +61,7 @@ class ReportWriterAgent(InputAgent[ChefState]):
             return state.mark_failed("Invalid response from Chef agent")
 
         self._log.info("Migration specification generated")
-        return state.update(specification=response_messages[-1].content)
+        return state.update(specification=response_messages[-1].text)
 
     def _build_file_listing(self, state: ChefState) -> str:
         """Build file listing from structured analysis."""

--- a/src/inputs/powershell/report_writer_agent.py
+++ b/src/inputs/powershell/report_writer_agent.py
@@ -52,7 +52,7 @@ class ReportWriterAgent(InputAgent[PowerShellAnalysisState]):
             return state.mark_failed("Invalid response from PowerShell agent")
 
         self._log.info("Migration specification generated")
-        return state.update(specification=response_messages[-1].content)
+        return state.update(specification=response_messages[-1].text)
 
     def _build_file_listing(self, state: PowerShellAnalysisState) -> str:
         """Build file listing from structured analysis."""

--- a/src/inputs/puppet/report_writer_agent.py
+++ b/src/inputs/puppet/report_writer_agent.py
@@ -66,7 +66,7 @@ class ReportWriterAgent(InputAgent[PuppetState]):
             return state.mark_failed("Invalid response from Puppet agent")
 
         self._log.info("Migration specification generated")
-        return state.update(specification=response_messages[-1].content)
+        return state.update(specification=response_messages[-1].text)
 
     def _build_file_listing(self, state: PuppetState) -> str:
         """Build file listing from execution tree files only."""


### PR DESCRIPTION
message.content is provider-shaped and unreliable across models: it's usually a plain string, but for reasoning models (gpt-oss via LiteLLM, DeepSeek, etc.) it can hold structured content blocks or omit the final answer text depending on where the provider puts reasoning output.

.text is the normalized, provider-agnostic accessor that always extracts the final text blocks and excludes reasoning/tool-call content, so downstream consumers (validation reports, write output, migration specifications) get consistent results regardless of the configured model.