### PR TITLE
decide summarization threshold by model context window

### DIFF
--- a/src/base_agent.py
+++ b/src/base_agent.py
@@ -20,6 +20,7 @@ from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 
 from src.config import get_settings
+from src.config.settings import SummaryContextSize
 from src.const import X2A_ORIGINAL_MESSAGE
 from src.middleware.agent_dump import (
     AgentDumpCallbackHandler,
@@ -57,7 +58,7 @@ class BaseAgent[S: BaseState](ABC):
     _NAME: ClassVar[str | None] = None
     RULES_FILE: ClassVar[str | None] = None
     GOAL: ClassVar[str | None] = None
-    MAX_TOKENS_BEFORE_SUMMARY: ClassVar[int] = 20000
+    SUMMARY_CONTEXT_RATIO: ClassVar[SummaryContextSize | None] = None
     MESSAGES_TO_KEEP: ClassVar[int] = 6
 
     STRUCTURED_OUTPUT_INSTRUCTION = """CRITICAL INSTRUCTION - STRUCTURED OUTPUT REQUIRED:
@@ -172,31 +173,24 @@ Retry your response now, ensuring it matches the schema structure exactly."""
     def _effective_summary_threshold(self) -> int:
         """Compute the effective max_tokens for summarization.
 
-        Applies the summary_context_size multiplier to the agent's
-        MAX_TOKENS_BEFORE_SUMMARY and caps it at the model's context window.
+        Uses SUMMARY_CONTEXT_RATIO if set on the agent class, otherwise falls back
+        to the global SUMMARY_CONTEXT_SIZE setting. Both are fractions of the model's
+        context window.
         """
-        settings = get_settings()
-        multiplier = settings.llm.summary_context_size.multiplier
-        scaled = int(self.MAX_TOKENS_BEFORE_SUMMARY * multiplier)
-
+        context_size = (
+            self.SUMMARY_CONTEXT_RATIO or get_settings().llm.summary_context_size
+        )
+        ratio = context_size.ratio
         context_window = get_context_window()
-        if scaled > context_window:
-            self._log.warning(
-                "Summary threshold exceeds context window, capping",
-                requested=scaled,
-                context_window=context_window,
-                agent=self.agent_name,
-            )
-            return context_window
-
-        if multiplier != 1.0:
+        effective = int(context_window * ratio)
+        if ratio != SummaryContextSize.COMPACT.ratio:
             self._log.info(
-                "Summary threshold scaled",
-                base=self.MAX_TOKENS_BEFORE_SUMMARY,
-                multiplier=multiplier,
-                effective=scaled,
+                "Summary threshold computed",
+                context_window=context_window,
+                ratio=ratio,
+                effective=effective,
             )
-        return scaled
+        return effective
 
     def __call__(self, state: S) -> S:
         """Entry point. Wraps execute() with automatic telemetry + logging."""

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -15,30 +15,26 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 class SummaryContextSize(StrEnum):
     """Controls how aggressively conversation history is summarized.
 
-    Each level applies a multiplier to the agent's MAX_TOKENS_BEFORE_SUMMARY
-    threshold. Higher values preserve more conversation context before
-    triggering summarization, at the cost of using more of the model's
-    context window.
-
-    The effective threshold is capped at the model's context window size.
+    Each level is a fraction of the model's actual context window.
+    Higher values preserve more context before triggering summarization.
     """
 
-    COMPACT = "compact"  # 1x   -- current default behavior
-    MEDIUM = "medium"  # 1.5x
-    LARGE = "large"  # 2x
-    FULL = "full"  # 3x
+    COMPACT = "compact"  # 25% of context window, current default behavior
+    MEDIUM = "medium"  # 40% of context window
+    LARGE = "large"  # 55% of context window
+    FULL = "full"  # 75% of context window
 
     @property
-    def multiplier(self) -> float:
-        """Return the token multiplier for this context size."""
-        return _MULTIPLIERS[self]
+    def ratio(self) -> float:
+        """Return the context window fraction for this level."""
+        return _RATIOS[self]
 
 
-_MULTIPLIERS: dict[SummaryContextSize, float] = {
-    SummaryContextSize.COMPACT: 1.0,
-    SummaryContextSize.MEDIUM: 1.5,
-    SummaryContextSize.LARGE: 2.0,
-    SummaryContextSize.FULL: 3.0,
+_RATIOS: dict[SummaryContextSize, float] = {
+    SummaryContextSize.COMPACT: 0.25,
+    SummaryContextSize.MEDIUM: 0.40,
+    SummaryContextSize.LARGE: 0.55,
+    SummaryContextSize.FULL: 0.75,
 }
 
 
@@ -103,7 +99,8 @@ class LLMSettings(BaseSettings):
         default=SummaryContextSize.COMPACT,
         validation_alias="SUMMARY_CONTEXT_SIZE",
         description="Controls conversation summarization aggressiveness. "
-        "Higher values keep more context before summarizing (compact=1x, medium=1.5x, large=2x, full=3x).",
+        "Sets the fraction of the model context window at which summarization triggers "
+        "(compact=25%, medium=40%, large=55%, full=75%).",
     )
 
     @field_validator("summary_context_size", mode="before")

--- a/src/exporters/write_agent.py
+++ b/src/exporters/write_agent.py
@@ -17,6 +17,7 @@ from langchain_core.tools import BaseTool
 from langgraph.graph import START, StateGraph
 
 from prompts.get_prompt import get_prompt
+from src.config.settings import SummaryContextSize
 from src.exporters.agent_state import WriteAgentState
 from src.exporters.export_agent import ExportAgent
 from src.exporters.state import ExportState
@@ -69,12 +70,12 @@ class WriteAgent(ExportAgent[ExportState]):
     SYSTEM_PROMPT_NAME = "export_ansible_write_system"
     USER_PROMPT_NAME = "export_ansible_write_task"
 
-    # Increase summarization limits to prevent losing checklist context
+    # Increase summary context ratio to prevent losing checklist context
     # WriteAgent needs higher limits because:
     # 1. Large checklists with many items must stay in context
     # 2. File writing operations generate verbose tool results
     # 3. For smaller models (GPT-OSS-120b), summarization can cause premature completion
-    MAX_TOKENS_BEFORE_SUMMARY = 30000  # Increased from default 20000
+    SUMMARY_CONTEXT_RATIO = SummaryContextSize.MEDIUM
     MESSAGES_TO_KEEP = 8  # Increased from default 20
 
     GOAL = """All non-molecule checklist items that were PENDING or MISSING have been written to disk and marked COMPLETE.

--- a/src/inputs/puppet/hiera_analysis_agent.py
+++ b/src/inputs/puppet/hiera_analysis_agent.py
@@ -14,6 +14,7 @@ from langchain_community.tools.file_management.list_dir import ListDirectoryTool
 from langchain_core.tools import BaseTool
 
 from prompts.get_prompt import get_prompt
+from src.config.settings import SummaryContextSize
 from src.inputs.input_agent import InputAgent
 from src.inputs.puppet.state import PuppetState
 from src.types.telemetry import AgentMetrics
@@ -50,7 +51,7 @@ class HieraAnalysisAgent(InputAgent[PuppetState]):
         ListDirectoryTool,
     ]
 
-    MAX_TOKENS_BEFORE_SUMMARY = 50000
+    SUMMARY_CONTEXT_RATIO = SummaryContextSize.MEDIUM
 
     def execute(self, state: PuppetState, metrics: AgentMetrics | None) -> PuppetState:
         return state

--- a/tests/config/test_settings.py
+++ b/tests/config/test_settings.py
@@ -60,11 +60,11 @@ class TestLLMSettings:
 class TestSummaryContextSize:
     """Tests for SummaryContextSize enum."""
 
-    def test_multiplier_values(self):
-        assert SummaryContextSize.COMPACT.multiplier == 1.0
-        assert SummaryContextSize.MEDIUM.multiplier == 1.5
-        assert SummaryContextSize.LARGE.multiplier == 2.0
-        assert SummaryContextSize.FULL.multiplier == 3.0
+    def test_ratio_values(self):
+        assert SummaryContextSize.COMPACT.ratio == 0.25
+        assert SummaryContextSize.MEDIUM.ratio == 0.40
+        assert SummaryContextSize.LARGE.ratio == 0.55
+        assert SummaryContextSize.FULL.ratio == 0.75
 
     def test_string_values(self):
         assert SummaryContextSize.COMPACT.value == "compact"

--- a/tests/test_base_agent.py
+++ b/tests/test_base_agent.py
@@ -10,6 +10,7 @@ from langchain_core.tools import BaseTool
 
 from src.base_agent import BaseAgent
 from src.config import reset_settings
+from src.config.settings import SummaryContextSize
 from src.middleware.goal_validation import GoalValidationMiddleware
 from src.middleware.rules import RulesMiddleware
 from src.middleware.telemetry import TelemetryMiddleware
@@ -975,10 +976,8 @@ class TestBaseAgentMiddleware:
         assert agent.GOAL == "Verify output file exists"
 
 
-class HighThresholdAgent(BaseAgent[BaseState]):
-    """Agent with a high MAX_TOKENS_BEFORE_SUMMARY for testing scaling."""
-
-    MAX_TOKENS_BEFORE_SUMMARY = 50_000
+class AgentWithRatioOverride(BaseAgent[BaseState]):
+    SUMMARY_CONTEXT_RATIO = SummaryContextSize.FULL
 
     def execute(self, state, metrics):
         return state
@@ -993,58 +992,44 @@ class TestEffectiveSummaryThreshold:
     def teardown_method(self):
         reset_settings()
 
-    @patch("src.base_agent.get_context_window", return_value=200_000)
-    def test_compact_returns_base_value(self, _mock_cw, monkeypatch):
+    @patch("src.base_agent.get_context_window", return_value=128_000)
+    def test_compact_is_25_percent(self, _mock_cw, monkeypatch):
         monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "compact")
         reset_settings()
-        agent = ConcreteAgent()
-        assert agent._effective_summary_threshold() == 20_000
+        assert ConcreteAgent()._effective_summary_threshold() == 32_000
 
-    @patch("src.base_agent.get_context_window", return_value=200_000)
-    def test_medium_scales_by_1_5(self, _mock_cw, monkeypatch):
+    @patch("src.base_agent.get_context_window", return_value=128_000)
+    def test_medium_is_40_percent(self, _mock_cw, monkeypatch):
         monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "medium")
         reset_settings()
-        agent = ConcreteAgent()
-        assert agent._effective_summary_threshold() == 30_000
+        assert ConcreteAgent()._effective_summary_threshold() == 51_200
 
-    @patch("src.base_agent.get_context_window", return_value=200_000)
-    def test_large_scales_by_2(self, _mock_cw, monkeypatch):
+    @patch("src.base_agent.get_context_window", return_value=128_000)
+    def test_large_is_55_percent(self, _mock_cw, monkeypatch):
         monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "large")
         reset_settings()
-        agent = ConcreteAgent()
-        assert agent._effective_summary_threshold() == 40_000
+        assert ConcreteAgent()._effective_summary_threshold() == 70_400
 
-    @patch("src.base_agent.get_context_window", return_value=200_000)
-    def test_full_scales_by_3(self, _mock_cw, monkeypatch):
+    @patch("src.base_agent.get_context_window", return_value=128_000)
+    def test_full_is_75_percent(self, _mock_cw, monkeypatch):
         monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
         reset_settings()
-        agent = ConcreteAgent()
-        assert agent._effective_summary_threshold() == 60_000
+        assert ConcreteAgent()._effective_summary_threshold() == 96_000
 
-    @patch("src.base_agent.get_context_window", return_value=200_000)
-    def test_applies_to_agent_specific_threshold(self, _mock_cw, monkeypatch):
-        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "large")
+    @patch("src.base_agent.get_context_window", return_value=32_000)
+    def test_scales_with_smaller_context_window(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "compact")
         reset_settings()
-        agent = HighThresholdAgent()
-        assert agent._effective_summary_threshold() == 100_000
+        assert ConcreteAgent()._effective_summary_threshold() == 8_000
 
-    @patch("src.base_agent.get_context_window", return_value=25_000)
-    def test_caps_at_context_window(self, _mock_cw, monkeypatch):
-        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
+    @patch("src.base_agent.get_context_window", return_value=128_000)
+    def test_per_agent_ratio_overrides_global_setting(self, _mock_cw, monkeypatch):
+        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "compact")
         reset_settings()
-        agent = ConcreteAgent()  # 20_000 * 3 = 60_000 > 25_000
-        assert agent._effective_summary_threshold() == 25_000
+        assert AgentWithRatioOverride()._effective_summary_threshold() == 96_000
 
-    @patch("src.base_agent.get_context_window", return_value=40_000)
-    def test_caps_high_threshold_agent_at_context_window(self, _mock_cw, monkeypatch):
-        monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
-        reset_settings()
-        agent = HighThresholdAgent()  # 50_000 * 3 = 150_000 > 40_000
-        assert agent._effective_summary_threshold() == 40_000
-
-    @patch("src.base_agent.get_context_window", return_value=200_000)
+    @patch("src.base_agent.get_context_window", return_value=128_000)
     def test_messages_to_keep_unchanged(self, _mock_cw, monkeypatch):
         monkeypatch.setenv("SUMMARY_CONTEXT_SIZE", "full")
         reset_settings()
-        agent = ConcreteAgent()
-        assert agent.MESSAGES_TO_KEEP == 6
+        assert ConcreteAgent().MESSAGES_TO_KEEP == 6


### PR DESCRIPTION
Replace the fixed MAX_TOKENS_BEFORE_SUMMARY constant with a ratio of the model's context window