### PR TITLE
feat: add ansible argument specs in the role

### DIFF
--- a/prompts/export_ansible_planning_system.md
+++ b/prompts/export_ansible_planning_system.md
@@ -21,9 +21,14 @@ Your task is to ensure the checklist is complete:
 Checklist categories:
 
 Structure Files:
-- List required Ansible role structure files (meta/main.yml, handlers/main.yml, etc.)
+- List required Ansible role structure files (meta/main.yml, handlers/main.yml, meta/argument_specs.yml, etc.)
 - For meta/main.yml, use metadata.rb as source if it exists, otherwise use N/A
 - Format: metadata.rb → meta/main.yml  OR  N/A → meta/main.yml
+- Every role MUST have a checklist item for meta/argument_specs.yml:
+  - Category: STRUCTURE
+  - Source: defaults/main.yml (or N/A if no defaults)
+  - Target: <role_path>/meta/argument_specs.yml
+  - This item depends on defaults/main.yml being written first
 
 Templates:
 - List all Chef ERB templates (.erb files) that need conversion to Jinja2 (.j2 files)

--- a/prompts/export_ansible_planning_task.j2
+++ b/prompts/export_ansible_planning_task.j2
@@ -75,6 +75,7 @@ Sample calls (replace {{module}} with actual module name from ANSIBLE OUTPUT PAT
 - add_checklist_task(category="templates", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/templates/config.j2", description="Configuration template")
 - add_checklist_task(category="recipes", source_path="<full_path_from_file_structure>", target_path="ansible/roles/{{module}}/tasks/main.yml", description="Main recipe tasks")
 - add_checklist_task(category="structure", source_path="N/A", target_path="ansible/roles/{{module}}/meta/main.yml", description="Role metadata")
+- add_checklist_task(category="structure", source_path="N/A", target_path="ansible/roles/{{module}}/meta/argument_specs.yml", description="Role argument specs for fail-fast parameter validation (generate after defaults/main.yml)")
 - add_checklist_task(category="dependencies", source_path="collection:namespace.collection_name", target_path="ansible/roles/{{module}}/requirements.yml", description="External collection dependency")
 
 Your goal: Ensure the checklist contains EVERY file mentioned in the migration plan.

--- a/prompts/export_ansible_review_system.md
+++ b/prompts/export_ansible_review_system.md
@@ -63,7 +63,18 @@ Common patterns:
 
 Fix: Move `variables:` content to task-level `vars:`.
 
-### 6. Molecule Test Correctness
+### 6. Missing Argument Specs
+
+Roles that have defaults/main.yml but no meta/argument_specs.yml.
+
+Common patterns:
+- defaults/main.yml exists with role variables but meta/argument_specs.yml is missing
+- meta/argument_specs.yml exists but does not cover all variables from defaults/main.yml
+- argument_specs.yml has incorrect types that do not match the default values
+
+Fix: Generate argument_specs.yml from defaults/main.yml with correct types and descriptions. Use `ansible_write` to write the file to `<role_path>/meta/argument_specs.yml`.
+
+### 7. Molecule Test Correctness
 
 Molecule test files (converge.yml, verify.yml) that violate the execution environment constraints or will fail at runtime.
 

--- a/prompts/export_ansible_write_system.j2
+++ b/prompts/export_ansible_write_system.j2
@@ -353,6 +353,91 @@ IMPORTANT: Use Ubuntu release names (bionic, focal) NOT version numbers ("18.04"
 {% include 'write_from_puppet.md' %}
 {% endif %}
 
+ARGUMENT SPECS:
+Every role MUST include a meta/argument_specs.yml file that documents all role parameters.
+Generate this file AFTER writing defaults/main.yml, using the variables defined there.
+
+Write this file using ansible_write to: <role_path>/meta/argument_specs.yml
+
+Format:
+```yaml
+---
+argument_specs:
+  main:
+    short_description: <one-line description from meta/main.yml>
+    description:
+      - <longer description of what the role does>
+    options:
+      <variable_name>:
+        type: <str|bool|int|float|dict|list>
+        required: <true if no default, false if default exists>
+        default: <value from defaults/main.yml>
+        description: <what this variable controls>
+```
+
+Type mapping from defaults/main.yml values:
+  - quoted string or bare word        -> type: str
+  - true / false                      -> type: bool
+  - integer                           -> type: int
+  - float                             -> type: float
+  - YAML dict / mapping               -> type: dict
+  - YAML list / sequence              -> type: list
+
+For dict options with known structure, add `options:` to describe the nested keys.
+For list options with dict elements, add `elements: dict` and nested `options:`.
+
+Edge cases:
+- No defaults/main.yml: Generate an argument_specs with just `short_description` and no `options:`
+- Credential variables (injected by AAP at runtime, not in defaults): Include with `required: true` and no default, with a description noting they are injected by AAP credential types
+- Variables from vars/main.yml: These are role-internal and should NOT appear in argument_specs (they are not user-facing parameters)
+
+Example: given defaults/main.yml containing:
+```yaml
+myrole_app_port: 8080
+myrole_enable_tls: true
+myrole_allowed_hosts:
+  - localhost
+myrole_config:
+  max_connections: 100
+  timeout: 30
+```
+
+Generate meta/argument_specs.yml as:
+```yaml
+---
+argument_specs:
+  main:
+    short_description: Install and configure the application service
+    description:
+      - Deploys the application with configurable networking and TLS settings.
+    options:
+      myrole_app_port:
+        type: int
+        required: false
+        default: 8080
+        description: TCP port the application listens on.
+      myrole_enable_tls:
+        type: bool
+        required: false
+        default: true
+        description: Whether to enable TLS for the application.
+      myrole_allowed_hosts:
+        type: list
+        elements: str
+        required: false
+        default:
+          - localhost
+        description: List of hostnames allowed to connect.
+      myrole_config:
+        type: dict
+        required: false
+        default:
+          max_connections: 100
+          timeout: 30
+        description: >-
+          Application configuration parameters.
+```
+
 Do NOT generate molecule files (molecule/default/*) — they are handled by a separate MoleculeAgent.
 Skip any checklist items in the MOLECULE category.
 


### PR DESCRIPTION
This commits add a way to ansible to write all the variables inside the arguments specs as defined here:

https://docs.ansible.com/projects/ansible/latest/playbook_guide/playbooks_reuse_roles.html#role-argument-validation

FIX: FLPATH-4648

Generated data:

```
../chef-examples/ansible/roles/nginx_multisite/meta/argument_specs.yml
---
---
argument_specs:
  main:
    short_description: Configure Nginx as a multi-site web server with SSL and security hardening
    description:
      - Installs and configures Nginx with multiple SSL-enabled virtual hosts.
      - Configures fail2ban, UFW firewall, sysctl security settings, and SSH hardening.
      - Generates self-signed SSL certificates for each configured site.
    options:
      nginx_multisite_sites:
        type: dict
        required: false
        default:
          test.cluster.local:
            document_root: /opt/server/test
            ssl_enabled: true
          ci.cluster.local:
            document_root: /opt/server/ci
            ssl_enabled: true
          status.cluster.local:
            document_root: /opt/server/status
            ssl_enabled: true
        description: Dictionary of virtual host sites to configure. Each key is the server name (e.g. test.cluster.local) and the value is a dict with
          document_root (str) and ssl_enabled (bool).
      nginx_multisite_ssl_certificate_path:
        type: str
        required: false
        default: /etc/ssl/certs
        description: Directory path where SSL certificates (.crt files) are stored.
      nginx_multisite_ssl_private_key_path:
        type: str
        required: false
        default: /etc/ssl/private
        description: Directory path where SSL private keys (.key files) are stored.
      nginx_multisite_security_fail2ban_enabled:
        type: bool
        required: false
        default: true
        description: Whether to enable and configure fail2ban intrusion prevention.
      nginx_multisite_security_ufw_enabled:
        type: bool
        required: false
        default: true
        description: Whether to enable and configure UFW firewall rules.
      nginx_multisite_security_ssh_disable_root:
        type: bool
        required: false
        default: true
        description: Whether to disable SSH root login in sshd_config.
      nginx_multisite_security_ssh_password_auth:
        type: bool
        required: false
        default: false
        description: Whether to allow SSH password authentication. Set to false to disable password authentication and require key-based authentication.

---
../chef-examples/ansible/roles/nginx_multisite/meta/main.yml
---
---
galaxy_info:
  author: Migration Tool
  description: Migrated to modern Ansible
  galaxy_tags: []
  license: Apache-2.0
  min_ansible_version: "2.10"
  namespace: x2a
  platforms:
    - name: Ubuntu
      versions:
        - bionic
        - focal
    - name: EL
      versions:
        - "7"
        - "8"
        - "9"
        - "10"
  role_name: nginx_multisite

---
```