### PR TITLE
feat: telemetry middleware

### DIFF
--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -28,6 +28,7 @@ from src.middleware.agent_dump import (
 )
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
+from src.middleware.telemetry import TelemetryMiddleware
 from src.middleware.x2a_summarize import X2ASummarizationMiddleware
 from src.model import (
     get_context_window,
@@ -158,6 +159,12 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         if settings.logging.json_lines:
             stack.append(AgentDumpMiddleware(self._get_snapshot_writer()))
 
+        # TelemetryMiddleware must stay last: it wraps the actual model call
+        # (wrap_model_call composes outermost-first), so placing it last keeps
+        # it innermost -- it always measures the real call and never
+        # intercepts/short-circuits control flow owned by other middleware.
+        stack.append(TelemetryMiddleware())
+
         # Cache for reuse
         self._middleware_cache = stack
         return stack
@@ -250,26 +257,6 @@ Retry your response now, ensuring it matches the schema structure exactly."""
             config["callbacks"] = [handler]
         return config
 
-    def _extract_token_usage(self, result: dict) -> tuple[int, int]:
-        """Extract total input and output tokens from AIMessage objects.
-
-        Returns:
-        Tuple of (input_tokens, output_tokens)
-        """
-        input_tokens = 0
-        output_tokens = 0
-
-        for msg in result.get("messages", []):
-            if not isinstance(msg, AIMessage):
-                continue
-            if not hasattr(msg, "usage_metadata") or not msg.usage_metadata:
-                continue
-
-            input_tokens += msg.usage_metadata.get("input_tokens", 0)
-            output_tokens += msg.usage_metadata.get("output_tokens", 0)
-
-        return input_tokens, output_tokens
-
     def invoke_react(
         self,
         state: S,
@@ -308,10 +295,12 @@ Retry your response now, ensuring it matches the schema structure exactly."""
         tool_calls = report_tool_calls(result)
         self._log.info(f"Tool calls: {tool_calls.to_string()}")
 
+        # Token usage is recorded by TelemetryMiddleware (via wrap_model_call)
+        # as each model call happens, using the same AgentRuntimeContext passed
+        # above. Recording it again here from the final message list would
+        # double-count every token.
         if metrics:
             metrics.record_tool_calls(tool_calls)
-            input_tokens, output_tokens = self._extract_token_usage(result)
-            metrics.record_tokens(input_tokens, output_tokens)
 
         return result
 

--- a/src/middleware/telemetry.py
+++ b/src/middleware/telemetry.py
@@ -1,0 +1,80 @@
+"""Middleware that records LLM token usage into per-invocation AgentMetrics.
+
+Mirrors deepagents' CostTrackingMiddleware: it wraps every model call made
+within the agent's graph via wrap_model_call/awrap_model_call and records
+usage against the AgentMetrics carried in the per-invocation
+AgentRuntimeContext, so tokens are captured at the source regardless of
+which node triggered the call -- without every call site having to
+remember to record them manually.
+
+This middleware is intentionally a pure observer:
+- It calls the handler exactly once and never retries, short-circuits, or
+  rewrites the request/response.
+- It never raises from the handler call itself; a bug in metrics recording
+  must never break agent execution, so recording is wrapped defensively.
+- It keeps no state on self; everything it needs is read per-call from
+  request.runtime.context, so it is safe to share/cache across
+  invocations like the other middleware.
+
+It should be placed last in the middleware stack (closest to the actual
+model call) so it always measures the real call and is never skipped by
+an earlier middleware short-circuiting.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+
+from langchain.agents.middleware.types import (
+    AgentMiddleware,
+    ModelRequest,
+    ModelResponse,
+)
+from langchain_core.messages import AIMessage
+
+from src.types.telemetry import AgentRuntimeContext
+from src.utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class TelemetryMiddleware(AgentMiddleware):
+    """Records token usage for every model call in this invocation into AgentMetrics."""
+
+    name = "Telemetry"
+
+    def wrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], ModelResponse],
+    ) -> ModelResponse:
+        response = handler(request)
+        self._record(request, response)
+        return response
+
+    async def awrap_model_call(
+        self,
+        request: ModelRequest,
+        handler: Callable[[ModelRequest], Awaitable[ModelResponse]],
+    ) -> ModelResponse:
+        response = await handler(request)
+        self._record(request, response)
+        return response
+
+    @staticmethod
+    def _record(request: ModelRequest, response: ModelResponse) -> None:
+        try:
+            metrics = AgentRuntimeContext.metrics_from(request.runtime)
+            if metrics is None:
+                return
+            for message in response.result:
+                if not isinstance(message, AIMessage):
+                    continue
+                usage = getattr(message, "usage_metadata", None)
+                if not usage:
+                    continue
+                metrics.record_tokens(
+                    usage.get("input_tokens", 0), usage.get("output_tokens", 0)
+                )
+        except Exception as e:
+            logger.error("Failed to record telemetry for model call", error=str(e))

--- a/src/middleware/x2a_summarize.py
+++ b/src/middleware/x2a_summarize.py
@@ -21,6 +21,7 @@ from langgraph.runtime import Runtime
 
 from prompts.get_prompt import get_prompt
 from src.const import X2A_ORIGINAL_MESSAGE
+from src.types.telemetry import AgentMetrics, AgentRuntimeContext
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -59,7 +60,8 @@ class X2ASummarizationMiddleware(AgentMiddleware):
             return None
 
         original, to_summarize, kept = result
-        summary_text = self._create_summary(to_summarize)
+        metrics = AgentRuntimeContext.metrics_from(runtime)
+        summary_text = self._create_summary(to_summarize, metrics)
 
         if summary_text is None:
             return None
@@ -76,7 +78,8 @@ class X2ASummarizationMiddleware(AgentMiddleware):
             return None
 
         original, to_summarize, kept = result
-        summary_text = await self._acreate_summary(to_summarize)
+        metrics = AgentRuntimeContext.metrics_from(runtime)
+        summary_text = await self._acreate_summary(to_summarize, metrics)
 
         if summary_text is None:
             return None
@@ -163,7 +166,9 @@ class X2ASummarizationMiddleware(AgentMiddleware):
         cutoff = self._adjust_cutoff_for_tool_pairs(messages, cutoff)
         return messages[cutoff:]
 
-    def _create_summary(self, messages: list[AnyMessage]) -> str | None:
+    def _create_summary(
+        self, messages: list[AnyMessage], metrics: AgentMetrics | None = None
+    ) -> str | None:
         if not messages:
             return "No previous actions to summarize."
 
@@ -171,6 +176,7 @@ class X2ASummarizationMiddleware(AgentMiddleware):
 
         try:
             response = self._model.invoke(prompt_text)
+            self._record_tokens(response, metrics)
             return response.text.strip()
         except Exception as e:
             logger.error(
@@ -178,7 +184,9 @@ class X2ASummarizationMiddleware(AgentMiddleware):
             )
             return None
 
-    async def _acreate_summary(self, messages: list[AnyMessage]) -> str | None:
+    async def _acreate_summary(
+        self, messages: list[AnyMessage], metrics: AgentMetrics | None = None
+    ) -> str | None:
         if not messages:
             return "No previous actions to summarize."
 
@@ -186,12 +194,30 @@ class X2ASummarizationMiddleware(AgentMiddleware):
 
         try:
             response = await self._model.ainvoke(prompt_text)
+            self._record_tokens(response, metrics)
             return response.text.strip()
         except Exception as e:
             logger.error(
                 "Summarization failed, keeping original messages", error=str(e)
             )
             return None
+
+    @staticmethod
+    def _record_tokens(response: Any, metrics: AgentMetrics | None) -> None:
+        """Thread summarization LLM token usage into the invocation's AgentMetrics.
+
+        Without this, tokens spent compacting the conversation are silently
+        dropped from telemetry, since this middleware issues its own model
+        call outside of invoke_react/invoke_llm.
+        """
+        if metrics is None:
+            return
+        usage = getattr(response, "usage_metadata", None)
+        if not usage:
+            return
+        metrics.record_tokens(
+            usage.get("input_tokens", 0), usage.get("output_tokens", 0)
+        )
 
     def _build_summary_prompt(self, messages: list[AnyMessage]) -> str:
         formatted = get_buffer_string(messages)

--- a/tests/middleware/test_telemetry.py
+++ b/tests/middleware/test_telemetry.py
@@ -1,0 +1,141 @@
+"""Tests for TelemetryMiddleware."""
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from src.middleware.telemetry import TelemetryMiddleware
+from src.types.telemetry import AgentMetrics, AgentRuntimeContext
+
+
+def _ai_message(input_tokens: int, output_tokens: int) -> AIMessage:
+    return AIMessage(
+        content="response",
+        usage_metadata={
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        },
+    )
+
+
+def _response(*messages):
+    return Mock(result=list(messages))
+
+
+def _request(metrics: AgentMetrics | None):
+    runtime = Mock(context=AgentRuntimeContext(metrics=metrics))
+    return Mock(runtime=runtime)
+
+
+class TestWrapModelCall:
+    """Tests for the synchronous wrap_model_call hook."""
+
+    def test_records_tokens_on_metrics(self):
+        metrics = AgentMetrics(name="TestAgent")
+        request = _request(metrics)
+        response = _response(_ai_message(100, 50))
+        handler = Mock(return_value=response)
+
+        middleware = TelemetryMiddleware()
+        result = middleware.wrap_model_call(request, handler)
+
+        assert result is response
+        handler.assert_called_once_with(request)
+        assert metrics.input_tokens == 100
+        assert metrics.output_tokens == 50
+
+    def test_accumulates_across_multiple_ai_messages(self):
+        metrics = AgentMetrics(name="TestAgent")
+        request = _request(metrics)
+        response = _response(
+            HumanMessage(content="not counted"),
+            _ai_message(10, 5),
+            ToolMessage(content="tool result", tool_call_id="1"),
+        )
+        handler = Mock(return_value=response)
+
+        TelemetryMiddleware().wrap_model_call(request, handler)
+
+        assert metrics.input_tokens == 10
+        assert metrics.output_tokens == 5
+
+    def test_noop_without_metrics_on_context(self):
+        request = _request(None)
+        response = _response(_ai_message(10, 5))
+        handler = Mock(return_value=response)
+
+        result = TelemetryMiddleware().wrap_model_call(request, handler)
+
+        assert result is response
+        handler.assert_called_once_with(request)
+
+    def test_noop_when_runtime_has_no_context(self):
+        request = Mock(runtime=Mock(spec=[]))
+        response = _response(_ai_message(10, 5))
+        handler = Mock(return_value=response)
+
+        result = TelemetryMiddleware().wrap_model_call(request, handler)
+
+        assert result is response
+
+    def test_ignores_ai_message_without_usage_metadata(self):
+        metrics = AgentMetrics(name="TestAgent")
+        request = _request(metrics)
+        response = _response(AIMessage(content="no usage info"))
+        handler = Mock(return_value=response)
+
+        TelemetryMiddleware().wrap_model_call(request, handler)
+
+        assert metrics.input_tokens == 0
+        assert metrics.output_tokens == 0
+
+    def test_never_raises_when_recording_fails(self):
+        """A telemetry bug must never break agent execution."""
+        request = Mock(runtime=Mock(context=object()))
+        response = _response(_ai_message(10, 5))
+        handler = Mock(return_value=response)
+
+        # Should not raise even though runtime.context has no .metrics
+        result = TelemetryMiddleware().wrap_model_call(request, handler)
+
+        assert result is response
+
+    def test_calls_handler_exactly_once(self):
+        """Middleware must be a pure observer: never retries or short-circuits."""
+        metrics = AgentMetrics(name="TestAgent")
+        request = _request(metrics)
+        response = _response(_ai_message(1, 1))
+        handler = Mock(return_value=response)
+
+        TelemetryMiddleware().wrap_model_call(request, handler)
+
+        assert handler.call_count == 1
+
+    def test_propagates_handler_exceptions(self):
+        """Errors from the actual model call must not be swallowed."""
+        request = _request(AgentMetrics(name="TestAgent"))
+        handler = Mock(side_effect=RuntimeError("model failed"))
+
+        with pytest.raises(RuntimeError, match="model failed"):
+            TelemetryMiddleware().wrap_model_call(request, handler)
+
+
+class TestAWrapModelCall:
+    """Tests for the async awrap_model_call hook."""
+
+    def test_records_tokens_on_metrics(self):
+        metrics = AgentMetrics(name="TestAgent")
+        request = _request(metrics)
+        response = _response(_ai_message(20, 8))
+
+        async def handler(_request):
+            return response
+
+        result = asyncio.run(TelemetryMiddleware().awrap_model_call(request, handler))
+
+        assert result is response
+        assert metrics.input_tokens == 20
+        assert metrics.output_tokens == 8

--- a/tests/middleware/test_x2a_summarize.py
+++ b/tests/middleware/test_x2a_summarize.py
@@ -15,6 +15,7 @@ from langgraph.graph.message import REMOVE_ALL_MESSAGES
 
 from src.const import X2A_ORIGINAL_MESSAGE
 from src.middleware.x2a_summarize import X2ASummarizationMiddleware
+from src.types.telemetry import AgentMetrics, AgentRuntimeContext
 
 
 class MockRuntime:
@@ -630,6 +631,68 @@ class TestSummaryCreation:
         result = middleware._create_summary(messages)
 
         assert result is None
+
+    def test_create_summary_records_token_usage_on_metrics(self, middleware, model):
+        """Test that summarization LLM usage is threaded into AgentMetrics."""
+        model.invoke.return_value = Mock(
+            text="Summary text",
+            usage_metadata={"input_tokens": 42, "output_tokens": 7},
+        )
+        metrics = AgentMetrics(name="TestAgent")
+        messages = [AIMessage(content="First")]
+
+        result = middleware._create_summary(messages, metrics)
+
+        assert result == "Summary text"
+        assert metrics.input_tokens == 42
+        assert metrics.output_tokens == 7
+
+    def test_create_summary_without_metrics_is_noop(self, middleware, model):
+        """Test that summarization works fine without metrics (no-op tracking)."""
+        messages = [AIMessage(content="First")]
+
+        result = middleware._create_summary(messages, None)
+
+        assert result == "Summary text"
+
+
+class TestBeforeModelMetricsThreading:
+    """Tests that before_model/abefore_model thread AgentMetrics from runtime context."""
+
+    @pytest.fixture
+    def model(self):
+        mock = Mock()
+        mock.invoke.return_value = Mock(
+            text="Summary text",
+            usage_metadata={"input_tokens": 10, "output_tokens": 5},
+        )
+        return mock
+
+    def test_before_model_records_tokens_via_runtime_context(self, model):
+        """Test that before_model reads metrics off runtime.context and records tokens."""
+        middleware = X2ASummarizationMiddleware(
+            model, max_tokens=10, messages_to_keep=1
+        )
+        metrics = AgentMetrics(name="TestAgent")
+        runtime = Mock(context=AgentRuntimeContext(metrics=metrics))
+
+        original = HumanMessage(
+            content="Original",
+            additional_kwargs={X2A_ORIGINAL_MESSAGE: True},
+            id="msg1",
+        )
+        messages = [
+            original,
+            AIMessage(content="Long response " * 100, id="msg2"),
+            ToolMessage(content="Tool result " * 100, tool_call_id="123", id="msg3"),
+        ]
+        state = {"messages": messages}
+
+        result = middleware.before_model(state, runtime)
+
+        assert result is not None
+        assert metrics.input_tokens == 10
+        assert metrics.output_tokens == 5
 
 
 class TestEndToEndScenarios:

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -12,6 +12,7 @@ from src.base_agent import BaseAgent
 from src.config import reset_settings
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
+from src.middleware.telemetry import TelemetryMiddleware
 from src.middleware.x2a_summarize import X2ASummarizationMiddleware
 from src.types.base_state import BaseState
 
@@ -64,162 +65,6 @@ class TestBaseAgentName:
     def test_agent_name_uses_custom_name_when_defined(self):
         agent = NamedAgent()
         assert agent.agent_name == "My Custom Agent"
-
-
-class TestBaseAgentTokenExtraction:
-    """Tests for BaseAgent._extract_token_usage method."""
-
-    @pytest.fixture
-    def agent(self):
-        """Create a test agent instance."""
-        return ConcreteAgent()
-
-    def test_extract_token_usage_empty_messages(self, agent):
-        """Test extraction with no messages."""
-        result = {"messages": []}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 0
-        assert output_tokens == 0
-
-    def test_extract_token_usage_no_ai_messages(self, agent):
-        """Test extraction with no AI messages."""
-        result = {
-            "messages": [
-                HumanMessage(content="Hello"),
-                HumanMessage(content="World"),
-            ]
-        }
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 0
-        assert output_tokens == 0
-
-    def test_extract_token_usage_single_ai_message(self, agent):
-        """Test extraction from single AI message."""
-        ai_msg = AIMessage(content="Response")
-        ai_msg.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 100, "output_tokens": 50}
-        )
-
-        result = {"messages": [ai_msg]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 100
-        assert output_tokens == 50
-
-    def test_extract_token_usage_multiple_ai_messages(self, agent):
-        """Test extraction accumulates across multiple AI messages."""
-        ai_msg1 = AIMessage(content="First")
-        ai_msg1.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 100, "output_tokens": 50}
-        )
-
-        ai_msg2 = AIMessage(content="Second")
-        ai_msg2.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 200, "output_tokens": 75}
-        )
-
-        result = {"messages": [ai_msg1, ai_msg2]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 300
-        assert output_tokens == 125
-
-    def test_extract_token_usage_mixed_messages(self, agent):
-        """Test extraction with mixed message types."""
-        human_msg = HumanMessage(content="Question")
-        ai_msg1 = AIMessage(content="Answer 1")
-        ai_msg1.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 100, "output_tokens": 50}
-        )
-
-        ai_msg2 = AIMessage(content="Answer 2")
-        ai_msg2.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 150, "output_tokens": 60}
-        )
-
-        result = {"messages": [human_msg, ai_msg1, human_msg, ai_msg2]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 250
-        assert output_tokens == 110
-
-    def test_extract_token_usage_missing_metadata(self, agent):
-        """Test extraction handles AI messages without usage_metadata."""
-        ai_msg_with_metadata = AIMessage(content="First")
-        ai_msg_with_metadata.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 100, "output_tokens": 50}
-        )
-
-        ai_msg_without_metadata = AIMessage(content="Second")
-        # No usage_metadata attribute
-
-        result = {"messages": [ai_msg_with_metadata, ai_msg_without_metadata]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 100
-        assert output_tokens == 50
-
-    def test_extract_token_usage_none_metadata(self, agent):
-        """Test extraction handles None usage_metadata."""
-        ai_msg1 = AIMessage(content="First")
-        ai_msg1.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 100, "output_tokens": 50}
-        )
-
-        ai_msg2 = AIMessage(content="Second")
-        ai_msg2.usage_metadata = None
-
-        result = {"messages": [ai_msg1, ai_msg2]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 100
-        assert output_tokens == 50
-
-    def test_extract_token_usage_partial_metadata(self, agent):
-        """Test extraction handles missing keys in usage_metadata."""
-        ai_msg1 = AIMessage(content="First")
-        ai_msg1.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 100, "output_tokens": 50}
-        )
-
-        ai_msg2 = AIMessage(content="Second")
-        ai_msg2.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 75}
-        )  # Missing output_tokens
-
-        ai_msg3 = AIMessage(content="Third")
-        ai_msg3.usage_metadata = cast(
-            UsageMetadata, {"output_tokens": 25}
-        )  # Missing input_tokens
-
-        result = {"messages": [ai_msg1, ai_msg2, ai_msg3]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 175  # 100 + 75 + 0
-        assert output_tokens == 75  # 50 + 0 + 25
-
-    def test_extract_token_usage_zero_tokens(self, agent):
-        """Test extraction with zero token values."""
-        ai_msg = AIMessage(content="Response")
-        ai_msg.usage_metadata = cast(
-            UsageMetadata, {"input_tokens": 0, "output_tokens": 0}
-        )
-
-        result = {"messages": [ai_msg]}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 0
-        assert output_tokens == 0
-
-    def test_extract_token_usage_missing_messages_key(self, agent):
-        """Test extraction when result has no messages key."""
-        result = {}
-        input_tokens, output_tokens = agent._extract_token_usage(result)
-
-        assert input_tokens == 0
-        assert output_tokens == 0
 
 
 class TestBaseAgentInvokeLLM:
@@ -1069,24 +914,34 @@ class TestBaseAgentMiddleware:
         agent = ConcreteAgent()
         stack = agent.middleware()
 
-        assert len(stack) == 1
+        assert len(stack) == 2
         assert isinstance(stack[0], X2ASummarizationMiddleware)
+        assert isinstance(stack[1], TelemetryMiddleware)
 
     def test_middleware_with_rules_file(self):
         agent = RuledAgent()
         stack = agent.middleware()
 
-        assert len(stack) == 2
+        assert len(stack) == 3
         assert isinstance(stack[0], RulesMiddleware)
         assert isinstance(stack[1], X2ASummarizationMiddleware)
+        assert isinstance(stack[2], TelemetryMiddleware)
 
     def test_middleware_with_goal(self):
         agent = GoalAgent()
         stack = agent.middleware()
 
-        assert len(stack) == 2
+        assert len(stack) == 3
         assert isinstance(stack[0], GoalValidationMiddleware)
         assert isinstance(stack[1], X2ASummarizationMiddleware)
+        assert isinstance(stack[2], TelemetryMiddleware)
+
+    def test_middleware_telemetry_is_last(self):
+        """TelemetryMiddleware must stay innermost (last), see middleware() docstring."""
+        agent = GoalAgent()
+        stack = agent.middleware()
+
+        assert isinstance(stack[-1], TelemetryMiddleware)
 
     def test_middleware_with_goal_passes_agent_reference(self):
         agent = GoalAgent()


### PR DESCRIPTION
Moving the telemetry from the invoke_react to a middleware, close to what deepagents is doing on the Cost tracking[0].

The idea is that if any middleware is change the messages list, there is no way to interference on the metrics, and it shoudn't touch it, like the Snapshot writter.

So, using `wrap_model_call` we should always track the correct value. We keep invoke() and invoke_structured use the same format as now, because there is no need for telemetry.

[0] https://github.com/langchain-ai/deepagents/blob/54fe91fd3745e285899961bfe74380c837674164/libs/code/deepagents_code/cost_tracking.py#L2294

FIX FLPATH-4820
