### PR TITLE
feat: add SUMMARY_CONTEXT_SIZE env variable

### DIFF
--- a/scripts/generate_env_docs.py
+++ b/scripts/generate_env_docs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Generate environment variable documentation from pydantic-settings."""
 
+import enum
 import inspect
 import sys
 from pathlib import Path
@@ -80,6 +81,11 @@ def get_type_string(annotation: Any) -> str:
         args = get_args(annotation)
         return f"enum: {', '.join(repr(a) for a in args)}"
 
+    # Handle Enum types
+    if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+        values = [member.value for member in annotation]
+        return f"enum: {', '.join(repr(v) for v in values)}"
+
     # Fallback
     return (
         str(annotation).replace("typing.", "").replace("<class '", "").replace("'>", "")
@@ -121,6 +127,8 @@ def get_default_string(default: Any, type_str: str) -> str:
         return f"`{default}`"
     if isinstance(default, (int, float)):
         return f"`{default}`"
+    if isinstance(default, enum.Enum):
+        return f"`{default.value}`"
     return f"`{default}`"
 
 

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -29,7 +29,12 @@ from src.middleware.agent_dump import (
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
 from src.middleware.x2a_summarize import X2ASummarizationMiddleware
-from src.model import get_model, get_runnable_config, report_tool_calls
+from src.model import (
+    get_context_window,
+    get_model,
+    get_runnable_config,
+    report_tool_calls,
+)
 from src.types.base_state import BaseState
 from src.types.telemetry import AgentMetrics, telemetry_context
 from src.utils.logging import get_logger
@@ -140,10 +145,11 @@ Retry your response now, ensuring it matches the schema structure exactly."""
             stack.append(GoalValidationMiddleware(self.GOAL, agent=self))
         if self.RULES_FILE:
             stack.append(RulesMiddleware(self.RULES_FILE))
+        effective_max_tokens = self._effective_summary_threshold()
         stack.append(
             X2ASummarizationMiddleware(
                 model=self.model,
-                max_tokens=self.MAX_TOKENS_BEFORE_SUMMARY,
+                max_tokens=effective_max_tokens,
                 messages_to_keep=self.MESSAGES_TO_KEEP,
             ),
         )
@@ -154,6 +160,35 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         # Cache for reuse
         self._middleware_cache = stack
         return stack
+
+    def _effective_summary_threshold(self) -> int:
+        """Compute the effective max_tokens for summarization.
+
+        Applies the summary_context_size multiplier to the agent's
+        MAX_TOKENS_BEFORE_SUMMARY and caps it at the model's context window.
+        """
+        settings = get_settings()
+        multiplier = settings.llm.summary_context_size.multiplier
+        scaled = int(self.MAX_TOKENS_BEFORE_SUMMARY * multiplier)
+
+        context_window = get_context_window()
+        if scaled > context_window:
+            self._log.warning(
+                "Summary threshold exceeds context window, capping",
+                requested=scaled,
+                context_window=context_window,
+                agent=self.agent_name,
+            )
+            return context_window
+
+        if multiplier != 1.0:
+            self._log.info(
+                "Summary threshold scaled",
+                base=self.MAX_TOKENS_BEFORE_SUMMARY,
+                multiplier=multiplier,
+                effective=scaled,
+            )
+        return scaled
 
     def __call__(self, state: S) -> S:
         """Entry point. Wraps execute() with automatic telemetry + logging."""

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -25,6 +25,7 @@ from src.config.settings import (
     MoleculeSettings,
     ProcessingSettings,
     Settings,
+    SummaryContextSize,
     get_settings,
     reset_settings,
 )
@@ -36,6 +37,7 @@ __all__ = [
     "MoleculeSettings",
     "ProcessingSettings",
     "Settings",
+    "SummaryContextSize",
     "get_settings",
     "reset_settings",
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -4,11 +4,42 @@ This module provides type-safe configuration with environment variable loading,
 validation, and sensible defaults for all x2a-convertor settings.
 """
 
+from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class SummaryContextSize(StrEnum):
+    """Controls how aggressively conversation history is summarized.
+
+    Each level applies a multiplier to the agent's MAX_TOKENS_BEFORE_SUMMARY
+    threshold. Higher values preserve more conversation context before
+    triggering summarization, at the cost of using more of the model's
+    context window.
+
+    The effective threshold is capped at the model's context window size.
+    """
+
+    COMPACT = "compact"  # 1x   -- current default behavior
+    MEDIUM = "medium"  # 1.5x
+    LARGE = "large"  # 2x
+    FULL = "full"  # 3x
+
+    @property
+    def multiplier(self) -> float:
+        """Return the token multiplier for this context size."""
+        return _MULTIPLIERS[self]
+
+
+_MULTIPLIERS: dict[SummaryContextSize, float] = {
+    SummaryContextSize.COMPACT: 1.0,
+    SummaryContextSize.MEDIUM: 1.5,
+    SummaryContextSize.LARGE: 2.0,
+    SummaryContextSize.FULL: 3.0,
+}
 
 
 class LLMSettings(BaseSettings):
@@ -68,6 +99,19 @@ class LLMSettings(BaseSettings):
         validation_alias="LLM_CONNECT_TIMEOUT",
         description="Connection timeout in seconds for LLM API calls",
     )
+    summary_context_size: SummaryContextSize = Field(
+        default=SummaryContextSize.COMPACT,
+        validation_alias="SUMMARY_CONTEXT_SIZE",
+        description="Controls conversation summarization aggressiveness. "
+        "Higher values keep more context before summarizing (compact=1x, medium=1.5x, large=2x, full=3x).",
+    )
+
+    @field_validator("summary_context_size", mode="before")
+    @classmethod
+    def lowercase_summary_context_size(cls, v: str) -> str:
+        if isinstance(v, str):
+            return v.lower()
+        return v
 
 
 class AAPSettings(BaseSettings):

--- a/src/model.py
+++ b/src/model.py
@@ -15,6 +15,8 @@ from src.config import get_settings
 from src.config.settings import LLMSettings
 from src.utils.logging import get_logger
 
+DEFAULT_CONTEXT_WINDOW = 128_000
+
 logger = get_logger(__name__)
 
 
@@ -190,3 +192,24 @@ def get_model() -> BaseChatModel:
     logger.info("LLM initialized", **log_kwargs)
 
     return chat_model
+
+
+def get_context_window() -> int:
+    """Return the model's max input token capacity.
+
+    Uses litellm.get_model_info() to auto-detect the context window.
+    Falls back to DEFAULT_CONTEXT_WINDOW (128k) for unknown models.
+    """
+    model = get_settings().llm.model
+    try:
+        info = litellm.get_model_info(model)
+        value = info.get("max_input_tokens")
+        if value and isinstance(value, int):
+            return value
+    except Exception:
+        logger.warning(
+            "Could not detect context window from litellm, using default",
+            model=model,
+            default=DEFAULT_CONTEXT_WINDOW,
+        )
+    return DEFAULT_CONTEXT_WINDOW

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -1,5 +1,7 @@
 """Tests for centralized configuration settings."""
 
+import pytest
+
 from src.config import (
     AAPSettings,
     LLMSettings,
@@ -7,6 +9,7 @@ from src.config import (
     MoleculeSettings,
     ProcessingSettings,
     Settings,
+    SummaryContextSize,
     get_settings,
     reset_settings,
 )
@@ -23,6 +26,10 @@ class TestLLMSettings:
         assert settings.reasoning_effort is None
         assert settings.rate_limit_requests is None
 
+    def test_default_summary_context_size(self):
+        settings = LLMSettings()
+        assert settings.summary_context_size == SummaryContextSize.COMPACT
+
     def test_env_override(self, monkeypatch):
         monkeypatch.setenv("LLM_MODEL", "gpt-4")
         monkeypatch.setenv("MAX_TOKENS", "16384")
@@ -32,6 +39,42 @@ class TestLLMSettings:
         assert settings.model == "gpt-4"
         assert settings.max_tokens == 16384
         assert settings.temperature == 0.7
+
+    @pytest.mark.parametrize(
+        "env_value,expected",
+        [
+            ("compact", SummaryContextSize.COMPACT),
+            ("medium", SummaryContextSize.MEDIUM),
+            ("large", SummaryContextSize.LARGE),
+            ("full", SummaryContextSize.FULL),
+            ("COMPACT", SummaryContextSize.COMPACT),
+            ("LARGE", SummaryContextSize.LARGE),
+        ],
+    )
+    def test_summary_context_size_env_override(self, monkeypatch, env_value, expected):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", env_value)
+        settings = LLMSettings()
+        assert settings.summary_context_size == expected
+
+
+class TestSummaryContextSize:
+    """Tests for SummaryContextSize enum."""
+
+    def test_multiplier_values(self):
+        assert SummaryContextSize.COMPACT.multiplier == 1.0
+        assert SummaryContextSize.MEDIUM.multiplier == 1.5
+        assert SummaryContextSize.LARGE.multiplier == 2.0
+        assert SummaryContextSize.FULL.multiplier == 3.0
+
+    def test_string_values(self):
+        assert SummaryContextSize.COMPACT.value == "compact"
+        assert SummaryContextSize.MEDIUM.value == "medium"
+        assert SummaryContextSize.LARGE.value == "large"
+        assert SummaryContextSize.FULL.value == "full"
+
+    def test_invalid_value_raises(self):
+        with pytest.raises(ValueError):
+            SummaryContextSize("tiny")
 
 
 class TestAAPSettings:

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -1,12 +1,14 @@
 """Tests for BaseAgent functionality."""
 
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.messages.ai import UsageMetadata
 
 from src.base_agent import BaseAgent
+from src.config import reset_settings
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
 from src.middleware.x2a_summarize import X2ASummarizationMiddleware
@@ -981,3 +983,78 @@ class TestBaseAgentMiddleware:
     def test_goal_classvar_set_on_subclass(self):
         agent = GoalAgent()
         assert agent.GOAL == "Verify output file exists"
+
+
+class HighThresholdAgent(BaseAgent[BaseState]):
+    """Agent with a high MAX_TOKENS_BEFORE_SUMMARY for testing scaling."""
+
+    MAX_TOKENS_BEFORE_SUMMARY = 50_000
+
+    def execute(self, state, metrics):
+        return state
+
+
+class TestEffectiveSummaryThreshold:
+    """Tests for BaseAgent._effective_summary_threshold()."""
+
+    def setup_method(self):
+        reset_settings()
+
+    def teardown_method(self):
+        reset_settings()
+
+    @patch("src.base_agent.get_context_window", return_value=200_000)
+    def test_compact_returns_base_value(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "compact")
+        reset_settings()
+        agent = ConcreteAgent()
+        assert agent._effective_summary_threshold() == 20_000
+
+    @patch("src.base_agent.get_context_window", return_value=200_000)
+    def test_medium_scales_by_1_5(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "medium")
+        reset_settings()
+        agent = ConcreteAgent()
+        assert agent._effective_summary_threshold() == 30_000
+
+    @patch("src.base_agent.get_context_window", return_value=200_000)
+    def test_large_scales_by_2(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "large")
+        reset_settings()
+        agent = ConcreteAgent()
+        assert agent._effective_summary_threshold() == 40_000
+
+    @patch("src.base_agent.get_context_window", return_value=200_000)
+    def test_full_scales_by_3(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
+        reset_settings()
+        agent = ConcreteAgent()
+        assert agent._effective_summary_threshold() == 60_000
+
+    @patch("src.base_agent.get_context_window", return_value=200_000)
+    def test_applies_to_agent_specific_threshold(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "large")
+        reset_settings()
+        agent = HighThresholdAgent()
+        assert agent._effective_summary_threshold() == 100_000
+
+    @patch("src.base_agent.get_context_window", return_value=25_000)
+    def test_caps_at_context_window(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
+        reset_settings()
+        agent = ConcreteAgent()  # 20_000 * 3 = 60_000 > 25_000
+        assert agent._effective_summary_threshold() == 25_000
+
+    @patch("src.base_agent.get_context_window", return_value=40_000)
+    def test_caps_high_threshold_agent_at_context_window(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
+        reset_settings()
+        agent = HighThresholdAgent()  # 50_000 * 3 = 150_000 > 40_000
+        assert agent._effective_summary_threshold() == 40_000
+
+    @patch("src.base_agent.get_context_window", return_value=200_000)
+    def test_messages_to_keep_unchanged(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
+        reset_settings()
+        agent = ConcreteAgent()
+        assert agent.MESSAGES_TO_KEEP == 6

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,32 @@
+"""Tests for model utilities."""
+
+from unittest.mock import patch
+
+from src.model import DEFAULT_CONTEXT_WINDOW, get_context_window
+
+
+class TestGetContextWindow:
+    """Tests for get_context_window helper."""
+
+    def test_returns_max_input_tokens_from_litellm(self, monkeypatch):
+        monkeypatch.setenv("LLM_MODEL", "openai/gpt-4o")
+        with patch("src.model.litellm.get_model_info") as mock_info:
+            mock_info.return_value = {"max_input_tokens": 128_000}
+            assert get_context_window() == 128_000
+
+    def test_falls_back_on_missing_key(self, monkeypatch):
+        monkeypatch.setenv("LLM_MODEL", "openai/gpt-4o")
+        with patch("src.model.litellm.get_model_info") as mock_info:
+            mock_info.return_value = {}
+            assert get_context_window() == DEFAULT_CONTEXT_WINDOW
+
+    def test_falls_back_on_exception(self, monkeypatch):
+        monkeypatch.setenv("LLM_MODEL", "unknown/model")
+        with patch("src.model.litellm.get_model_info", side_effect=Exception("boom")):
+            assert get_context_window() == DEFAULT_CONTEXT_WINDOW
+
+    def test_falls_back_on_none_value(self, monkeypatch):
+        monkeypatch.setenv("LLM_MODEL", "openai/gpt-4o")
+        with patch("src.model.litellm.get_model_info") as mock_info:
+            mock_info.return_value = {"max_input_tokens": None}
+            assert get_context_window() == DEFAULT_CONTEXT_WINDOW


### PR DESCRIPTION
This PR introduces a new method for setting the summarization threshold based on four values, ensuring the correct context window size is used for the model. We are maintaining the current default behavior, but adding this option for users who require more flexibility.

FIX FLPATH-4801