### PR TITLE
fix: issues with tool call logging

### DIFF
--- a/src/middleware/tool_call_logging.py
+++ b/src/middleware/tool_call_logging.py
@@ -65,7 +65,7 @@ class ToolCallLoggingMiddleware(AgentMiddleware):
             "Tool call finished",
             tool=tool_name,
             duration_s=round(duration, 3),
-            args=self._select_args(request),
+            tool_args=self._select_args(request),
         )
 
     def _log_failure(
@@ -76,7 +76,7 @@ class ToolCallLoggingMiddleware(AgentMiddleware):
             "Tool call failed",
             tool=tool_name,
             duration_s=round(duration, 3),
-            args=self._select_args(request),
+            tool_args=self._select_args(request),
         )
 
     @staticmethod


### PR DESCRIPTION
When fixing the PR review, I created this error:

```
Error: Missing required field 'Attempt to overwrite 'args' in LogRecord' in configuration.
```

args is not a valid function argument.

Issue: FLPATH-4856