### PR TITLE
feat: baseAgent add Agent context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,36 @@ Guidelines:
 - **States and dataclasses** follow the same rule — if a state holds structured data, add a method rather than letting every consumer reimplement the traversal
 - **Test the logic where it lives** — edge cases for formatting and computation belong in the model's test file, not the caller's
 
+### Construct Instances Through Classmethods, Not Caller-Side Assembly
+
+When code builds a new instance of a class from some other shape of data (a dict, a different object, a raw value, another instance's fields), that construction belongs on the target class as a classmethod — not assembled field-by-field at the call site. This is the same "logic lives on the owning class" principle applied to construction instead of formatting.
+
+```python
+# Good: the class knows how to build itself from other shapes of data
+@dataclass
+class AgentMetrics:
+    name: str
+    input_tokens: int = 0
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "AgentMetrics":
+        return cls(name=data.get("name", ""), input_tokens=data.get("input_tokens", 0))
+
+# Caller delegates
+metrics = AgentMetrics.from_dict(raw)
+
+# Bad: caller reaches in and assembles the object itself
+metrics = AgentMetrics(name=raw.get("name", ""), input_tokens=raw.get("input_tokens", 0))
+```
+
+This also applies to defensive extraction, not just deserialization: if a function reads a value off some carrier object (a runtime, a context, a response payload) with `getattr`/fallback handling in order to hand it to (or construct) another type, that extraction belongs on the type it produces or the type it reads from — e.g. `AgentRuntimeContext.metrics_from(runtime)` rather than a private helper on every middleware that needs it.
+
+Guidelines:
+- Name constructors by what they build from: `from_dict`, `from_json`, `from_settings`, `from_path`, `from_results`
+- Use plain classmethods for semantic constructors even without alternate input shapes, e.g. `AAPDiscoveryResult.success(...)` / `AAPDiscoveryResult.failed(...)` instead of callers setting flags/fields directly
+- If the same field-by-field construction (or the same defensive `getattr` chain) appears at more than one call site, that is the signal to move it onto the class as a classmethod
+- **Test the constructor where it lives** — edge cases for parsing/defaulting belong in the class's own test file
+
 ## Tools
 
 Custom tools extend `X2ATool` (`tools/base_tool.py`), which provides structured logging bound to the agent that invokes the tool:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -331,6 +331,16 @@ Agents use a middleware stack configured in `BaseAgent.middleware()`:
 | `X2ASummarizationMiddleware` | Compacts conversation when token count exceeds threshold |
 | `AgentDumpMiddleware` | Dumps messages to JSON Lines for debugging (when `JSON_LINES` is set) |
 
+### Telemetry Through Middleware
+
+Middleware instances are cached on the agent (see `BaseAgent.middleware()`) and outlive any single `execute()` call, so they cannot receive `metrics` as a normal Python argument the way agent code does. `GoalValidationMiddleware` runs its own `invoke_react()` (explore phase) and `invoke_structured()` (classify phase) calls, including retries, and these must still be counted in the agent's token telemetry.
+
+LangGraph provides a purpose-built channel for exactly this: per-invocation **runtime context**. `BaseAgent.invoke_react()` builds the graph with `create_agent(..., context_schema=AgentRuntimeContext)` and calls `agent.invoke(..., context=AgentRuntimeContext(metrics=metrics))`. LangGraph surfaces that object back to every middleware hook as `runtime.context` -- e.g. `GoalValidationMiddleware.after_agent(self, state, runtime)` reads `runtime.context.metrics` and threads it into its own `invoke_react()`/`invoke_structured()` calls. See `AgentRuntimeContext` in `src/types/telemetry.py`.
+
+This is preferred over stashing call-scoped data on `self` (e.g. `self._current_metrics`): the context is scoped to the single `agent.invoke()` call instead of mutable shared instance state, so it stays correct even if an agent instance is ever invoked concurrently or re-entrantly.
+
+**Rule:** any call to `invoke_react()`, `invoke_structured()`, or `invoke_llm()` must be given a `metrics` value (the `metrics` parameter passed into `execute()`, or -- from middleware/helpers that don't receive it directly -- `metrics` read off `runtime.context`). Omitting `metrics` silently drops that call's token usage and tool calls from telemetry -- it will not raise or fail tests unless a telemetry test specifically covers it. There is no automated lint for this yet; review call sites manually when adding or modifying `invoke_react`/`invoke_structured`/`invoke_llm` calls.
+
 ## Python Standards
 
 - Python 3.13+ required

--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -36,7 +36,7 @@ from src.model import (
     report_tool_calls,
 )
 from src.types.base_state import BaseState
-from src.types.telemetry import AgentMetrics, telemetry_context
+from src.types.telemetry import AgentMetrics, AgentRuntimeContext, telemetry_context
 from src.utils.logging import get_logger
 from tools.base_tool import X2ATool
 
@@ -288,12 +288,21 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         tagged_messages = self._tag_original_messages(messages)
 
         agent = create_agent(
-            model=self.model, middleware=self.middleware(), tools=tools
+            model=self.model,
+            middleware=self.middleware(),
+            tools=tools,
+            context_schema=AgentRuntimeContext,
         )
 
+        # `context` is LangGraph's per-invocation runtime context, surfaced to
+        # middleware hooks as `runtime.context` (see AgentRuntimeContext).
+        # This is how middleware such as GoalValidationMiddleware learns
+        # which AgentMetrics belongs to this invocation, since the
+        # middleware instance itself is cached across invocations.
         result = agent.invoke(
             {"messages": tagged_messages},
             get_runnable_config(),
+            context=AgentRuntimeContext(metrics=metrics),
         )
 
         tool_calls = report_tool_calls(result)

--- a/src/exporters/aap_discovery_agent.py
+++ b/src/exporters/aap_discovery_agent.py
@@ -136,7 +136,7 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
     # -------------------------------------------------------------------------
 
     def _run_discovery_agent(
-        self, state: ExportState, metrics: AgentMetrics | None = None
+        self, state: ExportState, metrics: AgentMetrics | None
     ) -> str:
         """Run the discovery agent to find relevant collections."""
         system_prompt = get_prompt(self.SYSTEM_PROMPT_NAME).format()
@@ -165,7 +165,7 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
     # -------------------------------------------------------------------------
 
     def _extract_and_verify_collections(
-        self, content: str, metrics: AgentMetrics | None = None
+        self, content: str, metrics: AgentMetrics | None
     ) -> list[DiscoveredCollection]:
         """Extract collection references and verify them in Private Hub."""
         refs = self._extract_collection_refs(content, metrics)
@@ -179,7 +179,7 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
         return self._verify_collections(refs)
 
     def _extract_collection_refs(
-        self, content: str, metrics: AgentMetrics | None = None
+        self, content: str, metrics: AgentMetrics | None
     ) -> list[ExtractedCollectionRef]:
         """Extract collection references from LLM output using structured output."""
         extraction_prompt = get_prompt(self.EXTRACTION_PROMPT_NAME).format(

--- a/src/exporters/aap_discovery_agent.py
+++ b/src/exporters/aap_discovery_agent.py
@@ -114,7 +114,9 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
 
         try:
             discovery_content = self._run_discovery_agent(state, metrics)
-            collections = self._extract_and_verify_collections(discovery_content)
+            collections = self._extract_and_verify_collections(
+                discovery_content, metrics
+            )
 
             self._log_discovery_results(collections)
 
@@ -163,10 +165,10 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
     # -------------------------------------------------------------------------
 
     def _extract_and_verify_collections(
-        self, content: str
+        self, content: str, metrics: AgentMetrics | None = None
     ) -> list[DiscoveredCollection]:
         """Extract collection references and verify them in Private Hub."""
-        refs = self._extract_collection_refs(content)
+        refs = self._extract_collection_refs(content, metrics)
         if not refs:
             return []
 
@@ -176,7 +178,9 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
 
         return self._verify_collections(refs)
 
-    def _extract_collection_refs(self, content: str) -> list[ExtractedCollectionRef]:
+    def _extract_collection_refs(
+        self, content: str, metrics: AgentMetrics | None = None
+    ) -> list[ExtractedCollectionRef]:
         """Extract collection references from LLM output using structured output."""
         extraction_prompt = get_prompt(self.EXTRACTION_PROMPT_NAME).format(
             discovery_content=content
@@ -185,7 +189,7 @@ class AAPDiscoveryAgent(ExportAgent[ExportState]):
         try:
             messages = [{"role": "user", "content": extraction_prompt}]
             extraction_result = self.invoke_structured(
-                CollectionExtractionOutput, messages
+                CollectionExtractionOutput, messages, metrics=metrics
             )
             if isinstance(extraction_result, CollectionExtractionOutput):
                 return extraction_result.collections

--- a/src/middleware/goal_validation.py
+++ b/src/middleware/goal_validation.py
@@ -83,7 +83,7 @@ class GoalValidationMiddleware(AgentMiddleware):
             return messages
         return messages[: self.CONTEXT_HEAD] + messages[-self.CONTEXT_TAIL :]
 
-    def _run_validation(self, state: dict) -> tuple[bool, str]:
+    def _run_validation(self, state: dict, metrics: Any = None) -> tuple[bool, str]:
         self._log.info("Running goal validation", retry_count=self.retry_count)
 
         messages = state.get("messages", [])
@@ -102,6 +102,7 @@ class GoalValidationMiddleware(AgentMiddleware):
             explore_result = self.agent.invoke_react(
                 state=state,
                 messages=[{"role": "user", "content": explore_prompt}],
+                metrics=metrics,
                 tools=tools,
             )
 
@@ -114,6 +115,7 @@ class GoalValidationMiddleware(AgentMiddleware):
             result = self.agent.invoke_structured(
                 schema=GoalValidationResult,
                 messages=[{"role": "user", "content": classify_prompt}],
+                metrics=metrics,
             )
 
             if not result:
@@ -133,6 +135,20 @@ class GoalValidationMiddleware(AgentMiddleware):
         finally:
             self._in_validation = False
 
+    @staticmethod
+    def _extract_metrics_from_runtime(runtime: Any) -> Any:
+        """Read the AgentMetrics for this invocation from runtime.context.
+
+        `runtime` is LangGraph's per-invocation Runtime object; `context` is
+        the AgentRuntimeContext passed by BaseAgent.invoke_react() into
+        `agent.invoke(..., context=...)`. This is how the explore/classify
+        LLM calls below get threaded into the same AgentMetrics as the rest
+        of the agent's execution, even though this middleware instance is
+        cached and reused across many invocations.
+        """
+        context = getattr(runtime, "context", None)
+        return getattr(context, "metrics", None)
+
     @hook_config(can_jump_to=["model"])
     def after_agent(self, state, runtime):
         if self._in_validation:
@@ -147,7 +163,8 @@ class GoalValidationMiddleware(AgentMiddleware):
             messages_count=len(state.get("messages", [])),
         )
 
-        goal_achieved, feedback = self._run_validation(state)
+        metrics = self._extract_metrics_from_runtime(runtime)
+        goal_achieved, feedback = self._run_validation(state, metrics)
 
         if goal_achieved:
             self._log.info("Goal achieved", feedback=feedback)

--- a/src/middleware/goal_validation.py
+++ b/src/middleware/goal_validation.py
@@ -8,6 +8,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.messages.utils import get_buffer_string
 from pydantic import BaseModel, Field
 
+from src.types.telemetry import AgentMetrics, AgentRuntimeContext
 from src.utils.logging import get_logger
 
 EXPLORE_PROMPT_TEMPLATE = """You are a read-only verification agent checking whether the following goal was achieved. Do NOT create, write, or modify any files.
@@ -83,7 +84,9 @@ class GoalValidationMiddleware(AgentMiddleware):
             return messages
         return messages[: self.CONTEXT_HEAD] + messages[-self.CONTEXT_TAIL :]
 
-    def _run_validation(self, state: dict, metrics: Any = None) -> tuple[bool, str]:
+    def _run_validation(
+        self, state: dict, metrics: AgentMetrics | None = None
+    ) -> tuple[bool, str]:
         self._log.info("Running goal validation", retry_count=self.retry_count)
 
         messages = state.get("messages", [])
@@ -105,7 +108,6 @@ class GoalValidationMiddleware(AgentMiddleware):
                 metrics=metrics,
                 tools=tools,
             )
-
             last_ai = self.agent.get_last_ai_message(explore_result)
             findings = last_ai.text if last_ai else "No findings available"
             classify_prompt = CLASSIFY_PROMPT_TEMPLATE.format(
@@ -117,7 +119,6 @@ class GoalValidationMiddleware(AgentMiddleware):
                 messages=[{"role": "user", "content": classify_prompt}],
                 metrics=metrics,
             )
-
             if not result:
                 self._log.warning("No response from validation")
                 return False, "Validation did not respond"
@@ -135,20 +136,6 @@ class GoalValidationMiddleware(AgentMiddleware):
         finally:
             self._in_validation = False
 
-    @staticmethod
-    def _extract_metrics_from_runtime(runtime: Any) -> Any:
-        """Read the AgentMetrics for this invocation from runtime.context.
-
-        `runtime` is LangGraph's per-invocation Runtime object; `context` is
-        the AgentRuntimeContext passed by BaseAgent.invoke_react() into
-        `agent.invoke(..., context=...)`. This is how the explore/classify
-        LLM calls below get threaded into the same AgentMetrics as the rest
-        of the agent's execution, even though this middleware instance is
-        cached and reused across many invocations.
-        """
-        context = getattr(runtime, "context", None)
-        return getattr(context, "metrics", None)
-
     @hook_config(can_jump_to=["model"])
     def after_agent(self, state, runtime):
         if self._in_validation:
@@ -163,7 +150,7 @@ class GoalValidationMiddleware(AgentMiddleware):
             messages_count=len(state.get("messages", [])),
         )
 
-        metrics = self._extract_metrics_from_runtime(runtime)
+        metrics = AgentRuntimeContext.metrics_from(runtime)
         goal_achieved, feedback = self._run_validation(state, metrics)
 
         if goal_achieved:

--- a/src/types/telemetry.py
+++ b/src/types/telemetry.py
@@ -359,6 +359,25 @@ class Telemetry:
         return path
 
 
+@dataclass
+class AgentRuntimeContext:
+    """LangGraph runtime context for a single ``create_agent()`` invocation.
+
+    Passed via ``agent.invoke(..., context=AgentRuntimeContext(metrics=metrics))``
+    in ``BaseAgent.invoke_react()`` and read back by middleware as
+    ``runtime.context`` (e.g. in a hook like ``after_agent(self, state, runtime)``).
+
+    This is how call-scoped data such as the current ``AgentMetrics`` reaches
+    middleware: middleware instances are cached on the agent and outlive any
+    single invocation, so they have no other way to know which metrics object
+    belongs to the invocation currently running. Without this, middleware
+    that issues its own LLM calls (e.g. ``GoalValidationMiddleware``) would
+    silently drop those calls from telemetry.
+    """
+
+    metrics: AgentMetrics | None = None
+
+
 @contextmanager
 def telemetry_context(telemetry: "Telemetry | None", agent_name: str):
     """Context manager for timing agent execution.

--- a/src/types/telemetry.py
+++ b/src/types/telemetry.py
@@ -377,6 +377,24 @@ class AgentRuntimeContext:
 
     metrics: AgentMetrics | None = None
 
+    @classmethod
+    def metrics_from(cls, runtime: Any) -> "AgentMetrics | None":
+        """Read the AgentMetrics for this invocation from a LangGraph runtime.
+
+        ``runtime`` is LangGraph's per-invocation Runtime object; ``runtime.context``
+        is the AgentRuntimeContext passed by ``BaseAgent.invoke_react()`` into
+        ``agent.invoke(..., context=...)``. This is how call-scoped middleware
+        (e.g. ``GoalValidationMiddleware``, which is cached and reused across many
+        invocations and issues its own explore/classify LLM calls) recovers the
+        AgentMetrics belonging to the invocation currently running, so those calls
+        get threaded into the same telemetry as the rest of the agent's execution.
+
+        Defensive against ``runtime`` or ``runtime.context`` not carrying an
+        AgentRuntimeContext (e.g. hooks invoked outside of invoke_react()).
+        """
+        context = getattr(runtime, "context", None)
+        return getattr(context, "metrics", None)
+
 
 @contextmanager
 def telemetry_context(telemetry: "Telemetry | None", agent_name: str):

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -927,6 +927,54 @@ class TestBaseAgentInvokeReact:
 
         assert invoked_messages[0].content == "Specific content to preserve"
 
+    def test_invoke_react_passes_metrics_via_runtime_context(
+        self, agent, mock_agent_create
+    ):
+        """invoke_react must pass `metrics` through LangGraph's `context`
+        argument (surfaced to middleware as `runtime.context`), since that is
+        the only channel middleware -- cached across invocations -- has to
+        learn which AgentMetrics belongs to the invocation currently running.
+        """
+        from unittest.mock import Mock
+
+        from src.types.telemetry import AgentMetrics, AgentRuntimeContext
+
+        mock_agent_instance = Mock()
+        mock_agent_instance.invoke.return_value = {"messages": []}
+        mock_agent_create.return_value = mock_agent_instance
+
+        metrics = AgentMetrics(name="ConcreteAgent")
+        state = BaseState(user_message="test", path="/test")
+        agent.invoke_react(state, [{"role": "user", "content": "hi"}], metrics=metrics)
+
+        # context_schema wired into create_agent so LangGraph accepts context=
+        assert mock_agent_create.call_args.kwargs["context_schema"] is (
+            AgentRuntimeContext
+        )
+
+        invoke_call = mock_agent_instance.invoke.call_args
+        passed_context = invoke_call.kwargs["context"]
+        assert isinstance(passed_context, AgentRuntimeContext)
+        assert passed_context.metrics is metrics
+
+    def test_invoke_react_passes_none_metrics_via_runtime_context(
+        self, agent, mock_agent_create
+    ):
+        from unittest.mock import Mock
+
+        from src.types.telemetry import AgentRuntimeContext
+
+        mock_agent_instance = Mock()
+        mock_agent_instance.invoke.return_value = {"messages": []}
+        mock_agent_create.return_value = mock_agent_instance
+
+        state = BaseState(user_message="test", path="/test")
+        agent.invoke_react(state, [{"role": "user", "content": "hi"}])
+
+        passed_context = mock_agent_instance.invoke.call_args.kwargs["context"]
+        assert isinstance(passed_context, AgentRuntimeContext)
+        assert passed_context.metrics is None
+
 
 class FooTool(BaseTool):
     """Simple tool used to identify which tool set was built."""

--- a/tests/test_goal_validation.py
+++ b/tests/test_goal_validation.py
@@ -15,7 +15,11 @@ EXPLORE_FINDINGS = "Verified: migration-plan.md exists and contains expected con
 
 
 class FakeAgent:
-    def __init__(self, structured_result=None, explore_content=EXPLORE_FINDINGS):
+    def __init__(
+        self,
+        structured_result=None,
+        explore_content=EXPLORE_FINDINGS,
+    ):
         self._structured_result = structured_result
         self._explore_content = explore_content
 
@@ -192,6 +196,96 @@ class TestRunValidation:
         mw.agent.invoke_react = MagicMock(side_effect=RuntimeError("fail"))
         mw._run_validation({"messages": []})
         assert mw._in_validation is False
+
+    def test_metrics_argument_threaded_into_invoke_react_and_invoke_structured(self):
+        """The explore/classify calls must forward the metrics passed into
+        _run_validation() so their token usage and retries are counted in
+        telemetry instead of being silently dropped.
+        """
+        sentinel_metrics = object()
+        agent = MagicMock()
+        agent.invoke_react.return_value = {"messages": [AIMessage(content="findings")]}
+        agent.get_last_ai_message.return_value = AIMessage(content="findings")
+        agent.invoke_structured.return_value = GoalValidationResult(
+            achieved=True, feedback="ok"
+        )
+        mw = GoalValidationMiddleware("goal", agent=agent)
+
+        mw._run_validation({"messages": []}, metrics=sentinel_metrics)
+
+        assert agent.invoke_react.call_args[1]["metrics"] is sentinel_metrics
+        assert agent.invoke_structured.call_args[1]["metrics"] is sentinel_metrics
+
+    def test_metrics_defaults_to_none_when_not_provided(self):
+        agent = MagicMock()
+        agent.invoke_react.return_value = {"messages": [AIMessage(content="findings")]}
+        agent.get_last_ai_message.return_value = AIMessage(content="findings")
+        agent.invoke_structured.return_value = GoalValidationResult(
+            achieved=True, feedback="ok"
+        )
+        mw = GoalValidationMiddleware("goal", agent=agent)
+
+        mw._run_validation({"messages": []})
+
+        assert agent.invoke_react.call_args[1]["metrics"] is None
+        assert agent.invoke_structured.call_args[1]["metrics"] is None
+
+
+class TestExtractMetricsFromRuntime:
+    """Tests for reading AgentMetrics out of LangGraph's runtime.context.
+
+    BaseAgent.invoke_react() passes an AgentRuntimeContext(metrics=...) into
+    `agent.invoke(..., context=...)`, and LangGraph surfaces it back to
+    middleware hooks as `runtime.context`. This is how GoalValidationMiddleware
+    (a cached instance reused across invocations) learns which AgentMetrics
+    belongs to the invocation currently running.
+    """
+
+    def test_extracts_metrics_from_runtime_context(self, make_middleware):
+        from src.types.telemetry import AgentMetrics, AgentRuntimeContext
+
+        mw = make_middleware()
+        sentinel_metrics = AgentMetrics(name="test")
+        runtime = MagicMock()
+        runtime.context = AgentRuntimeContext(metrics=sentinel_metrics)
+
+        assert mw._extract_metrics_from_runtime(runtime) is sentinel_metrics
+
+    def test_returns_none_when_context_missing(self, make_middleware):
+        mw = make_middleware()
+        runtime = MagicMock()
+        runtime.context = None
+
+        assert mw._extract_metrics_from_runtime(runtime) is None
+
+    def test_returns_none_when_runtime_has_no_context_attribute(self, make_middleware):
+        mw = make_middleware()
+
+        assert mw._extract_metrics_from_runtime(object()) is None
+
+    def test_after_agent_forwards_runtime_metrics_to_run_validation(
+        self, make_middleware
+    ):
+        from src.types.telemetry import AgentMetrics, AgentRuntimeContext
+
+        mw = make_middleware(
+            structured_result=GoalValidationResult(achieved=True, feedback="ok")
+        )
+        sentinel_metrics = AgentMetrics(name="test")
+        runtime = MagicMock()
+        runtime.context = AgentRuntimeContext(metrics=sentinel_metrics)
+        seen = {}
+        original_run_validation = mw._run_validation
+
+        def spy(state, metrics=None):
+            seen["metrics"] = metrics
+            return original_run_validation(state, metrics)
+
+        mw._run_validation = spy
+
+        mw.after_agent({"messages": []}, runtime)
+
+        assert seen["metrics"] is sentinel_metrics
 
 
 class TestAfterAgent:

--- a/tests/test_goal_validation.py
+++ b/tests/test_goal_validation.py
@@ -10,6 +10,7 @@ from src.middleware.goal_validation import (
     GoalValidationMiddleware,
     GoalValidationResult,
 )
+from src.types.telemetry import AgentMetrics
 
 EXPLORE_FINDINGS = "Verified: migration-plan.md exists and contains expected content."
 
@@ -202,7 +203,7 @@ class TestRunValidation:
         _run_validation() so their token usage and retries are counted in
         telemetry instead of being silently dropped.
         """
-        sentinel_metrics = object()
+        sentinel_metrics = AgentMetrics(name="sentinel")
         agent = MagicMock()
         agent.invoke_react.return_value = {"messages": [AIMessage(content="findings")]}
         agent.get_last_ai_message.return_value = AIMessage(content="findings")
@@ -231,37 +232,13 @@ class TestRunValidation:
         assert agent.invoke_structured.call_args[1]["metrics"] is None
 
 
-class TestExtractMetricsFromRuntime:
-    """Tests for reading AgentMetrics out of LangGraph's runtime.context.
+class TestAfterAgentMetricsForwarding:
+    """Tests that after_agent threads runtime metrics into _run_validation.
 
-    BaseAgent.invoke_react() passes an AgentRuntimeContext(metrics=...) into
-    `agent.invoke(..., context=...)`, and LangGraph surfaces it back to
-    middleware hooks as `runtime.context`. This is how GoalValidationMiddleware
-    (a cached instance reused across invocations) learns which AgentMetrics
-    belongs to the invocation currently running.
+    The actual extraction logic lives on AgentRuntimeContext.metrics_from()
+    (see tests/types/test_telemetry.py); these tests only cover that
+    after_agent wires it up correctly.
     """
-
-    def test_extracts_metrics_from_runtime_context(self, make_middleware):
-        from src.types.telemetry import AgentMetrics, AgentRuntimeContext
-
-        mw = make_middleware()
-        sentinel_metrics = AgentMetrics(name="test")
-        runtime = MagicMock()
-        runtime.context = AgentRuntimeContext(metrics=sentinel_metrics)
-
-        assert mw._extract_metrics_from_runtime(runtime) is sentinel_metrics
-
-    def test_returns_none_when_context_missing(self, make_middleware):
-        mw = make_middleware()
-        runtime = MagicMock()
-        runtime.context = None
-
-        assert mw._extract_metrics_from_runtime(runtime) is None
-
-    def test_returns_none_when_runtime_has_no_context_attribute(self, make_middleware):
-        mw = make_middleware()
-
-        assert mw._extract_metrics_from_runtime(object()) is None
 
     def test_after_agent_forwards_runtime_metrics_to_run_validation(
         self, make_middleware

--- a/tests/types/test_telemetry.py
+++ b/tests/types/test_telemetry.py
@@ -4,6 +4,7 @@ import json
 import time
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -11,6 +12,7 @@ from src.model import ToolCallCounter
 from src.types.telemetry import (
     TELEMETRY_FILENAME,
     AgentMetrics,
+    AgentRuntimeContext,
     Telemetry,
     telemetry_context,
 )
@@ -853,3 +855,31 @@ def sample_telemetry():
     agent1.stop()
     telemetry.stop()
     return telemetry
+
+
+class TestAgentRuntimeContextMetricsFrom:
+    """Tests for reading AgentMetrics out of LangGraph's runtime.context.
+
+    BaseAgent.invoke_react() passes an AgentRuntimeContext(metrics=...) into
+    `agent.invoke(..., context=...)`, and LangGraph surfaces it back to
+    middleware hooks as `runtime.context`. This is how call-scoped middleware
+    (e.g. GoalValidationMiddleware, a cached instance reused across
+    invocations) learns which AgentMetrics belongs to the invocation
+    currently running.
+    """
+
+    def test_extracts_metrics_from_runtime_context(self):
+        sentinel_metrics = AgentMetrics(name="test")
+        runtime = MagicMock()
+        runtime.context = AgentRuntimeContext(metrics=sentinel_metrics)
+
+        assert AgentRuntimeContext.metrics_from(runtime) is sentinel_metrics
+
+    def test_returns_none_when_context_missing(self):
+        runtime = MagicMock()
+        runtime.context = None
+
+        assert AgentRuntimeContext.metrics_from(runtime) is None
+
+    def test_returns_none_when_runtime_has_no_context_attribute(self):
+        assert AgentRuntimeContext.metrics_from(object()) is None


### PR DESCRIPTION
This add a way to add context to the middleware to keep the metrics information per agent.

Fix FLPATH-4819