### PR TITLE
changed tools recordings

### DIFF
--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -30,10 +30,10 @@ from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
 from src.middleware.x2a_summarize import X2ASummarizationMiddleware
 from src.model import (
+    ToolCallCounterCallback,
     get_context_window,
     get_model,
     get_runnable_config,
-    report_tool_calls,
 )
 from src.types.base_state import BaseState
 from src.types.telemetry import AgentMetrics, AgentRuntimeContext, telemetry_context
@@ -299,13 +299,20 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         # This is how middleware such as GoalValidationMiddleware learns
         # which AgentMetrics belongs to this invocation, since the
         # middleware instance itself is cached across invocations.
+        counter_callback = ToolCallCounterCallback()
+        config = get_runnable_config()
+        existing = config.get("callbacks")
+        config["callbacks"] = [
+            *(existing if isinstance(existing, list) else []),
+            counter_callback,
+        ]
+
         result = agent.invoke(
             {"messages": tagged_messages},
-            get_runnable_config(),
+            config,
             context=AgentRuntimeContext(metrics=metrics),
         )
-
-        tool_calls = report_tool_calls(result)
+        tool_calls = counter_callback.counter
         self._log.info(f"Tool calls: {tool_calls.to_string()}")
 
         if metrics:

--- a/src/model.py
+++ b/src/model.py
@@ -82,21 +82,15 @@ class ToolCallCounter(Counter):
         return "Tool calls:\n\t -" + "\n\t- ".join(report_lines)
 
 
-def report_tool_calls(state: dict[str, Any]) -> ToolCallCounter:
-    messages = state.get("messages", [])
-    tool_call_counts = ToolCallCounter()
+class ToolCallCounterCallback(BaseCallbackHandler):
+    """Counts tool calls at invocation time, immune to message summarization."""
 
-    for msg in messages:
-        if hasattr(msg, "tool_calls") and msg.tool_calls:
-            for tool_call in msg.tool_calls:
-                tool_name = (
-                    tool_call.get("name")
-                    if isinstance(tool_call, dict)
-                    else tool_call.name
-                )
-                tool_call_counts[tool_name] += 1
+    def __init__(self):
+        super().__init__()
+        self.counter = ToolCallCounter()
 
-    return tool_call_counts
+    def on_tool_start(self, serialized, input_str, **kwargs):
+        self.counter[serialized.get("name", "unknown")] += 1
 
 
 def get_last_ai_message(state: dict[str, Any]):

--- a/src/types/telemetry.py
+++ b/src/types/telemetry.py
@@ -72,7 +72,7 @@ class AgentMetrics:
         """Merge tool call counts from a ToolCallCounter.
 
         Args:
-            counter: ToolCallCounter from report_tool_calls()
+            counter: ToolCallCounter from ToolCallCounterCallback.counter
 
         Returns:
             Self for method chaining

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,11 @@
 
 from unittest.mock import patch
 
-from src.model import DEFAULT_CONTEXT_WINDOW, get_context_window
+from src.model import (
+    DEFAULT_CONTEXT_WINDOW,
+    ToolCallCounterCallback,
+    get_context_window,
+)
 
 
 class TestGetContextWindow:
@@ -30,3 +34,20 @@ class TestGetContextWindow:
         with patch("src.model.litellm.get_model_info") as mock_info:
             mock_info.return_value = {"max_input_tokens": None}
             assert get_context_window() == DEFAULT_CONTEXT_WINDOW
+
+
+class TestToolCallCounterCallback:
+    def test_on_tool_start_increments_counter(self):
+        callback = ToolCallCounterCallback()
+        callback.on_tool_start({"name": "my_tool"}, "input")
+        callback.on_tool_start({"name": "my_tool"}, "input")
+        callback.on_tool_start({"name": "other_tool"}, "input")
+
+        assert callback.counter["my_tool"] == 2
+        assert callback.counter["other_tool"] == 1
+
+    def test_on_tool_start_falls_back_to_unknown(self):
+        callback = ToolCallCounterCallback()
+        callback.on_tool_start({}, "input")
+
+        assert callback.counter["unknown"] == 1


### PR DESCRIPTION
When X2ASummarizationMiddleware is called it wiped the messages we derived the tool calls from , making any tool calls before the summary invisible to  telemetry. 