### PR TITLE
fix: export agent issues on get_tools

### DIFF
--- a/src/exporters/aap_discovery_agent.py
+++ b/src/exporters/aap_discovery_agent.py
@@ -104,11 +104,6 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
         super().__init__(model)
         self._settings = get_settings().aap
 
-    def extra_tools_from_state(self, state: ExportState) -> list[BaseTool]:
-        if state.checklist is None:
-            return []
-        return state.checklist.get_tools()
-
     def execute(self, state: ExportState, metrics: AgentMetrics | None) -> ExportState:
         """Execute AAP discovery and update state with results."""
         if not self._settings.is_galaxy_enabled():

--- a/src/exporters/export_agent.py
+++ b/src/exporters/export_agent.py
@@ -6,8 +6,11 @@ inherit it instead of repeating the constant.
 
 from typing import ClassVar
 
+from langchain_core.tools import BaseTool
+
 from src.base_agent import BaseAgent
 from src.const import EXPORT_AGENTS_FILE
+from src.exporters.state import ExportState
 from src.types.base_state import BaseState
 
 
@@ -16,6 +19,27 @@ class ExportAgent[S: BaseState](BaseAgent[S]):
 
     Sets RULES_FILE to EXPORT_AGENTS_FILE so every subclass
     automatically receives export-agent rules via RulesMiddleware.
+
+    Provides a default ``extra_tools_from_state`` that extracts
+    checklist tools from an ``ExportState``.  When GoalValidationMiddleware
+    calls back through invoke_react, state is a plain dict (LangGraph's
+    internal AgentState) that cannot be converted to ExportState, so
+    state-derived tools are skipped.
     """
 
     RULES_FILE: ClassVar[str] = EXPORT_AGENTS_FILE
+
+    def extra_tools_from_state(self, state: S) -> list[BaseTool]:
+        """Return checklist tools from the ExportState.
+
+        GoalValidationMiddleware operates inside LangGraph's inner agent
+        graph whose state is a plain dict with only ``messages``.
+        The dict cannot be converted to an ExportState (required fields
+        like module, path, checklist are absent), so we return an empty
+        list in that case.
+        """
+        if not isinstance(state, ExportState):
+            return []
+        if state.checklist is None:
+            return []
+        return state.checklist.get_tools()

--- a/src/exporters/molecule_agent.py
+++ b/src/exporters/molecule_agent.py
@@ -63,11 +63,6 @@ class MoleculeAgent(ExportAgent[ExportState]):
         self._graph = self._build_internal_graph()
         self._current_metrics: AgentMetrics | None = None
 
-    def extra_tools_from_state(self, state: ExportState) -> list[BaseTool]:
-        if state.checklist is None:
-            return []
-        return state.checklist.get_tools()
-
     def _build_internal_graph(self):
         """Build the internal StateGraph for molecule test generation."""
         workflow = StateGraph(MoleculeAgentState)

--- a/src/exporters/planning_agent.py
+++ b/src/exporters/planning_agent.py
@@ -38,11 +38,6 @@ class PlanningAgent(ExportAgent[ExportState]):
     SYSTEM_PROMPT_NAME = "export_ansible_planning_system"
     USER_PROMPT_NAME = "export_ansible_planning_task"
 
-    def extra_tools_from_state(self, state: ExportState) -> list[BaseTool]:
-        if state.checklist is None:
-            return []
-        return state.checklist.get_tools()
-
     def execute(self, state: ExportState, metrics: AgentMetrics | None) -> ExportState:
         """Execute planning phase."""
         self._log.info(

--- a/src/exporters/validation_agent.py
+++ b/src/exporters/validation_agent.py
@@ -121,11 +121,6 @@ class ValidationAgent(ExportAgent[ExportState]):
         self._graph = self._build_internal_graph()
         self._current_metrics: AgentMetrics | None = None
 
-    def extra_tools_from_state(self, state: ExportState) -> list[BaseTool]:
-        if state.checklist is None:
-            return []
-        return state.checklist.get_tools()
-
     def _build_internal_graph(self):
         """Build the internal StateGraph for validation workflow."""
         workflow = StateGraph(ValidationAgentState)

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -88,11 +88,6 @@ class WriteAgent(ExportAgent[ExportState]):
         self._graph = self._build_internal_graph()
         self._current_metrics: AgentMetrics | None = None
 
-    def extra_tools_from_state(self, state: ExportState) -> list[BaseTool]:
-        if state.checklist is None:
-            return []
-        return state.checklist.get_tools()
-
     def _build_internal_graph(self):
         """Build the internal StateGraph for write workflow."""
         workflow = StateGraph(WriteAgentState)


### PR DESCRIPTION
It was an error on the goal_validation middleware, and this one it's to return the state from messages, not the ExportState.

Issue:

```
ERROR:x2convertor.src.middleware.goal_validation: Validation failed [error='dict' object has no attribute 'checklist']
WARNING:x2convertor.src.middleware.goal_validation: Goal not achieved [retry_count=0 feedback=Validation error: 'dict' object has no attribute 'checklist']

```

Fix FLPATH-4800